### PR TITLE
Expose issue link direction, comment ID

### DIFF
--- a/issue.go
+++ b/issue.go
@@ -248,6 +248,7 @@ type IssueLinkType struct {
 
 // Comment represents a comment by a person to an issue in JIRA.
 type Comment struct {
+	ID           string            `json:"id,omitempty"`
 	Self         string            `json:"self,omitempty"`
 	Name         string            `json:"name,omitempty"`
 	Author       User              `json:"author,omitempty"`

--- a/issue.go
+++ b/issue.go
@@ -231,9 +231,9 @@ type IssueLink struct {
 	ID           string        `json:"id"`
 	Self         string        `json:"self"`
 	Type         IssueLinkType `json:"type"`
-	OutwardIssue Issue         `json:"outwardIssue"`
-	InwardIssue  Issue         `json:"inwardIssue"`
-	Comment      Comment       `json:"comment"`
+	OutwardIssue *Issue        `json:"outwardIssue"`
+	InwardIssue  *Issue        `json:"inwardIssue"`
+	Comment      *Comment      `json:"comment"`
 }
 
 // IssueLinkType represents a type of a link between to issues in JIRA.

--- a/issue_test.go
+++ b/issue_test.go
@@ -94,13 +94,13 @@ func TestIssueAddLink(t *testing.T) {
 		Type: IssueLinkType{
 			Name: "Duplicate",
 		},
-		InwardIssue: Issue{
+		InwardIssue: &Issue{
 			Key: "HSP-1",
 		},
-		OutwardIssue: Issue{
+		OutwardIssue: &Issue{
 			Key: "MKY-1",
 		},
-		Comment: Comment{
+		Comment: &Comment{
 			Body: "Linked related issue!",
 			Visibility: CommentVisibility{
 				Type:  "group",


### PR DESCRIPTION
A small two-in-one PR:
* The ID field in the Comment struct was missing.
* It was hard to detect the issue link direction without checking for the presence of OutwardIssue and InwardIssue. However, as they were not pointer types, detecting their presence was not possible, and one would have to check for zero values in the resulting Issue struct, which wasn't very nice. The same goes for presence of the issue link comment.