### PR TITLE
Attachment support

### DIFF
--- a/authentication.go
+++ b/authentication.go
@@ -1,8 +1,6 @@
 package jira
 
-import (
-	"fmt"
-)
+import "fmt"
 
 // AuthenticationService handles authentication for the JIRA instance / API.
 //

--- a/authentication.go
+++ b/authentication.go
@@ -63,6 +63,15 @@ func (s *AuthenticationService) AcquireSessionCookie(username, password string) 
 	return true, nil
 }
 
+// Authenticated reports if the current Client has an authenticated session with JIRA
+func (s *AuthenticationService) Authenticated() bool {
+	if s != nil {
+		return s.client.session != nil
+	} else {
+		return false
+	}
+}
+
 // TODO Missing API Call GET (Returns information about the currently authenticated user's session)
 // See https://docs.atlassian.com/jira/REST/latest/#auth/1/session
 // TODO Missing API Call DELETE (Logs the current user out of JIRA, destroying the existing session, if any.)

--- a/authentication_test.go
+++ b/authentication_test.go
@@ -62,11 +62,6 @@ func TestAcquireSessionCookie_Success(t *testing.T) {
 		fmt.Fprint(w, `{"session":{"name":"JSESSIONID","value":"12345678901234567890"},"loginInfo":{"failedLoginCount":10,"loginCount":127,"lastFailedLoginTime":"2016-03-16T04:22:35.386+0000","previousLoginTime":"2016-03-16T04:22:35.386+0000"}}`)
 	})
 
-	// Test before we've attempted to authenticate
-	if testClient.Authentication.Authenticated() != false {
-		t.Error("Expected false, but result was true")
-	}
-
 	res, err := testClient.Authentication.AcquireSessionCookie("foo", "bar")
 	if err != nil {
 		t.Errorf("No error expected. Got %s", err)
@@ -77,5 +72,15 @@ func TestAcquireSessionCookie_Success(t *testing.T) {
 
 	if testClient.Authentication.Authenticated() != true {
 		t.Error("Expected true, but result was false")
+	}
+}
+
+func TestAuthenticated_NotInit(t *testing.T) {
+	// Skip setup() because we don't want a fully setup client
+	testClient = new(Client)
+
+	// Test before we've attempted to authenticate
+	if testClient.Authentication.Authenticated() != false {
+		t.Error("Expected false, but result was true")
 	}
 }

--- a/authentication_test.go
+++ b/authentication_test.go
@@ -36,6 +36,10 @@ func TestAcquireSessionCookie_Fail(t *testing.T) {
 	if res == true {
 		t.Error("Expected error, but result was true")
 	}
+
+	if testClient.Authentication.Authenticated() != false {
+		t.Error("Expected false, but result was true")
+	}
 }
 
 func TestAcquireSessionCookie_Success(t *testing.T) {
@@ -58,11 +62,20 @@ func TestAcquireSessionCookie_Success(t *testing.T) {
 		fmt.Fprint(w, `{"session":{"name":"JSESSIONID","value":"12345678901234567890"},"loginInfo":{"failedLoginCount":10,"loginCount":127,"lastFailedLoginTime":"2016-03-16T04:22:35.386+0000","previousLoginTime":"2016-03-16T04:22:35.386+0000"}}`)
 	})
 
+	// Test before we've attempted to authenticate
+	if testClient.Authentication.Authenticated() != false {
+		t.Error("Expected false, but result was true")
+	}
+
 	res, err := testClient.Authentication.AcquireSessionCookie("foo", "bar")
 	if err != nil {
 		t.Errorf("No error expected. Got %s", err)
 	}
 	if res == false {
 		t.Error("Expected result was true. Got false")
+	}
+
+	if testClient.Authentication.Authenticated() != true {
+		t.Error("Expected true, but result was false")
 	}
 }

--- a/issue.go
+++ b/issue.go
@@ -35,11 +35,12 @@ type Attachment struct {
 	Id       string `json:"id,omitempty"`
 	Filename string `json:"filename,omitempty"`
 	//	TODO Missing fields
-	//Author   string `json:"author,omitempty"`
-	Created  string `json:"created,omitempty"`
-	Size     int    `json:"size,omitempty"`
-	MimeType string `json:"mimeType,omitempty"`
-	Content  string `json:"content,omitempty"`
+	Author    *Assignee `json:"author,omitempty"`
+	Created   string    `json:"created,omitempty"`
+	Size      int       `json:"size,omitempty"`
+	MimeType  string    `json:"mimeType,omitempty"`
+	Content   string    `json:"content,omitempty"`
+	Thumbnail string    `json:"thumbnail,omitempty"`
 }
 
 // IssueFields represents single fields of a JIRA issue.
