### PR TITLE
NewRawRequest method to use a native io.Reader instead of marshalling

### DIFF
--- a/jira.go
+++ b/jira.go
@@ -61,6 +61,35 @@ func NewClient(httpClient *http.Client, baseURL string) (*Client, error) {
 	return c, nil
 }
 
+// NewRawRequest creates an API request.
+// A relative URL can be provided in urlStr, in which case it is resolved relative to the baseURL of the Client.
+// Relative URLs should always be specified without a preceding slash.
+// Allows using an optional native io.Reader for sourcing the request body.
+func (c *Client) NewRawRequest(method, urlStr string, body io.Reader) (*http.Request, error) {
+	rel, err := url.Parse(urlStr)
+	if err != nil {
+		return nil, err
+	}
+
+	u := c.baseURL.ResolveReference(rel)
+
+	req, err := http.NewRequest(method, u.String(), body)
+	if err != nil {
+		return nil, err
+	}
+
+	req.Header.Set("Content-Type", "application/json")
+
+	// Set session cookie if there is one
+	if c.session != nil {
+		for _, cookie := range c.session.Cookies {
+			req.AddCookie(cookie)
+		}
+	}
+
+	return req, nil
+}
+
 // NewRequest creates an API request.
 // A relative URL can be provided in urlStr, in which case it is resolved relative to the baseURL of the Client.
 // Relative URLs should always be specified without a preceding slash.

--- a/jira_test.go
+++ b/jira_test.go
@@ -145,6 +145,30 @@ func TestClient_NewRequest(t *testing.T) {
 	}
 }
 
+func TestClient_NewRawRequest(t *testing.T) {
+	c, err := NewClient(nil, testJIRAInstanceURL)
+	if err != nil {
+		t.Errorf("An error occured. Expected nil. Got %+v.", err)
+	}
+
+	inURL, outURL := "rest/api/2/issue/", testJIRAInstanceURL+"rest/api/2/issue/"
+
+	outBody := `{"key":"MESOS"}` + "\n"
+	inBody := outBody
+	req, _ := c.NewRawRequest("GET", inURL, strings.NewReader(outBody))
+
+	// Test that relative URL was expanded
+	if got, want := req.URL.String(), outURL; got != want {
+		t.Errorf("NewRawRequest(%q) URL is %v, want %v", inURL, got, want)
+	}
+
+	// Test that body was JSON encoded
+	body, _ := ioutil.ReadAll(req.Body)
+	if got, want := string(body), outBody; got != want {
+		t.Errorf("NewRawRequest(%v) Body is %v, want %v", inBody, got, want)
+	}
+}
+
 func testURLParseError(t *testing.T, err error) {
 	if err == nil {
 		t.Errorf("Expected error to be returned")


### PR DESCRIPTION
When using custom fields it would be impossible to annotate the field name and/or create it dynamically at run time (it would involve reflection black magic and other weird tricks).

The most simple solution I could find is to simply emulate the native `http.NewRequest` parameters as per this PR.