### PR TITLE
Fixes the structs tags. Adds test to verify empty fields are ommitted

### DIFF
--- a/issue.go
+++ b/issue.go
@@ -172,12 +172,12 @@ func (i *IssueFields) UnmarshalJSON(data []byte) error {
 // Typical types are "Request", "Bug", "Story", ...
 type IssueType struct {
 	Self        string `json:"self,omitempty" structs:"self,omitempty"`
-	ID          string `json:"id,omitempty" struct:"id,omitempty"`
-	Description string `json:"description,omitempty" struct:"description,omitempty"`
-	IconURL     string `json:"iconUrl,omitempty" struct:"iconUrl,omitempty"`
-	Name        string `json:"name,omitempty" struct:"name,omitempty"`
-	Subtask     bool   `json:"subtask,omitempty" struct:"subtask,omitempty"`
-	AvatarID    int    `json:"avatarId,omitempty" struct:"avatarId,omitempty"`
+	ID          string `json:"id,omitempty" structs:"id,omitempty"`
+	Description string `json:"description,omitempty" structs:"description,omitempty"`
+	IconURL     string `json:"iconUrl,omitempty" structs:"iconUrl,omitempty"`
+	Name        string `json:"name,omitempty" structs:"name,omitempty"`
+	Subtask     bool   `json:"subtask,omitempty" structs:"subtask,omitempty"`
+	AvatarID    int    `json:"avatarId,omitempty" structs:"avatarId,omitempty"`
 }
 
 // Resolution represents a resolution of a JIRA issue.

--- a/issue_test.go
+++ b/issue_test.go
@@ -572,6 +572,44 @@ func TestIssueFields_TestMarshalJSON_PopulateUnknownsSuccess(t *testing.T) {
 
 }
 
+func TestIssueFields_MarshalJSON_OmitsEmptyFields(t *testing.T) {
+	i := &IssueFields{
+		Description: "blahblah",
+		Type: IssueType{
+			Name: "Story",
+		},
+		Labels: []string{"aws-docker"},
+	}
+
+	rawdata, err := json.Marshal(i)
+	if err != nil {
+		t.Errorf("Expected nil err, recieved %s", err)
+	}
+
+	// convert json to map and see if unset keys are there
+	issuef := tcontainer.NewMarshalMap()
+	err = json.Unmarshal(rawdata, &issuef)
+	if err != nil {
+		t.Errorf("Expected nil err, received %s", err)
+	}
+
+	_, err = issuef.Int("issuetype/avatarId")
+	if err == nil {
+		t.Error("Expected non nil error, recieved nil")
+	}
+
+	// verify that the field that should be there, is.
+	name, err := issuef.String("issuetype/name")
+	if err != nil {
+		t.Errorf("Expected nil err, received %s", err)
+	}
+
+	if name != "Story" {
+		t.Errorf("Expected Story, received %s", name)
+	}
+
+}
+
 func TestIssueFields_MarshalJSON_Success(t *testing.T) {
 	i := &IssueFields{
 		Description: "example bug report",


### PR DESCRIPTION
The structs tag were wrongly named as "struct" at some places. This caused unproper marshalling of IssueFields. This has been fixed and a unit test added to verify the tags which shouldn't be there isn't. 
@bigkraig this will fix the issue. 