@@ -272,7 +273,7 @@ func (s *IssueService) DownloadAttachment(attachmentID string) (*http.Response, 
 }
 
 // PostAttachment uploads an attachment provided as an io.Reader to a given attachment ID
-func (s *IssueService) PostAttachment(attachmentID string, r io.Reader, attachmentName string) (*Issue, *http.Response, error) {
+func (s *IssueService) PostAttachment(attachmentID string, r io.Reader, attachmentName string) (*[]Attachment, *http.Response, error) {
 	apiEndpoint := fmt.Sprintf("rest/api/2/issue/%s/attachments", attachmentID)
 
 	b := new(bytes.Buffer)
@@ -297,13 +298,14 @@ func (s *IssueService) PostAttachment(attachmentID string, r io.Reader, attachme
 
 	req.Header.Set("Content-Type", writer.FormDataContentType())
 
-	issue := new(Issue)
-	resp, err := s.client.Do(req, issue)
+	// PostAttachment response returns a JSON array (as multiple attachments can be posted)
+	attachment := new([]Attachment)
+	resp, err := s.client.Do(req, attachment)
 	if err != nil {
 		return nil, resp, err
 	}
 
-	return issue, resp, nil
+	return attachment, resp, nil
 
 }
 

--- a/issue.go
+++ b/issue.go
@@ -284,11 +284,12 @@ func (s *IssueService) PostAttachment(attachmentID string, r io.Reader, attachme
 		return nil, nil, err
 	}
 
-	// Copy the file
-	if _, err = io.Copy(fw, r); err != nil {
-		return nil, nil, err
+	if r != nil {
+		// Copy the file
+		if _, err = io.Copy(fw, r); err != nil {
+			return nil, nil, err
+		}
 	}
-
 	writer.Close()
 
 	req, err := s.client.NewMultiPartRequest("POST", apiEndpoint, b)

--- a/issue_test.go
+++ b/issue_test.go
@@ -154,6 +154,31 @@ func TestIssueDownloadAttachment(t *testing.T) {
 	}
 }
 
+func TestIssueDownloadAttachment_BadStatus(t *testing.T) {
+
+	setup()
+	defer teardown()
+	testMux.HandleFunc("/secure/attachment/", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "GET")
+		testRequestURL(t, r, "/secure/attachment/10000/")
+
+		w.WriteHeader(http.StatusForbidden)
+	})
+
+	resp, err := testClient.Issue.DownloadAttachment("10000")
+	if resp == nil {
+		t.Error("Expected response. Response is nil")
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusForbidden {
+		t.Errorf("Expected Status code %d. Given %d", http.StatusForbidden, resp.StatusCode)
+	}
+	if err == nil {
+		t.Errorf("Error expected")
+	}
+}
+
 func TestIssuePostAttachment(t *testing.T) {
 	var testAttachment = "Here is an attachment"
 
@@ -165,25 +190,26 @@ func TestIssuePostAttachment(t *testing.T) {
 		status := http.StatusOK
 
 		file, _, err := r.FormFile("file")
-		defer file.Close()
 		if err != nil {
 			status = http.StatusNotAcceptable
 		}
 		if file == nil {
 			status = http.StatusNoContent
-		}
+		} else {
 
-		// Read the file into memory
-		data, err := ioutil.ReadAll(file)
-		if err != nil {
-			status = http.StatusInternalServerError
-		}
-		if string(data) != testAttachment {
-			status = http.StatusNotAcceptable
-		}
+			// Read the file into memory
+			data, err := ioutil.ReadAll(file)
+			if err != nil {
+				status = http.StatusInternalServerError
+			}
+			if string(data) != testAttachment {
+				status = http.StatusNotAcceptable
+			}
 
-		w.WriteHeader(status)
-		fmt.Fprint(w, `[{"self":"http://jira/jira/rest/api/2/attachment/228924","id":"228924","filename":"example.jpg","author":{"self":"http://jira/jira/rest/api/2/user?username=test","name":"test","emailAddress":"test@test.com","avatarUrls":{"16x16":"http://jira/jira/secure/useravatar?size=small&avatarId=10082","48x48":"http://jira/jira/secure/useravatar?avatarId=10082"},"displayName":"Tester","active":true},"created":"2016-05-24T00:25:17.000-0700","size":32280,"mimeType":"image/jpeg","content":"http://jira/jira/secure/attachment/228924/example.jpg","thumbnail":"http://jira/jira/secure/thumbnail/228924/_thumb_228924.png"}]`)
+			w.WriteHeader(status)
+			fmt.Fprint(w, `[{"self":"http://jira/jira/rest/api/2/attachment/228924","id":"228924","filename":"example.jpg","author":{"self":"http://jira/jira/rest/api/2/user?username=test","name":"test","emailAddress":"test@test.com","avatarUrls":{"16x16":"http://jira/jira/secure/useravatar?size=small&avatarId=10082","48x48":"http://jira/jira/secure/useravatar?avatarId=10082"},"displayName":"Tester","active":true},"created":"2016-05-24T00:25:17.000-0700","size":32280,"mimeType":"image/jpeg","content":"http://jira/jira/secure/attachment/228924/example.jpg","thumbnail":"http://jira/jira/secure/thumbnail/228924/_thumb_228924.png"}]`)
+			file.Close()
+		}
 	})
 
 	reader := strings.NewReader(testAttachment)
