### PR TITLE
Fix MetaIssueTypes to MetaIssueType and GetProjectWithKey from createmeta

### DIFF
--- a/metaissue.go
+++ b/metaissue.go
@@ -20,7 +20,7 @@ type MetaProject struct {
 	Key    string `json:"key,omitempty"`
 	Name   string `json:"name,omitempty"`
 	// omitted avatarUrls
-	IssueTypes []*MetaIssueTypes `json:"issuetypes,omitempty"`
+	IssueTypes []*MetaIssueType `json:"issuetypes,omitempty"`
 }
 
 // metaIssueTypes represents the different issue types a project has.
@@ -29,7 +29,7 @@ type MetaProject struct {
 // have arbitraty keys related to customfields. It is not possible to
 // expect these for a general way. This will be returning a map.
 // Further processing must be done depending on what is required.
-type MetaIssueTypes struct {
+type MetaIssueType struct {
 	Self        string                `json:"expand,omitempty"`
 	Id          string                `json:"id,omitempty"`
 	Description string                `json:"description,omitempty"`
@@ -73,7 +73,7 @@ func (m *CreateMetaInfo) GetProjectWithName(name string) *MetaProject {
 
 // GetIssueWithName returns an IssueType with name from a given MetaProject. If not found, this returns nil.
 // The comparision of the name is case insensitive
-func (p *MetaProject) GetIssueTypeWithName(name string) *MetaIssueTypes {
+func (p *MetaProject) GetIssueTypeWithName(name string) *MetaIssueType {
 	for _, m := range p.IssueTypes {
 		if strings.ToLower(m.Name) == strings.ToLower(name) {
 			return m
@@ -99,7 +99,7 @@ func (p *MetaProject) GetIssueTypeWithName(name string) *MetaIssueTypes {
 //				}
 // the returned map would have "Epic Link" as the key and "customfield_10806" as value.
 // This choice has been made so that the it is easier to generate the create api request later.
-func (t *MetaIssueTypes) GetMandatoryFields() (map[string]string, error) {
+func (t *MetaIssueType) GetMandatoryFields() (map[string]string, error) {
 	ret := make(map[string]string)
 	for key, _ := range t.Fields {
 		required, err := t.Fields.Bool(key + "/required")
@@ -119,7 +119,7 @@ func (t *MetaIssueTypes) GetMandatoryFields() (map[string]string, error) {
 
 // GetAllFields returns a map of all the fields for an IssueType. This includes all required and not required.
 // The key of the returned map is what you see in the form and the value is how it is representated in the jira schema.
-func (t *MetaIssueTypes) GetAllFields() (map[string]string, error) {
+func (t *MetaIssueType) GetAllFields() (map[string]string, error) {
 	ret := make(map[string]string)
 	for key, _ := range t.Fields {
 

--- a/metaissue.go
+++ b/metaissue.go
@@ -24,7 +24,7 @@ type MetaProject struct {
 	IssueTypes []*MetaIssueType `json:"issuetypes,omitempty"`
 }
 
-// metaIssueTypes represents the different issue types a project has.
+// MetaIssueType represents the different issue types a project has.
 //
 // Note: Fields is interface because this is an object which can
 // have arbitraty keys related to customfields. It is not possible to

--- a/metaissue.go
+++ b/metaissue.go
@@ -71,6 +71,17 @@ func (m *CreateMetaInfo) GetProjectWithName(name string) *MetaProject {
 	return nil
 }
 
+// GetProjectWithName returns a project with "name" from the meta information recieved. If not found, this returns nil.
+// The comparision of the name is case insensitive.
+func (m *CreateMetaInfo) GetProjectWithKey(key string) *MetaProject {
+	for _, m := range m.Projects {
+		if strings.ToLower(m.Key) == strings.ToLower(key) {
+			return m
+		}
+	}
+	return nil
+}
+
 // GetIssueWithName returns an IssueType with name from a given MetaProject. If not found, this returns nil.
 // The comparision of the name is case insensitive
 func (p *MetaProject) GetIssueTypeWithName(name string) *MetaIssueType {

--- a/metaissue_test.go
+++ b/metaissue_test.go
@@ -378,7 +378,7 @@ func TestIssueService_GetCreateMeta_Success(t *testing.T) {
 
 }
 
-func TestMetaIssueTypes_GetMandatoryFields(t *testing.T) {
+func TestMetaIssueType_GetMandatoryFields(t *testing.T) {
 	data := make(map[string]interface{})
 
 	data["summary"] = map[string]interface{}{
@@ -396,7 +396,7 @@ func TestMetaIssueTypes_GetMandatoryFields(t *testing.T) {
 		"name":     "Epic Link",
 	}
 
-	m := new(MetaIssueTypes)
+	m := new(MetaIssueType)
 	m.Fields = data
 
 	mandatory, err := m.GetMandatoryFields()
@@ -409,14 +409,14 @@ func TestMetaIssueTypes_GetMandatoryFields(t *testing.T) {
 	}
 }
 
-func TestMetaIssueTypes_GetMandatoryFields_NonExistentRequiredKey_Fail(t *testing.T) {
+func TestMetaIssueType_GetMandatoryFields_NonExistentRequiredKey_Fail(t *testing.T) {
 	data := make(map[string]interface{})
 
 	data["summary"] = map[string]interface{}{
 		"name": "Summary",
 	}
 
-	m := new(MetaIssueTypes)
+	m := new(MetaIssueType)
 	m.Fields = data
 
 	_, err := m.GetMandatoryFields()
@@ -425,14 +425,14 @@ func TestMetaIssueTypes_GetMandatoryFields_NonExistentRequiredKey_Fail(t *testin
 	}
 }
 
-func TestMetaIssueTypes_GetMandatoryFields_NonExistentNameKey_Fail(t *testing.T) {
+func TestMetaIssueType_GetMandatoryFields_NonExistentNameKey_Fail(t *testing.T) {
 	data := make(map[string]interface{})
 
 	data["summary"] = map[string]interface{}{
 		"required": true,
 	}
 
-	m := new(MetaIssueTypes)
+	m := new(MetaIssueType)
 	m.Fields = data
 
 	_, err := m.GetMandatoryFields()
@@ -441,7 +441,7 @@ func TestMetaIssueTypes_GetMandatoryFields_NonExistentNameKey_Fail(t *testing.T)
 	}
 }
 
-func TestMetaIssueTypes_GetAllFields(t *testing.T) {
+func TestMetaIssueType_GetAllFields(t *testing.T) {
 	data := make(map[string]interface{})
 
 	data["summary"] = map[string]interface{}{
@@ -459,7 +459,7 @@ func TestMetaIssueTypes_GetAllFields(t *testing.T) {
 		"name":     "Epic Link",
 	}
 
-	m := new(MetaIssueTypes)
+	m := new(MetaIssueType)
 	m.Fields = data
 
 	mandatory, err := m.GetAllFields()
@@ -473,14 +473,14 @@ func TestMetaIssueTypes_GetAllFields(t *testing.T) {
 	}
 }
 
-func TestMetaIssueTypes_GetAllFields_NonExistingNameKey_Fail(t *testing.T) {
+func TestMetaIssueType_GetAllFields_NonExistingNameKey_Fail(t *testing.T) {
 	data := make(map[string]interface{})
 
 	data["summary"] = map[string]interface{}{
 		"required": true,
 	}
 
-	m := new(MetaIssueTypes)
+	m := new(MetaIssueType)
 	m.Fields = data
 
 	_, err := m.GetAllFields()
@@ -489,7 +489,7 @@ func TestMetaIssueTypes_GetAllFields_NonExistingNameKey_Fail(t *testing.T) {
 	}
 }
 
-func TestCreateMetaInfo_GetProjectName_Success(t *testing.T) {
+func TestCreateMetaInfo_GetProjectWithName_Success(t *testing.T) {
 	metainfo := new(CreateMetaInfo)
 	metainfo.Projects = append(metainfo.Projects, &MetaProject{
 		Name: "SPN",
@@ -503,7 +503,7 @@ func TestCreateMetaInfo_GetProjectName_Success(t *testing.T) {
 
 func TestMetaProject_GetIssueTypeWithName_CaseMismatch_Success(t *testing.T) {
 	m := new(MetaProject)
-	m.IssueTypes = append(m.IssueTypes, &MetaIssueTypes{
+	m.IssueTypes = append(m.IssueTypes, &MetaIssueType{
 		Name: "Bug",
 	})
 
@@ -511,5 +511,29 @@ func TestMetaProject_GetIssueTypeWithName_CaseMismatch_Success(t *testing.T) {
 
 	if issuetype == nil {
 		t.Errorf("Expected non nil value, recieved nil")
+	}
+}
+
+func TestCreateMetaInfo_GetProjectWithKey_Success(t *testing.T) {
+	metainfo := new(CreateMetaInfo)
+	metainfo.Projects = append(metainfo.Projects, &MetaProject{
+		Key: "SPNKEY",
+	})
+
+	project := metainfo.GetProjectWithKey("SPNKEY")
+	if project == nil {
+		t.Errorf("Expected non nil value, recieved nil")
+	}
+}
+
+func TestCreateMetaInfo_GetProjectWithKey_NilForNonExistent(t *testing.T) {
+	metainfo := new(CreateMetaInfo)
+	metainfo.Projects = append(metainfo.Projects, &MetaProject{
+		Key: "SPNKEY",
+	})
+
+	project := metainfo.GetProjectWithKey("SPN")
+	if project != nil {
+		t.Errorf("Expected nil, recieved value")
 	}
 }


### PR DESCRIPTION
The name has been fixed from MetaIssueTypes to MetaIssueType because the latter is more intuitive. A new method GetProjectWithKey has been added so that it is easier to look for projects with key and not just name. This is essential when creating issue using createmeta information.

The tests has been fixed for the MetaIssueType and new tests added for the added function. 