### PR TITLE
Fix Comments unmarshalling

### DIFF
--- a/issue.go
+++ b/issue.go
@@ -78,7 +78,7 @@ type IssueFields struct {
 	AggregateProgress *Progress     `json:"aggregateprogress,omitempty"`
 	Worklog           *Worklog      `json:"worklog,omitempty"`
 	IssueLinks        []*IssueLink  `json:"issuelinks,omitempty"`
-	Comments          []*Comment    `json:"comment.comments,omitempty"`
+	Comments          *Comments     `json:"comment,omitempty"`
 	FixVersions       []*FixVersion `json:"fixVersions,omitempty"`
 	Labels            []string      `json:"labels,omitempty"`
 	Subtasks          []*Subtasks   `json:"subtasks,omitempty"`
@@ -243,6 +243,11 @@ type IssueLinkType struct {
 	Name    string `json:"name"`
 	Inward  string `json:"inward"`
 	Outward string `json:"outward"`
+}
+
+// Comments represents a list of Comment.
+type Comments struct {
+	Comments []*Comment `json:"comments,omitempty"`
 }
 
 // Comment represents a comment by a person to an issue in JIRA.

--- a/issue_test.go
+++ b/issue_test.go
@@ -138,6 +138,10 @@ func TestIssueFields(t *testing.T) {
 		t.Error("Expected labels for the returned issue")
 	}
 
+	if len(issue.Fields.Comments.Comments) != 1 {
+		t.Errorf("Expected one comment, %v found", len(issue.Fields.Comments.Comments))
+	}
+
 	if err != nil {
 		t.Errorf("Error given: %s", err)
 	}


### PR DESCRIPTION
This fixes #23 
I know this is not the most desired way of accessing Comments, since it requires to duplicate reference to Comments. I'm looking in a better way of doing this, but being a slice, it doesn't work.
I might like to find a better way of doing this, so help here would be appreciated.