### PR TITLE
Minor bug fig on parsing HTTP body

### DIFF
--- a/jira.go
+++ b/jira.go
@@ -97,8 +97,6 @@ func (c *Client) Do(req *http.Request, v interface{}) (*http.Response, error) {
 		return nil, err
 	}
 
-	defer resp.Body.Close()
-
 	err = CheckResponse(resp)
 	if err != nil {
 		// Even though there was an error, we still return the response
@@ -107,6 +105,8 @@ func (c *Client) Do(req *http.Request, v interface{}) (*http.Response, error) {
 	}
 
 	if v != nil {
+		// Open a NewDecoder and defer closing the reader only if there is a provided interface to decode to
+		defer resp.Body.Close()
 		err = json.NewDecoder(resp.Body).Decode(v)
 	}
 

--- a/jira_test.go
+++ b/jira_test.go
@@ -231,8 +231,7 @@ func TestDo_HTTPResponse(t *testing.T) {
 	})
 
 	req, _ := testClient.NewRequest("GET", "/", nil)
-	body := new(foo)
-	res, _ := testClient.Do(req, body)
+	res, _ := testClient.Do(req, nil)
 	_, err := ioutil.ReadAll(res.Body)
 
 	if err != nil {

--- a/jira_test.go
+++ b/jira_test.go
@@ -215,6 +215,33 @@ func TestDo(t *testing.T) {
 	}
 }
 
+func TestDo_HTTPResponse(t *testing.T) {
+	setup()
+	defer teardown()
+
+	type foo struct {
+		A string
+	}
+
+	testMux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		if m := "GET"; m != r.Method {
+			t.Errorf("Request method = %v, want %v", r.Method, m)
+		}
+		fmt.Fprint(w, `{"A":"a"}`)
+	})
+
+	req, _ := testClient.NewRequest("GET", "/", nil)
+	body := new(foo)
+	res, _ := testClient.Do(req, body)
+	_, err := ioutil.ReadAll(res.Body)
+
+	if err != nil {
+		t.Errorf("Error on parsing HTTP Response = %v", err.Error())
+	} else if res.StatusCode != 200 {
+		t.Errorf("Response code = %v, want %v", res.StatusCode, 200)
+	}
+}
+
 func TestDo_HTTPError(t *testing.T) {
 	setup()
 	defer teardown()


### PR DESCRIPTION
Hey Andy

Noticed a small bug here - if I haven't passed a struct into this line:
[jira.go:94](https://github.com/andygrunwald/go-jira/blob/master/jira.go#L94): `func (c *Client) Do(req *http.Request, v interface{}) (*http.Response, error) {`

There wasn't a way for me to get the resulting object out, because this line:
[jira.go:100](https://github.com/andygrunwald/go-jira/blob/master/jira.go#L100): `defer resp.Body.Close()`
already closed the body even if no struct is passed.  I made this change to let me parse responses straight from the HTTP response.  I included the test.  If you want to see the red condition on the test, just revert my changes to jira.go.

I'm fairly new to pull requests and the like - let me know if you would like this pull request to come from another branch.  Or let me know if I've possibly introduced bugs in your code with this change - hopefully not!

Kent