### PR TITLE
New TransitionPayloadFields to set fields on transitions

### DIFF
--- a/issue.go
+++ b/issue.go
@@ -303,6 +303,7 @@ type transitionResult struct {
 type Transition struct {
 	ID     string                     `json:"id" structs:"id"`
 	Name   string                     `json:"name" structs:"name"`
+	To     Status                     `json:"to" structs:"status"`
 	Fields map[string]TransitionField `json:"fields" structs:"fields"`
 }
 

--- a/issue.go
+++ b/issue.go
@@ -313,12 +313,18 @@ type TransitionField struct {
 
 // CreateTransitionPayload is used for creating new issue transitions
 type CreateTransitionPayload struct {
-	Transition TransitionPayload `json:"transition" structs:"transition"`
+	Transition TransitionPayload       `json:"transition" structs:"transition"`
+	Fields     TransitionPayloadFields `json:"fields" structs:"fields"`
 }
 
 // TransitionPayload represents the request payload of Transition calls like DoTransition
 type TransitionPayload struct {
 	ID string `json:"id" structs:"id"`
+}
+
+// TransitionPayloadFields represents the fields that can be set when executing a transition
+type TransitionPayloadFields struct {
+	Resolution *Resolution `json:"resolution,omitempty" structs:"resolution,omitempty"`
 }
 
 // Option represents an option value in a SelectList or MultiSelect


### PR DESCRIPTION
* New 'TransitionPayloadFields' to set field values when executing transitions (e.g. the built-in 'Resolution' field which is always required to resolve issues).
* Add 'To' field to transitions to be able to work with custom projects. This way you can check 'To.StatusCategory' to do automatic transitions in workflows with non-standard transition names. 