@@ -197,6 +223,63 @@ func TestIssuePostAttachment(t *testing.T) {
 	if resp.StatusCode != 200 {
 		t.Errorf("Expected Status code 200. Given %d", resp.StatusCode)
 	}
+
+	if err != nil {
+		t.Errorf("Error given: %s", err)
+	}
+}
+
+func TestIssuePostAttachment_NoResponse(t *testing.T) {
+	var testAttachment = "Here is an attachment"
+
+	setup()
+	defer teardown()
+	testMux.HandleFunc("/rest/api/2/issue/10000/attachments", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "POST")
+		testRequestURL(t, r, "/rest/api/2/issue/10000/attachments")
+		w.WriteHeader(http.StatusOK)
+	})
+	reader := strings.NewReader(testAttachment)
+
+	_, _, err := testClient.Issue.PostAttachment("10000", reader, "attachment")
+
+	if err == nil {
+		t.Errorf("Error expected: %s", err)
+	}
+}
+
+func TestIssuePostAttachment_NoFilename(t *testing.T) {
+	var testAttachment = "Here is an attachment"
+
+	setup()
+	defer teardown()
+	testMux.HandleFunc("/rest/api/2/issue/10000/attachments", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "POST")
+		testRequestURL(t, r, "/rest/api/2/issue/10000/attachments")
+		w.WriteHeader(http.StatusOK)
+		fmt.Fprint(w, `[{"self":"http://jira/jira/rest/api/2/attachment/228924","id":"228924","filename":"example.jpg","author":{"self":"http://jira/jira/rest/api/2/user?username=test","name":"test","emailAddress":"test@test.com","avatarUrls":{"16x16":"http://jira/jira/secure/useravatar?size=small&avatarId=10082","48x48":"http://jira/jira/secure/useravatar?avatarId=10082"},"displayName":"Tester","active":true},"created":"2016-05-24T00:25:17.000-0700","size":32280,"mimeType":"image/jpeg","content":"http://jira/jira/secure/attachment/228924/example.jpg","thumbnail":"http://jira/jira/secure/thumbnail/228924/_thumb_228924.png"}]`)
+	})
+	reader := strings.NewReader(testAttachment)
+
+	_, _, err := testClient.Issue.PostAttachment("10000", reader, "")
+
+	if err != nil {
+		t.Errorf("Error expected: %s", err)
+	}
+}
+
+func TestIssuePostAttachment_NoAttachment(t *testing.T) {
+
+	setup()
+	defer teardown()
+	testMux.HandleFunc("/rest/api/2/issue/10000/attachments", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "POST")
+		testRequestURL(t, r, "/rest/api/2/issue/10000/attachments")
+		w.WriteHeader(http.StatusOK)
+		fmt.Fprint(w, `[{"self":"http://jira/jira/rest/api/2/attachment/228924","id":"228924","filename":"example.jpg","author":{"self":"http://jira/jira/rest/api/2/user?username=test","name":"test","emailAddress":"test@test.com","avatarUrls":{"16x16":"http://jira/jira/secure/useravatar?size=small&avatarId=10082","48x48":"http://jira/jira/secure/useravatar?avatarId=10082"},"displayName":"Tester","active":true},"created":"2016-05-24T00:25:17.000-0700","size":32280,"mimeType":"image/jpeg","content":"http://jira/jira/secure/attachment/228924/example.jpg","thumbnail":"http://jira/jira/secure/thumbnail/228924/_thumb_228924.png"}]`)
+	})
+
+	_, _, err := testClient.Issue.PostAttachment("10000", nil, "attachment")
 
 	if err != nil {
 		t.Errorf("Error given: %s", err)

--- a/issue_test.go
+++ b/issue_test.go
@@ -2,7 +2,9 @@ package jira
 
 import (
 	"fmt"
+	"io/ioutil"
 	"net/http"
+	"strings"
 	"testing"
 )
 
@@ -112,6 +114,90 @@ func TestIssueAddLink(t *testing.T) {
 	if resp.StatusCode != 200 {
 		t.Errorf("Expected Status code 200. Given %d", resp.StatusCode)
 	}
+	if err != nil {
+		t.Errorf("Error given: %s", err)
+	}
+}
+
+func TestIssueDownloadAttachment(t *testing.T) {
+	var testAttachment = "Here is an attachment"
+
+	setup()
+	defer teardown()
+	testMux.HandleFunc("/secure/attachment/", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "GET")
+		testRequestURL(t, r, "/secure/attachment/10000/")
+
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte(testAttachment))
+	})
+
+	resp, err := testClient.Issue.DownloadAttachment("10000")
+	if resp == nil {
+		t.Error("Expected response. Response is nil")
+	}
+	defer resp.Body.Close()
+
+	attachment, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		t.Error("Expected attachment text", err)
+	}
+	if string(attachment) != testAttachment {
+		t.Errorf("Expecting an attachment", string(attachment))
+	}
+
+	if resp.StatusCode != 200 {
+		t.Errorf("Expected Status code 200. Given %d", resp.StatusCode)
+	}
+	if err != nil {
+		t.Errorf("Error given: %s", err)
+	}
+}
+
+func TestIssuePostAttachment(t *testing.T) {
+	var testAttachment = "Here is an attachment"
+
+	setup()
+	defer teardown()
+	testMux.HandleFunc("/rest/api/2/issue/10000/attachments", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "POST")
+		testRequestURL(t, r, "/rest/api/2/issue/10000/attachments")
+		status := http.StatusOK
+
+		file, _, err := r.FormFile("file")
+		defer file.Close()
+		if err != nil {
+			status = http.StatusNotAcceptable
+		}
+		if file == nil {
+			status = http.StatusNoContent
+		}
+
+		// Read the file into memory
+		data, err := ioutil.ReadAll(file)
+		if err != nil {
+			status = http.StatusInternalServerError
+		}
+		if string(data) != testAttachment {
+			status = http.StatusNotAcceptable
+		}
+
+		w.WriteHeader(status)
+		fmt.Fprint(w, `[{"self":"http://jira/jira/rest/api/2/attachment/228924","id":"228924","filename":"example.jpg","author":{"self":"http://jira/jira/rest/api/2/user?username=test","name":"test","emailAddress":"test@test.com","avatarUrls":{"16x16":"http://jira/jira/secure/useravatar?size=small&avatarId=10082","48x48":"http://jira/jira/secure/useravatar?avatarId=10082"},"displayName":"Tester","active":true},"created":"2016-05-24T00:25:17.000-0700","size":32280,"mimeType":"image/jpeg","content":"http://jira/jira/secure/attachment/228924/example.jpg","thumbnail":"http://jira/jira/secure/thumbnail/228924/_thumb_228924.png"}]`)
+	})
+
+	reader := strings.NewReader(testAttachment)
+
+	issue, resp, err := testClient.Issue.PostAttachment("10000", reader, "attachment")
+
+	if issue == nil {
+		t.Error("Expected response. Response is nil")
+	}
+
+	if resp.StatusCode != 200 {
+		t.Errorf("Expected Status code 200. Given %d", resp.StatusCode)
+	}
+
 	if err != nil {
 		t.Errorf("Error given: %s", err)
 	}

