### PR TITLE
Add Issue Update method

### DIFF
--- a/issue.go
+++ b/issue.go
@@ -588,6 +588,26 @@ func (s *IssueService) Create(issue *Issue) (*Issue, *Response, error) {
 	return responseIssue, resp, nil
 }
 
+// Update updates an issue from a JSON representation.
+//
+// JIRA API docs: https://docs.atlassian.com/jira/REST/cloud/#api/2/issue-editIssue
+func (s *IssueService) Update(issue *Issue) (*Issue, *Response, error) {
+	apiEndpoint := fmt.Sprintf("rest/api/2/issue/%v", issue.ID)
+	req, err := s.client.NewRequest("PUT", apiEndpoint, issue)
+	if err != nil {
+		return nil, nil, err
+	}
+	resp, err := s.client.Do(req, nil)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	// This is just to follow the rest of the API's convention of returning an issue.
+	// Returning the same pointer here is pointless, so we return a copy instead.
+	ret := *issue
+	return &ret, resp, nil
+}
+
 // AddComment adds a new comment to issueID.
 //
 // JIRA API docs: https://docs.atlassian.com/jira/REST/latest/#api/2/issue-addComment

--- a/issue_test.go
+++ b/issue_test.go
@@ -78,6 +78,31 @@ func TestIssueService_Create(t *testing.T) {
 	}
 }
 
+func TestIssueService_Update(t *testing.T) {
+	setup()
+	defer teardown()
+	testMux.HandleFunc("/rest/api/2/issue/10002", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "PUT")
+		testRequestURL(t, r, "/rest/api/2/issue/10002")
+
+		w.WriteHeader(http.StatusNoContent)
+	})
+
+	i := &Issue{
+		ID: "10002",
+		Fields: &IssueFields{
+			Description: "example bug report",
+		},
+	}
+	issue, _, err := testClient.Issue.Update(i)
+	if issue == nil {
+		t.Error("Expected issue. Issue is nil")
+	}
+	if err != nil {
+		t.Errorf("Error given: %s", err)
+	}
+}
+
 func TestIssueService_AddComment(t *testing.T) {
 	setup()
 	defer teardown()


### PR DESCRIPTION
JIRA only allows issues to be created with certain fields set. This
means if a user needs to create an issue through the API with the
description set, they need to create the issue first, and then call the
API again to update it.

Without this commit, the way to do this through the package is by
calling IssueService.Create and then use the client's NewRequest method
to create a raw HTTP request for the Update. This isn't bad, but it can
be better.