### PR TITLE
Fixed a nil response when getting a session cookie

### DIFF
--- a/authentication.go
+++ b/authentication.go
@@ -53,7 +53,10 @@ func (s *AuthenticationService) AcquireSessionCookie(username, password string) 
 
 	session := new(Session)
 	resp, err := s.client.Do(req, session)
-	session.Cookies = resp.Cookies()
+
+        if resp != nil {
+   	    session.Cookies = resp.Cookies()
+        }
 
 	if err != nil {
 		return false, fmt.Errorf("Auth at JIRA instance failed (HTTP(S) request). %s", err)


### PR DESCRIPTION
This fixes a panic error I was getting when a nil response was returned. This lets it fall through to the correct checks below that will return the appropriate error.