--- a/jira.go
+++ b/jira.go
@@ -143,7 +143,7 @@ func (c *Client) Do(req *http.Request, v interface{}) (*http.Response, error) {
 
 // Do sends an API request and returns the API response.
 // The API response is JSON decoded and stored in the value pointed to by v, or returned as an error if an API error has occurred.
-// The caller needs to call Body.Close when the response has been handled
+// The caller is expected to consume the Body, and needs to call Body.Close when the response has been handled
 func (c *Client) DoNoClose(req *http.Request, v interface{}) (*http.Response, error) {
 	resp, err := c.client.Do(req)
 	if err != nil {

--- a/jira.go
+++ b/jira.go
@@ -89,6 +89,34 @@ func (c *Client) NewRequest(method, urlStr string, body interface{}) (*http.Requ
 	return req, nil
 }
 
+// NewMultiPartRequest creates an API request including a multi-part file
+// A relative URL can be provided in urlStr, in which case it is resolved relative to the baseURL of the Client.
+// Relative URLs should always be specified without a preceding slash.
+// If specified, the value pointed to by buf is a multipart form
+func (c *Client) NewMultiPartRequest(method, urlStr string, buf *bytes.Buffer) (*http.Request, error) {
+	rel, err := url.Parse(urlStr)
+	if err != nil {
+		return nil, err
+	}
+
+	u := c.baseURL.ResolveReference(rel)
+
+	req, err := http.NewRequest(method, u.String(), buf)
+	if err != nil {
+		return nil, err
+	}
+
+	// Set required headers
+	req.Header.Set("X-Atlassian-Token", "nocheck")
+
+	// Set session cookie if there is one
+	if c.session != nil {
+		req.Header.Set("Cookie", fmt.Sprintf("%s=%s", c.session.Session.Name, c.session.Session.Value))
+	}
+
+	return req, nil
+}
+
 // Do sends an API request and returns the API response.
 // The API response is JSON decoded and stored in the value pointed to by v, or returned as an error if an API error has occurred.
 func (c *Client) Do(req *http.Request, v interface{}) (*http.Response, error) {
@@ -111,6 +139,38 @@ func (c *Client) Do(req *http.Request, v interface{}) (*http.Response, error) {
 	}
 
 	return resp, err
+}
+
+// Do sends an API request and returns the API response.
+// The API response is JSON decoded and stored in the value pointed to by v, or returned as an error if an API error has occurred.
+// The caller needs to call Body.Close when the response has been handled
+func (c *Client) DoNoClose(req *http.Request, v interface{}) (*http.Response, error) {
+	resp, err := c.client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+
+	err = CheckResponse(resp)
+	if err != nil {
+		// Even though there was an error, we still return the response
+		// in case the caller wants to inspect it further
+		return resp, err
+	}
+
+	if v != nil {
+		err = json.NewDecoder(resp.Body).Decode(v)
+	}
+
+	return resp, err
+}
+
+// Authenticated reports if the current Client has an authenticated session with JIRA
+func (c *Client) Authenticated() bool {
+	if c != nil {
+		return c.session != nil
+	} else {
+		return false
+	}
 }
 
 // CheckResponse checks the API response for errors, and returns them if present.

--- a/jira.go
+++ b/jira.go
@@ -164,14 +164,14 @@ func (c *Client) DoNoClose(req *http.Request, v interface{}) (*http.Response, er
 	return resp, err
 }
 
-// Authenticated reports if the current Client has an authenticated session with JIRA
-func (c *Client) Authenticated() bool {
-	if c != nil {
-		return c.session != nil
-	} else {
-		return false
-	}
-}
+//// Authenticated reports if the current Client has an authenticated session with JIRA
+//func (c *Client) Authenticated() bool {
+//	if c != nil {
+//		return c.session != nil
+//	} else {
+//		return false
+//	}
+//}
 
 // CheckResponse checks the API response for errors, and returns them if present.
 // A response is considered an error if it has a status code outside the 200 range.


### PR DESCRIPTION
Added support to upload & download attachments, and an additional method to see if a session has been authenticated

I did consider whether to add a new Attachment type to Client (as a peer of IssueService) but decided against it.


