### PR TITLE
Fix User.GET() method

### DIFF
--- a/user.go
+++ b/user.go
@@ -31,7 +31,7 @@ type User struct {
 //
 // JIRA API docs: https://docs.atlassian.com/jira/REST/cloud/#api/2/user-getUser
 func (s *UserService) Get(username string) (*User, *Response, error) {
-	apiEndpoint := fmt.Sprintf("/rest/api/2/user/%s", username)
+	apiEndpoint := fmt.Sprintf("/rest/api/2/user?username=%s", username)
 	req, err := s.client.NewRequest("GET", apiEndpoint, nil)
 	if err != nil {
 		return nil, nil, err


### PR DESCRIPTION
According to https://docs.atlassian.com/jira/REST/cloud/#api/2/user-getUser username must be provided as a query string parameter