### PR TITLE
Added Parent to issue fields

### DIFF
--- a/issue.go
+++ b/issue.go
@@ -101,6 +101,7 @@ type IssueFields struct {
 	Subtasks             []*Subtasks   `json:"subtasks,omitempty" structs:"subtasks,omitempty"`
 	Attachments          []*Attachment `json:"attachment,omitempty" structs:"attachment,omitempty"`
 	Epic                 *Epic         `json:"epic,omitempty" structs:"epic,omitempty"`
+	Parent               *Parent       `json:"parent,omitempty" structs:"parent,omitempty`
 	Unknowns             tcontainer.MarshalMap
 }
 
@@ -259,6 +260,12 @@ type StatusCategory struct {
 type Progress struct {
 	Progress int `json:"progress" structs:"progress"`
 	Total    int `json:"total" structs:"total"`
+}
+
+// Parent represents the parent of a JIRA issue, to be used with subtask issue types.
+type Parent struct {
+	ID  string `json:"id,omitempty" structs:id"`
+	Key string `json:"key,omitempty" structs:key"`
 }
 
 // Time represents the Time definition of JIRA as a time.Time of go


### PR DESCRIPTION
This PR adds support for creating sub tasks associated with a parent issue by name or id.
https://docs.atlassian.com/jira/REST/cloud/#api/2/issue-createIssue
```
Creating a sub-task is similar to creating a regular issue, with two important differences:
the issueType field must correspond to a sub-task issue type (you can use /issue/createmeta to discover sub-task issue types), and
you must provide a parent field in the issue create request containing the id or key of the parent issue
```