### PR TITLE
Fix bug in issue update

### DIFF
--- a/issue.go
+++ b/issue.go
@@ -588,11 +588,11 @@ func (s *IssueService) Create(issue *Issue) (*Issue, *Response, error) {
 	return responseIssue, resp, nil
 }
 
-// Update updates an issue from a JSON representation.
+// Update updates an issue from a JSON representation. The issue is found by key.
 //
 // JIRA API docs: https://docs.atlassian.com/jira/REST/cloud/#api/2/issue-editIssue
 func (s *IssueService) Update(issue *Issue) (*Issue, *Response, error) {
-	apiEndpoint := fmt.Sprintf("rest/api/2/issue/%v", issue.ID)
+	apiEndpoint := fmt.Sprintf("rest/api/2/issue/%v", issue.Key)
 	req, err := s.client.NewRequest("PUT", apiEndpoint, issue)
 	if err != nil {
 		return nil, nil, err

--- a/issue_test.go
+++ b/issue_test.go
@@ -81,15 +81,15 @@ func TestIssueService_Create(t *testing.T) {
 func TestIssueService_Update(t *testing.T) {
 	setup()
 	defer teardown()
-	testMux.HandleFunc("/rest/api/2/issue/10002", func(w http.ResponseWriter, r *http.Request) {
+	testMux.HandleFunc("/rest/api/2/issue/PROJ-9001", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "PUT")
-		testRequestURL(t, r, "/rest/api/2/issue/10002")
+		testRequestURL(t, r, "/rest/api/2/issue/PROJ-9001")
 
 		w.WriteHeader(http.StatusNoContent)
 	})
 
 	i := &Issue{
-		ID: "10002",
+		Key: "PROJ-9001",
 		Fields: &IssueFields{
 			Description: "example bug report",
 		},


### PR DESCRIPTION
The issue was being found by ID, but there are cases where a user will
have the issue key but not the ID, whereas if the user has the ID then
it's highly likely they have the key, because they probably got the ID
from the API, which would also return the key.