### PR TITLE
adds ability to list projects with query params

### DIFF
--- a/project.go
+++ b/project.go
@@ -2,6 +2,8 @@ package jira
 
 import (
 	"fmt"
+
+	"github.com/google/go-querystring/query"
 )
 
 // ProjectService handles projects for the JIRA instance / API.
@@ -73,10 +75,26 @@ type ProjectComponent struct {
 //
 // JIRA API docs: https://docs.atlassian.com/jira/REST/latest/#api/2/project-getAllProjects
 func (s *ProjectService) GetList() (*ProjectList, *Response, error) {
+	return s.ListWithOptions(&GetQueryOptions{})
+}
+
+// GetList gets all projects form JIRA with optional query params, like &GetQueryOptions{Expand: "issueTypes"} to get
+// a list of all projects and their supported issuetypes
+//
+// JIRA API docs: https://docs.atlassian.com/jira/REST/latest/#api/2/project-getAllProjects
+func (s *ProjectService) ListWithOptions(options *GetQueryOptions) (*ProjectList, *Response, error) {
 	apiEndpoint := "rest/api/2/project"
 	req, err := s.client.NewRequest("GET", apiEndpoint, nil)
 	if err != nil {
 		return nil, nil, err
+	}
+
+	if options != nil {
+		q, err := query.Values(options)
+		if err != nil {
+			return nil, nil, err
+		}
+		req.URL.RawQuery = q.Encode()
 	}
 
 	projectList := new(ProjectList)

--- a/project.go
+++ b/project.go
@@ -23,6 +23,7 @@ type ProjectList []struct {
 	AvatarUrls      AvatarUrls      `json:"avatarUrls" structs:"avatarUrls"`
 	ProjectTypeKey  string          `json:"projectTypeKey" structs:"projectTypeKey"`
 	ProjectCategory ProjectCategory `json:"projectCategory,omitempty" structs:"projectsCategory,omitempty"`
+	IssueTypes      []IssueType     `json:"issueTypes,omitempty" structs:"issueTypes,omitempty"`
 }
 
 // ProjectCategory represents a single project category

--- a/project_test.go
+++ b/project_test.go
@@ -31,6 +31,31 @@ func TestProjectService_GetList(t *testing.T) {
 	}
 }
 
+func TestProjectService_ListWithOptions(t *testing.T) {
+	setup()
+	defer teardown()
+	testAPIEdpoint := "/rest/api/2/project"
+
+	raw, err := ioutil.ReadFile("./mocks/all_projects.json")
+	if err != nil {
+		t.Error(err.Error())
+	}
+	testMux.HandleFunc(testAPIEdpoint, func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "GET")
+		testRequestURL(t, r, "/rest/api/2/project?expand=issueTypes")
+		fmt.Fprint(w, string(raw))
+	})
+
+	projects, _, err := testClient.Project.ListWithOptions(&GetQueryOptions{Expand: "issueTypes"})
+	if projects == nil {
+		t.Error("Expected project list. Project list is nil")
+	}
+	if err != nil {
+		t.Errorf("Error given: %s", err)
+	}
+}
+
+
 func TestProjectService_Get(t *testing.T) {
 	setup()
 	defer teardown()


### PR DESCRIPTION
The list projects API endpoint in Jira accepts the standard GetQueryOptions params (like `expand=`). This PR adds an extension to the ProjectService to pass these params through and refactors the existing `GetList` top use the new method. 

@rbriski and @andygrunwald let me know what you guys think.