### PR TITLE
add basic Version endpoints

### DIFF
--- a/jira.go
+++ b/jira.go
@@ -31,6 +31,7 @@ type Client struct {
 	Sprint         *SprintService
 	User           *UserService
 	Group          *GroupService
+	Version        *VersionService
 }
 
 // NewClient returns a new JIRA API client.
@@ -61,6 +62,7 @@ func NewClient(httpClient *http.Client, baseURL string) (*Client, error) {
 	c.Sprint = &SprintService{client: c}
 	c.User = &UserService{client: c}
 	c.Group = &GroupService{client: c}
+	c.Version = &VersionService{client: c}
 
 	return c, nil
 }

--- a/jira_test.go
+++ b/jira_test.go
@@ -112,6 +112,9 @@ func TestNewClient_WithServices(t *testing.T) {
 	if c.Group == nil {
 		t.Error("No GroupService provided")
 	}
+	if c.Version == nil {
+		t.Error("No VersionService provided")
+	}
 }
 
 func TestCheckResponse(t *testing.T) {

--- a/project.go
+++ b/project.go
@@ -53,18 +53,6 @@ type Project struct {
 	ProjectCategory ProjectCategory `json:"projectCategory,omitempty" structs:"projectCategory,omitempty"`
 }
 
-// Version represents a single release version of a project
-type Version struct {
-	Self            string `json:"self" structs:"self,omitempty"`
-	ID              string `json:"id" structs:"id,omitempty"`
-	Name            string `json:"name" structs:"name,omitempty"`
-	Archived        bool   `json:"archived" structs:"archived,omitempty"`
-	Released        bool   `json:"released" structs:"released,omitempty"`
-	ReleaseDate     string `json:"releaseDate" structs:"releaseDate,omitempty"`
-	UserReleaseDate string `json:"userReleaseDate" structs:"userReleaseDate,omitempty"`
-	ProjectID       int    `json:"projectId" structs:"projectId,omitempty"` // Unlike other IDs, this is returned as a number
-}
-
 // ProjectComponent represents a single component of a project
 type ProjectComponent struct {
 	Self                string `json:"self" structs:"self,omitempty"`

--- a/version.go
+++ b/version.go
@@ -1,0 +1,96 @@
+package jira
+
+import (
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+)
+
+// VersionService handles Versions for the JIRA instance / API.
+//
+// JIRA API docs: https://docs.atlassian.com/jira/REST/latest/#api/2/version
+type VersionService struct {
+	client *Client
+}
+
+// Version represents a single release version of a project
+type Version struct {
+	Self            string `json:"self,omitempty" structs:"self,omitempty"`
+	ID              string `json:"id,omitempty" structs:"id,omitempty"`
+	Name            string `json:"name,omitempty" structs:"name,omitempty"`
+	Description     string `json:"description,omitempty" structs:"name,omitempty"`
+	Archived        bool   `json:"archived,omitempty" structs:"archived,omitempty"`
+	Released        bool   `json:"released,omitempty" structs:"released,omitempty"`
+	ReleaseDate     string `json:"releaseDate,omitempty" structs:"releaseDate,omitempty"`
+	UserReleaseDate string `json:"userReleaseDate,omitempty" structs:"userReleaseDate,omitempty"`
+	ProjectID       int    `json:"projectId,omitempty" structs:"projectId,omitempty"` // Unlike other IDs, this is returned as a number
+}
+
+// Get gets version info from JIRA
+//
+// JIRA API docs: https://developer.atlassian.com/cloud/jira/platform/rest/#api-api-2-version-id-get
+func (s *VersionService) Get(versionID int) (*Version, *Response, error) {
+	apiEndpoint := fmt.Sprintf("/rest/api/2/version/%v", versionID)
+	req, err := s.client.NewRequest("GET", apiEndpoint, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	version := new(Version)
+	resp, err := s.client.Do(req, version)
+	if err != nil {
+		return nil, resp, NewJiraError(resp, err)
+	}
+	return version, resp, nil
+}
+
+// Create creates a version in JIRA.
+//
+// JIRA API docs: https://developer.atlassian.com/cloud/jira/platform/rest/#api-api-2-version-post
+func (s *VersionService) Create(version *Version) (*Version, *Response, error) {
+	apiEndpoint := "/rest/api/2/version"
+	req, err := s.client.NewRequest("POST", apiEndpoint, version)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	resp, err := s.client.Do(req, nil)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	responseVersion := new(Version)
+	defer resp.Body.Close()
+	data, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		e := fmt.Errorf("Could not read the returned data")
+		return nil, resp, NewJiraError(resp, e)
+	}
+	err = json.Unmarshal(data, responseVersion)
+	if err != nil {
+		e := fmt.Errorf("Could not unmarshall the data into struct")
+		return nil, resp, NewJiraError(resp, e)
+	}
+	return responseVersion, resp, nil
+}
+
+// Update updates a version from a JSON representation.
+//
+// JIRA API docs: https://developer.atlassian.com/cloud/jira/platform/rest/#api-api-2-version-id-put
+func (s *VersionService) Update(version *Version) (*Version, *Response, error) {
+	apiEndpoint := fmt.Sprintf("rest/api/2/version/%v", version.ID)
+	req, err := s.client.NewRequest("PUT", apiEndpoint, version)
+	if err != nil {
+		return nil, nil, err
+	}
+	resp, err := s.client.Do(req, nil)
+	if err != nil {
+		jerr := NewJiraError(resp, err)
+		return nil, resp, jerr
+	}
+
+	// This is just to follow the rest of the API's convention of returning a version.
+	// Returning the same pointer here is pointless, so we return a copy instead.
+	ret := *version
+	return &ret, resp, nil
+}

--- a/version_test.go
+++ b/version_test.go
@@ -1,0 +1,108 @@
+package jira
+
+import (
+	"fmt"
+	"net/http"
+	"testing"
+)
+
+func TestVersionService_Get_Success(t *testing.T) {
+	setup()
+	defer teardown()
+	testMux.HandleFunc("/rest/api/2/version/10002", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "GET")
+		testRequestURL(t, r, "/rest/api/2/version/10002")
+
+		fmt.Fprint(w, `{
+			"self": "http://www.example.com/jira/rest/api/2/version/10002",
+			"id": "10002",
+			"description": "An excellent version",
+			"name": "New Version 1",
+			"archived": false,
+			"released": true,
+			"releaseDate": "2010-07-06",
+			"overdue": true,
+			"userReleaseDate": "6/Jul/2010",
+			"projectId": 10000
+		}`)
+	})
+
+	version, _, err := testClient.Version.Get(10002)
+	if version == nil {
+		t.Error("Expected version. Issue is nil")
+	}
+	if err != nil {
+		t.Errorf("Error given: %s", err)
+	}
+}
+
+func TestVersionService_Create(t *testing.T) {
+	setup()
+	defer teardown()
+	testMux.HandleFunc("/rest/api/2/version", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "POST")
+		testRequestURL(t, r, "/rest/api/2/version")
+
+		w.WriteHeader(http.StatusCreated)
+		fmt.Fprint(w, `{
+			"description": "An excellent version",
+			"name": "New Version 1",
+			"archived": false,
+			"released": true,
+			"releaseDate": "2010-07-06",
+			"userReleaseDate": "6/Jul/2010",
+			"project": "PXA",
+			"projectId": 10000
+		  }`)
+	})
+
+	v := &Version{
+		Name:            "New Version 1",
+		Description:     "An excellent version",
+		ProjectID:       10000,
+		Released:        true,
+		ReleaseDate:     "2010-07-06",
+		UserReleaseDate: "6/Jul/2010",
+	}
+
+	version, _, err := testClient.Version.Create(v)
+	if version == nil {
+		t.Error("Expected version. Version is nil")
+	}
+	if err != nil {
+		t.Errorf("Error given: %s", err)
+	}
+}
+
+func TestServiceService_Update(t *testing.T) {
+	setup()
+	defer teardown()
+	testMux.HandleFunc("/rest/api/2/version/10002", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "PUT")
+		testRequestURL(t, r, "/rest/api/2/version/10002")
+		fmt.Fprint(w, `{
+			"description": "An excellent updated version",
+			"name": "New Updated Version 1",
+			"archived": false,
+			"released": true,
+			"releaseDate": "2010-07-06",
+			"userReleaseDate": "6/Jul/2010",
+			"project": "PXA",
+			"projectId": 10000
+		  }`)
+	})
+
+	v := &Version{
+		ID:          "10002",
+		Name:        "New Updated Version 1",
+		Description: "An excellent updated version",
+	}
+
+	version, _, err := testClient.Version.Update(v)
+	if version == nil {
+		t.Error("Expected version. Version is nil")
+	}
+	if err != nil {
+		t.Errorf("Error given: %s", err)
+	}
+}


### PR DESCRIPTION
This change adds support for following three Version operations:

- Get - https://developer.atlassian.com/cloud/jira/platform/rest/#api-api-2-version-id-get
- Create - https://developer.atlassian.com/cloud/jira/platform/rest/#api-api-2-version-post
- Update - https://developer.atlassian.com/cloud/jira/platform/rest/#api-api-2-version-id-put