### PR TITLE
Fixes 'JRIA' misprint in README.md (#98)

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@
 * Create and retrieve issue transitions (status updates)
 * Call every API endpoint of the JIRA, even if it is not directly implemented in this library
 
-This package is not JIRA API complete (yet), but you can call every API endpoint you want. See [Call a not implemented API endpoint](#call-a-not-implemented-api-endpoint) how to do this. For all possible API endpoints of JRIA have a look at [latest JIRA REST API documentation](https://docs.atlassian.com/jira/REST/latest/).
+This package is not JIRA API complete (yet), but you can call every API endpoint you want. See [Call a not implemented API endpoint](#call-a-not-implemented-api-endpoint) how to do this. For all possible API endpoints of JIRA have a look at [latest JIRA REST API documentation](https://docs.atlassian.com/jira/REST/latest/).
 
 ## Compatible JIRA versions
 


### PR DESCRIPTION
Fixes misprint in README.md as described in #98.