### PR TITLE
Add the "option" field type for custom fields

### DIFF
--- a/issue.go
+++ b/issue.go
@@ -312,6 +312,12 @@ type TransitionPayload struct {
 	ID string `json:"id" structs:"id"`
 }
 
+// Option represents an option value in a SelectList or MultiSelect
+// custom issue field
+type Option struct {
+	Value string `json:"value" structs:"value"`
+}
+
 // UnmarshalJSON will transform the JIRA time into a time.Time
 // during the transformation of the JIRA JSON response
 func (t *Time) UnmarshalJSON(b []byte) error {
@@ -718,7 +724,7 @@ func (s *IssueService) DoTransition(ticketID, transitionID string) (*Response, e
 //  * metaProject should contain metaInformation about the project where the issue should be created.
 //  * metaIssuetype is the MetaInformation about the Issuetype that needs to be created.
 //  * fieldsConfig is a key->value pair where key represents the name of the field as seen in the UI
-// 		And value is the string value for that particular key.
+//		And value is the string value for that particular key.
 // Note: This method doesn't verify that the fieldsConfig is complete with mandatory fields. The fieldsConfig is
 //		 supposed to be already verified with MetaIssueType.CheckCompleteAndAvailable. It will however return
 //		 error if the key is not found.
@@ -774,6 +780,10 @@ func InitIssueWithMetaAndFields(metaProject *MetaProject, metaIssuetype *MetaIss
 		case "issuetype":
 			issueFields.Unknowns[jiraKey] = IssueType{
 				Name: value,
+			}
+		case "option":
+			issueFields.Unknowns[jiraKey] = Option{
+				Value: value,
 			}
 		default:
 			return nil, fmt.Errorf("Unknown issue type encountered: %s for %s", valueType, key)

--- a/issue_test.go
+++ b/issue_test.go
@@ -894,6 +894,42 @@ func TestInitIssueWithMetaAndFields_PriorityValueType(t *testing.T) {
 	}
 }
 
+func TestInitIssueWithMetaAndFields_SelectList(t *testing.T) {
+	metaProject := MetaProject{
+		Name: "Engineering - Dept",
+		Id:   "ENG",
+	}
+
+	fields := tcontainer.NewMarshalMap()
+	fields["someitem"] = map[string]interface{}{
+		"name": "A Select Item",
+		"schema": map[string]interface{}{
+			"type": "option",
+		},
+	}
+
+	metaIssueType := MetaIssueType{
+		Fields: fields,
+	}
+
+	expectedVal := "Value"
+	fieldConfig := map[string]string{
+		"A Select Item": expectedVal,
+	}
+
+	issue, err := InitIssueWithMetaAndFields(&metaProject, &metaIssueType, fieldConfig)
+	if err != nil {
+		t.Errorf("Expected nil error, recieved %s", err)
+	}
+
+	a, _ := issue.Fields.Unknowns.Value("someitem")
+	gotVal := a.(Option).Value
+
+	if gotVal != expectedVal {
+		t.Errorf("Expected %s recieved %s", expectedVal, gotVal)
+	}
+}
+
 func TestInitIssueWithMetaAndFields_IssuetypeValueType(t *testing.T) {
 	metaProject := MetaProject{
 		Name: "Engineering - Dept",


### PR DESCRIPTION
## What does this PR do?
JIRA supports SelectList field types, which are similar to but
represented not quite the same as Strings. This change allows go-jira
to create issues with custom fields on them that are SelectLists.

## Why?

I had to create an issue in a project that heavily templates issues with custom fields, and it's making use of the "SelectList" type a lot. This was the only way I could get it to work on our installation.

I hope you find this PR acceptable - happy to fix anything that's wrong with it (: