### PR TITLE
Issue Changelog and Query Parameters for Issue.Get

### DIFF
--- a/issue.go
+++ b/issue.go
@@ -122,7 +122,7 @@ type IssueFields struct {
 	Attachments          []*Attachment `json:"attachment,omitempty" structs:"attachment,omitempty"`
 	Epic                 *Epic         `json:"epic,omitempty" structs:"epic,omitempty"`
 	Parent               *Parent       `json:"parent,omitempty" structs:"parent,omitempty"`
-	Changelog            Changelog `json:"changelog,omitemopty" structs:"changelog,omitempty"`
+	Changelog            *Changelog `json:"changelog,omitemopty" structs:"changelog,omitempty"`
 	Unknowns             tcontainer.MarshalMap
 }
 

--- a/issue.go
+++ b/issue.go
@@ -30,11 +30,12 @@ type IssueService struct {
 
 // Issue represents a JIRA issue.
 type Issue struct {
-	Expand string       `json:"expand,omitempty" structs:"expand,omitempty"`
-	ID     string       `json:"id,omitempty" structs:"id,omitempty"`
-	Self   string       `json:"self,omitempty" structs:"self,omitempty"`
-	Key    string       `json:"key,omitempty" structs:"key,omitempty"`
-	Fields *IssueFields `json:"fields,omitempty" structs:"fields,omitempty"`
+	Expand    string       `json:"expand,omitempty" structs:"expand,omitempty"`
+	ID        string       `json:"id,omitempty" structs:"id,omitempty"`
+	Self      string       `json:"self,omitempty" structs:"self,omitempty"`
+	Key       string       `json:"key,omitempty" structs:"key,omitempty"`
+	Fields    *IssueFields `json:"fields,omitempty" structs:"fields,omitempty"`
+	Changelog *Changelog    `json:"changelog,omitempty" structs:"changelog,omitempty"`
 }
 
 // Attachment represents a JIRA attachment
@@ -78,7 +79,7 @@ type ChangelogHistory struct {
 }
 
 type Changelog struct {
-	Histories []ChangelogHistory `json:"histories"`
+	Histories []ChangelogHistory `json:"histories,omitempty"`
 }
 
 // IssueFields represents single fields of a JIRA issue.
@@ -91,6 +92,7 @@ type IssueFields struct {
 	//      * "aggregatetimeoriginalestimate": null,
 	//      * "aggregatetimeestimate": null,
 	//      * "environment": null,
+	Expand               string        `json:"expand"`
 	Type                 IssueType     `json:"issuetype" structs:"issuetype"`
 	Project              Project       `json:"project,omitempty" structs:"project,omitempty"`
 	Resolution           *Resolution   `json:"resolution,omitempty" structs:"resolution,omitempty"`
@@ -122,7 +124,6 @@ type IssueFields struct {
 	Attachments          []*Attachment `json:"attachment,omitempty" structs:"attachment,omitempty"`
 	Epic                 *Epic         `json:"epic,omitempty" structs:"epic,omitempty"`
 	Parent               *Parent       `json:"parent,omitempty" structs:"parent,omitempty"`
-	Changelog            *Changelog `json:"changelog,omitemopty" structs:"changelog,omitempty"`
 	Unknowns             tcontainer.MarshalMap
 }
 
@@ -454,7 +455,7 @@ type CustomFields map[string]string
 // The given options will be appended to the query string
 //
 // JIRA API docs: https://docs.atlassian.com/jira/REST/latest/#api/2/issue-getIssue
-func (s *IssueService) Get(issueID string, queryOptions... map[string]string) (*Issue, *Response, error) {
+func (s *IssueService) Get(issueID string, queryOptions ... map[string]string) (*Issue, *Response, error) {
 	apiEndpoint := fmt.Sprintf("rest/api/2/issue/%s", issueID)
 	req, err := s.client.NewRequest("GET", apiEndpoint, nil)
 	if err != nil {
@@ -464,12 +465,12 @@ func (s *IssueService) Get(issueID string, queryOptions... map[string]string) (*
 	if len(queryOptions) > 0 {
 		q := req.URL.Query()
 		for _, opts := range queryOptions {
-			for k,v := range opts {
+			for k, v := range opts {
 				q.Add(k, v)
 			}
 		}
+		req.URL.RawQuery = q.Encode()
 	}
-
 
 	issue := new(Issue)
 	resp, err := s.client.Do(req, issue)

--- a/issue.go
+++ b/issue.go
@@ -451,9 +451,15 @@ type CustomFields map[string]string
 // This can be an issue id, or an issue key.
 // If the issue cannot be found via an exact match, JIRA will also look for the issue in a case-insensitive way, or by looking to see if the issue was moved.
 //
+// The given options will be appended to the query string
+//
 // JIRA API docs: https://docs.atlassian.com/jira/REST/latest/#api/2/issue-getIssue
-func (s *IssueService) Get(issueID string) (*Issue, *Response, error) {
+func (s *IssueService) Get(issueID string, queryOptions... string) (*Issue, *Response, error) {
 	apiEndpoint := fmt.Sprintf("rest/api/2/issue/%s", issueID)
+	if len(queryOptions) > 0 {
+		apiEndpoint = fmt.Sprintf("%s?%s", queryOptions)
+	}
+	
 	req, err := s.client.NewRequest("GET", apiEndpoint, nil)
 	if err != nil {
 		return nil, nil, err

--- a/issue.go
+++ b/issue.go
@@ -429,6 +429,8 @@ type SearchOptions struct {
 	StartAt int `url:"startAt,omitempty"`
 	// MaxResults: The maximum number of projects to return per page. Default: 50.
 	MaxResults int `url:"maxResults,omitempty"`
+	// Expand: Expand specific sections in the returned issues
+	Expand string `url:expand,omitempty"`
 }
 
 // searchResult is only a small wrapper arround the Search (with JQL) method

--- a/issue.go
+++ b/issue.go
@@ -61,6 +61,26 @@ type Epic struct {
 	Done    bool   `json:"done" structs:"done"`
 }
 
+type ChangelogItems struct {
+	Field      string `json:"field" structs:"field"`
+	FieldType  string `json:"fieldtype" structs:"fieldtype"`
+	From       interface{} `json:"from" structs:"from"`
+	FromString string `json:"fromString" structs:"fromString"`
+	To         interface{} `json:"to" structs:"to"`
+	ToString   string `json:"toString" structs:"toString"`
+}
+
+type ChangelogHistory struct {
+	Id      string `json:"id" structs:"id"`
+	Author  User `json:"author" structs:"author"`
+	Created string `json:"created" structs:"created"`
+	Items   []ChangelogItems `json:"items" structs:"items"`
+}
+
+type Changelog struct {
+	Histories []ChangelogHistory `json:"histories"`
+}
+
 // IssueFields represents single fields of a JIRA issue.
 // Every JIRA issue has several fields attached.
 type IssueFields struct {
@@ -102,6 +122,7 @@ type IssueFields struct {
 	Attachments          []*Attachment `json:"attachment,omitempty" structs:"attachment,omitempty"`
 	Epic                 *Epic         `json:"epic,omitempty" structs:"epic,omitempty"`
 	Parent               *Parent       `json:"parent,omitempty" structs:"parent,omitempty"`
+	Changelog            Changelog `json:"changelog,omitemopty" structs:"changelog,omitempty"`
 	Unknowns             tcontainer.MarshalMap
 }
 

--- a/issue.go
+++ b/issue.go
@@ -454,16 +454,22 @@ type CustomFields map[string]string
 // The given options will be appended to the query string
 //
 // JIRA API docs: https://docs.atlassian.com/jira/REST/latest/#api/2/issue-getIssue
-func (s *IssueService) Get(issueID string, queryOptions... string) (*Issue, *Response, error) {
+func (s *IssueService) Get(issueID string, queryOptions... map[string]string) (*Issue, *Response, error) {
 	apiEndpoint := fmt.Sprintf("rest/api/2/issue/%s", issueID)
-	if len(queryOptions) > 0 {
-		apiEndpoint = fmt.Sprintf("%s?%s", queryOptions)
-	}
-	
 	req, err := s.client.NewRequest("GET", apiEndpoint, nil)
 	if err != nil {
 		return nil, nil, err
 	}
+
+	if len(queryOptions) > 0 {
+		q := req.URL.Query()
+		for _, opts := range queryOptions {
+			for k,v := range opts {
+				q.Add(k, v)
+			}
+		}
+	}
+
 
 	issue := new(Issue)
 	resp, err := s.client.Do(req, issue)


### PR DESCRIPTION
With this PR I added the following functionality:

* Retrieve the unmarshal the changelog of Issues when present
* Add a way to append query parameters (e.g. `...?expand=changelog`) to Issue.Get(...) requests

This would address issue #45 in a way. Merge or provide suggestions for improvement or decline as you like.