### PR TITLE
Run Code Coverage on Golang tip only

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,9 +8,9 @@ go:
     - tip
 
 before_install:
-    - go get github.com/axw/gocov/gocov
-    - go get github.com/mattn/goveralls
-    - if ! go get code.google.com/p/go.tools/cmd/cover; then go get golang.org/x/tools/cmd/cover; fi
+    - if [[ $TRAVIS_GO_VERSION = 1.6 ]]; then go get github.com/axw/gocov/gocov; fi;
+    - if [[ $TRAVIS_GO_VERSION = 1.6 ]]; then go get github.com/mattn/goveralls; fi;
+    - if [[ $TRAVIS_GO_VERSION = 1.6 ]]; then if ! go get code.google.com/p/go.tools/cmd/cover; then go get golang.org/x/tools/cmd/cover; fi; fi;
 
 script:
-    - $HOME/gopath/bin/goveralls -service=travis-ci
+    - if [[ $TRAVIS_GO_VERSION = 1.6 ]]; then $HOME/gopath/bin/goveralls -service=travis-ci; fi;


### PR DESCRIPTION
Sometimes travis ci failes, because of coveralls. Lets try to fix this