### PR TITLE
Add UserService to handle JIRA User endpoints

### DIFF
--- a/issue.go
+++ b/issue.go
@@ -205,18 +205,6 @@ type Watches struct {
 	IsWatching bool   `json:"isWatching,omitempty" structs:"isWatching,omitempty"`
 }
 
-// User represents a user who is this JIRA issue assigned to.
-type User struct {
-	Self         string     `json:"self,omitempty" structs:"self,omitempty"`
-	Name         string     `json:"name,omitempty" structs:"name,omitempty"`
-	Key          string     `json:"key,omitempty" structs:"key,omitempty"`
-	EmailAddress string     `json:"emailAddress,omitempty" structs:"emailAddress,omitempty"`
-	AvatarUrls   AvatarUrls `json:"avatarUrls,omitempty" structs:"avatarUrls,omitempty"`
-	DisplayName  string     `json:"displayName,omitempty" structs:"displayName,omitempty"`
-	Active       bool       `json:"active,omitempty" structs:"active,omitempty"`
-	TimeZone     string     `json:"timeZone,omitempty" structs:"timeZone,omitempty"`
-}
-
 // AvatarUrls represents different dimensions of avatars / images
 type AvatarUrls struct {
 	Four8X48  string `json:"48x48,omitempty" structs:"48x48,omitempty"`

--- a/jira.go
+++ b/jira.go
@@ -29,6 +29,7 @@ type Client struct {
 	Project        *ProjectService
 	Board          *BoardService
 	Sprint         *SprintService
+	User           *UserService
 }
 
 // NewClient returns a new JIRA API client.
@@ -57,6 +58,7 @@ func NewClient(httpClient *http.Client, baseURL string) (*Client, error) {
 	c.Project = &ProjectService{client: c}
 	c.Board = &BoardService{client: c}
 	c.Sprint = &SprintService{client: c}
+	c.User = &UserService{client: c}
 
 	return c, nil
 }

--- a/user.go
+++ b/user.go
@@ -1,0 +1,74 @@
+package jira
+
+import (
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+)
+
+// UserService handles users for the JIRA instance / API.
+//
+// JIRA API docs: https://docs.atlassian.com/jira/REST/cloud/#api/2/user
+type UserService struct {
+	client *Client
+}
+
+// User represents a JIRA user.
+type User struct {
+	Self            string     `json:"self,omitempty" structs:"self,omitempty"`
+	Name            string     `json:"name,omitempty" structs:"name,omitempty"`
+	Password        string     `json:"-"`
+	Key             string     `json:"key,omitempty" structs:"key,omitempty"`
+	EmailAddress    string     `json:"emailAddress,omitempty" structs:"emailAddress,omitempty"`
+	AvatarUrls      AvatarUrls `json:"avatarUrls,omitempty" structs:"avatarUrls,omitempty"`
+	DisplayName     string     `json:"displayName,omitempty" structs:"displayName,omitempty"`
+	Active          bool       `json:"active,omitempty" structs:"active,omitempty"`
+	TimeZone        string     `json:"timeZone,omitempty" structs:"timeZone,omitempty"`
+	ApplicationKeys []string   `json:"applicationKeys,omitempty" structs:"applicationKeys,omitempty"`
+}
+
+// Get gets user info from JIRA
+//
+// JIRA API docs: https://docs.atlassian.com/jira/REST/cloud/#api/2/user-getUser
+func (s *UserService) Get(username string) (*User, *Response, error) {
+	apiEndpoint := fmt.Sprintf("/rest/api/2/user/%s", username)
+	req, err := s.client.NewRequest("GET", apiEndpoint, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	user := new(User)
+	resp, err := s.client.Do(req, user)
+	if err != nil {
+		return nil, resp, err
+	}
+	return user, resp, nil
+}
+
+// Create creates an user in JIRA.
+//
+// JIRA API docs: https://docs.atlassian.com/jira/REST/cloud/#api/2/user-createUser
+func (s *UserService) Create(user *User) (*User, *Response, error) {
+	apiEndpoint := "/rest/api/2/user"
+	req, err := s.client.NewRequest("POST", apiEndpoint, user)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	resp, err := s.client.Do(req, nil)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	responseUser := new(User)
+	defer resp.Body.Close()
+	data, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return nil, resp, fmt.Errorf("Could not read the returned data")
+	}
+	err = json.Unmarshal(data, responseUser)
+	if err != nil {
+		return nil, resp, fmt.Errorf("Could not unmarshall the data into struct")
+	}
+	return responseUser, resp, nil
+}

--- a/user_test.go
+++ b/user_test.go
@@ -1,0 +1,57 @@
+package jira
+
+import (
+	"fmt"
+	"net/http"
+	"testing"
+)
+
+func TestUserService_Get_Success(t *testing.T) {
+	setup()
+	defer teardown()
+	testMux.HandleFunc("/rest/api/2/user/fred", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "GET")
+		testRequestURL(t, r, "/rest/api/2/user/fred")
+
+		fmt.Fprint(w, `{"self":"http://www.example.com/jira/rest/api/2/user?username=fred","key":"fred",
+        "name":"fred","emailAddress":"fred@example.com","avatarUrls":{"48x48":"http://www.example.com/jira/secure/useravatar?size=large&ownerId=fred",
+        "24x24":"http://www.example.com/jira/secure/useravatar?size=small&ownerId=fred","16x16":"http://www.example.com/jira/secure/useravatar?size=xsmall&ownerId=fred",
+        "32x32":"http://www.example.com/jira/secure/useravatar?size=medium&ownerId=fred"},"displayName":"Fred F. User","active":true,"timeZone":"Australia/Sydney","groups":{"size":3,"items":[
+        {"name":"jira-user","self":"http://www.example.com/jira/rest/api/2/group?groupname=jira-user"},{"name":"jira-admin",
+        "self":"http://www.example.com/jira/rest/api/2/group?groupname=jira-admin"},{"name":"important","self":"http://www.example.com/jira/rest/api/2/group?groupname=important"
+        }]},"applicationRoles":{"size":1,"items":[]},"expand":"groups,applicationRoles"}`)
+	})
+
+	if user, _, err := testClient.User.Get("fred"); err != nil {
+		t.Errorf("Error given: %s", err)
+	} else if user == nil {
+		t.Error("Expected user. User is nil")
+	}
+}
+
+func TestUserService_Create(t *testing.T) {
+	setup()
+	defer teardown()
+	testMux.HandleFunc("/rest/api/2/user", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "POST")
+		testRequestURL(t, r, "/rest/api/2/user")
+
+		w.WriteHeader(http.StatusCreated)
+		fmt.Fprint(w, `{"name":"charlie","password":"abracadabra","emailAddress":"charlie@atlassian.com",
+        "displayName":"Charlie of Atlassian","applicationKeys":["jira-core"]}`)
+	})
+
+	u := &User{
+		Name:            "charlie",
+		Password:        "abracadabra",
+		EmailAddress:    "charlie@atlassian.com",
+		DisplayName:     "Charlie of Atlassian",
+		ApplicationKeys: []string{"jira-core"},
+	}
+
+	if user, _, err := testClient.User.Create(u); err != nil {
+		t.Errorf("Error given: %s", err)
+	} else if user == nil {
+		t.Error("Expected user. User is nil")
+	}
+}


### PR DESCRIPTION
This PR implements JIRA User endpoints:

Create: https://docs.atlassian.com/jira/REST/cloud/#api/2/user-createUser

Get: https://docs.atlassian.com/jira/REST/cloud/#api/2/user-getUser