### PR TITLE
Wrap http.Response in Response struct

### DIFF
--- a/issue.go
+++ b/issue.go
@@ -277,6 +277,11 @@ type CommentVisibility struct {
 	Value string `json:"value,omitempty"`
 }
 
+type SearchOptions struct {
+	StartAt    int
+	MaxResults int
+}
+
 // searchResult is only a small wrapper arround the Search (with JQL) method
 // to be able to parse the results
 type searchResult struct {
@@ -425,8 +430,15 @@ func (s *IssueService) AddLink(issueLink *IssueLink) (*Response, error) {
 // Search will search for tickets according to the jql
 //
 // JIRA API docs: https://developer.atlassian.com/jiradev/jira-apis/jira-rest-apis/jira-rest-api-tutorials/jira-rest-api-example-query-issues
-func (s *IssueService) Search(jql string) ([]Issue, *Response, error) {
-	u := fmt.Sprintf("rest/api/2/search?jql=%s", url.QueryEscape(jql))
+func (s *IssueService) Search(jql string, options *SearchOptions) ([]Issue, *Response, error) {
+	var u string
+	if options == nil {
+		u = fmt.Sprintf("rest/api/2/search?jql=%s", url.QueryEscape(jql))
+	} else {
+		u = fmt.Sprintf("rest/api/2/search?jql=%s&startAt=%d&maxResults=%d", url.QueryEscape(jql),
+			options.StartAt, options.MaxResults)
+	}
+
 	req, err := s.client.NewRequest("GET", u, nil)
 	if err != nil {
 		return []Issue{}, nil, err

--- a/issue_test.go
+++ b/issue_test.go
@@ -318,7 +318,7 @@ func TestIssue_Search(t *testing.T) {
 		testMethod(t, r, "GET")
 		testRequestURL(t, r, "/rest/api/2/search?jql=something")
 		w.WriteHeader(http.StatusOK)
-		fmt.Fprint(w, `{"expand": "schema,names","startAt": 0,"maxResults": 50,"total": 6,"issues": [{"expand": "html","id": "10230","self": "http://kelpie9:8081/rest/api/2/issue/BULK-62","key": "BULK-62","fields": {"summary": "testing","timetracking": null,"issuetype": {"self": "http://kelpie9:8081/rest/api/2/issuetype/5","id": "5","description": "The sub-task of the issue","iconUrl": "http://kelpie9:8081/images/icons/issue_subtask.gif","name": "Sub-task","subtask": true},"customfield_10071": null}},{"expand": "html","id": "10004","self": "http://kelpie9:8081/rest/api/2/issue/BULK-47","key": "BULK-47","fields": {"summary": "Cheese v1 2.0 issue","timetracking": null,"issuetype": {"self": "http://kelpie9:8081/rest/api/2/issuetype/3","id": "3","description": "A task that needs to be done.","iconUrl": "http://kelpie9:8081/images/icons/task.gif","name": "Task","subtask": false}}}]}`)
+		fmt.Fprint(w, `{"expand": "schema,names","startAt": 1,"maxResults": 40,"total": 6,"issues": [{"expand": "html","id": "10230","self": "http://kelpie9:8081/rest/api/2/issue/BULK-62","key": "BULK-62","fields": {"summary": "testing","timetracking": null,"issuetype": {"self": "http://kelpie9:8081/rest/api/2/issuetype/5","id": "5","description": "The sub-task of the issue","iconUrl": "http://kelpie9:8081/images/icons/issue_subtask.gif","name": "Sub-task","subtask": true},"customfield_10071": null}},{"expand": "html","id": "10004","self": "http://kelpie9:8081/rest/api/2/issue/BULK-47","key": "BULK-47","fields": {"summary": "Cheese v1 2.0 issue","timetracking": null,"issuetype": {"self": "http://kelpie9:8081/rest/api/2/issuetype/3","id": "3","description": "A task that needs to be done.","iconUrl": "http://kelpie9:8081/images/icons/task.gif","name": "Task","subtask": false}}}]}`)
 	})
 	_, resp, err := testClient.Issue.Search("something")
 
@@ -327,6 +327,16 @@ func TestIssue_Search(t *testing.T) {
 	}
 	if err != nil {
 		t.Errorf("Error given: %s", err)
+	}
+
+	if resp.StartAt != 1 {
+		t.Errorf("StartAt should populate with 1, %v given", resp.StartAt)
+	}
+	if resp.MaxResults != 40 {
+		t.Errorf("StartAt should populate with 40, %v given", resp.MaxResults)
+	}
+	if resp.Total != 6 {
+		t.Errorf("StartAt should populate with 6, %v given", resp.Total)
 	}
 }
 

--- a/issue_test.go
+++ b/issue_test.go
@@ -316,11 +316,13 @@ func TestIssue_Search(t *testing.T) {
 	defer teardown()
 	testMux.HandleFunc("/rest/api/2/search", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
-		testRequestURL(t, r, "/rest/api/2/search?jql=something")
+		testRequestURL(t, r, "/rest/api/2/search?jql=something&startAt=1&maxResults=40")
 		w.WriteHeader(http.StatusOK)
 		fmt.Fprint(w, `{"expand": "schema,names","startAt": 1,"maxResults": 40,"total": 6,"issues": [{"expand": "html","id": "10230","self": "http://kelpie9:8081/rest/api/2/issue/BULK-62","key": "BULK-62","fields": {"summary": "testing","timetracking": null,"issuetype": {"self": "http://kelpie9:8081/rest/api/2/issuetype/5","id": "5","description": "The sub-task of the issue","iconUrl": "http://kelpie9:8081/images/icons/issue_subtask.gif","name": "Sub-task","subtask": true},"customfield_10071": null}},{"expand": "html","id": "10004","self": "http://kelpie9:8081/rest/api/2/issue/BULK-47","key": "BULK-47","fields": {"summary": "Cheese v1 2.0 issue","timetracking": null,"issuetype": {"self": "http://kelpie9:8081/rest/api/2/issuetype/3","id": "3","description": "A task that needs to be done.","iconUrl": "http://kelpie9:8081/images/icons/task.gif","name": "Task","subtask": false}}}]}`)
 	})
-	_, resp, err := testClient.Issue.Search("something")
+
+	opt := &SearchOptions{StartAt: 1, MaxResults: 40}
+	_, resp, err := testClient.Issue.Search("something", opt)
 
 	if resp == nil {
 		t.Errorf("Response given: %+v", resp)
@@ -334,6 +336,37 @@ func TestIssue_Search(t *testing.T) {
 	}
 	if resp.MaxResults != 40 {
 		t.Errorf("StartAt should populate with 40, %v given", resp.MaxResults)
+	}
+	if resp.Total != 6 {
+		t.Errorf("StartAt should populate with 6, %v given", resp.Total)
+	}
+}
+
+func TestIssue_SearchWithoutPaging(t *testing.T) {
+
+	setup()
+	defer teardown()
+	testMux.HandleFunc("/rest/api/2/search", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "GET")
+		testRequestURL(t, r, "/rest/api/2/search?jql=something")
+		w.WriteHeader(http.StatusOK)
+		fmt.Fprint(w, `{"expand": "schema,names","startAt": 0,"maxResults": 50,"total": 6,"issues": [{"expand": "html","id": "10230","self": "http://kelpie9:8081/rest/api/2/issue/BULK-62","key": "BULK-62","fields": {"summary": "testing","timetracking": null,"issuetype": {"self": "http://kelpie9:8081/rest/api/2/issuetype/5","id": "5","description": "The sub-task of the issue","iconUrl": "http://kelpie9:8081/images/icons/issue_subtask.gif","name": "Sub-task","subtask": true},"customfield_10071": null}},{"expand": "html","id": "10004","self": "http://kelpie9:8081/rest/api/2/issue/BULK-47","key": "BULK-47","fields": {"summary": "Cheese v1 2.0 issue","timetracking": null,"issuetype": {"self": "http://kelpie9:8081/rest/api/2/issuetype/3","id": "3","description": "A task that needs to be done.","iconUrl": "http://kelpie9:8081/images/icons/task.gif","name": "Task","subtask": false}}}]}`)
+	})
+
+	_, resp, err := testClient.Issue.Search("something", nil)
+
+	if resp == nil {
+		t.Errorf("Response given: %+v", resp)
+	}
+	if err != nil {
+		t.Errorf("Error given: %s", err)
+	}
+
+	if resp.StartAt != 0 {
+		t.Errorf("StartAt should populate with 0, %v given", resp.StartAt)
+	}
+	if resp.MaxResults != 50 {
+		t.Errorf("StartAt should populate with 50, %v given", resp.MaxResults)
 	}
 	if resp.Total != 6 {
 		t.Errorf("StartAt should populate with 6, %v given", resp.Total)

--- a/jira_test.go
+++ b/jira_test.go
@@ -296,3 +296,24 @@ func TestGetBaseURL_WithURL(t *testing.T) {
 		t.Errorf("Base URLs are not equal. Expected %+v, got %+v", *u, b)
 	}
 }
+
+func TestPagingInfoEmptyByDefault(t *testing.T) {
+	c, _ := NewClient(nil, testJIRAInstanceURL)
+	req, _ := c.NewRequest("GET", "/", nil)
+	type foo struct {
+		A string
+	}
+	body := new(foo)
+
+	resp, _ := c.Do(req, body)
+
+	if resp.StartAt != 0 {
+		t.Errorf("StartAt not equal to 0")
+	}
+	if resp.MaxResults != 0 {
+		t.Errorf("StartAt not equal to 0")
+	}
+	if resp.Total != 0 {
+		t.Errorf("StartAt not equal to 0")
+	}
+}

--- a/project.go
+++ b/project.go
@@ -2,7 +2,6 @@ package jira
 
 import (
 	"fmt"
-	"net/http"
 )
 
 // ProjectService handles projects for the JIRA instance / API.
@@ -73,7 +72,7 @@ type ProjectComponent struct {
 // GetList gets all projects form JIRA
 //
 // JIRA API docs: https://docs.atlassian.com/jira/REST/latest/#api/2/project-getAllProjects
-func (s *ProjectService) GetList() (*ProjectList, *http.Response, error) {
+func (s *ProjectService) GetList() (*ProjectList, *Response, error) {
 	apiEndpoint := "rest/api/2/project"
 	req, err := s.client.NewRequest("GET", apiEndpoint, nil)
 	if err != nil {
@@ -93,7 +92,7 @@ func (s *ProjectService) GetList() (*ProjectList, *http.Response, error) {
 // This can be an project id, or an project key.
 //
 // JIRA API docs: https://docs.atlassian.com/jira/REST/latest/#api/2/project-getProject
-func (s *ProjectService) Get(projectID string) (*Project, *http.Response, error) {
+func (s *ProjectService) Get(projectID string) (*Project, *Response, error) {
 	apiEndpoint := fmt.Sprintf("/rest/api/2/project/%s", projectID)
 	req, err := s.client.NewRequest("GET", apiEndpoint, nil)
 	if err != nil {


### PR DESCRIPTION
The Response struct has StartAt, MaxResults and Total fields, which are
returned from JIRA API in issue search responses. They are now
accessible in Response object.

fixes #17 