### PR TITLE
Cleaning a bunch of go vet issues

### DIFF
--- a/authentication.go
+++ b/authentication.go
@@ -121,7 +121,7 @@ func (s *AuthenticationService) Authenticated() bool {
 // client anymore
 func (s *AuthenticationService) Logout() error {
 	if s.authType != authTypeSession || s.client.session == nil {
-		return fmt.Errorf("No user is authenticated yet.")
+		return fmt.Errorf("no user is authenticated")
 	}
 
 	apiEndpoint := "rest/auth/1/session"

--- a/issue.go
+++ b/issue.go
@@ -388,17 +388,18 @@ type Worklog struct {
 // WorklogRecord represents one entry of a Worklog
 type WorklogRecord struct {
 	Self             string `json:"self,omitempty" structs:"self,omitempty"`
-	Author           *User   `json:"author,omitempty" structs:"author,omitempty"`
-	UpdateAuthor     *User   `json:"updateAuthor,omitempty" structs:"updateAuthor,omitempty"`
+	Author           *User  `json:"author,omitempty" structs:"author,omitempty"`
+	UpdateAuthor     *User  `json:"updateAuthor,omitempty" structs:"updateAuthor,omitempty"`
 	Comment          string `json:"comment,omitempty" structs:"comment,omitempty"`
-	Created          *Time   `json:"created,omitempty" structs:"created,omitempty"`
-	Updated          *Time   `json:"updated,omitempty" structs:"updated,omitempty"`
-	Started          *Time   `json:"started,omitempty" structs:"started,omitempty"`
+	Created          *Time  `json:"created,omitempty" structs:"created,omitempty"`
+	Updated          *Time  `json:"updated,omitempty" structs:"updated,omitempty"`
+	Started          *Time  `json:"started,omitempty" structs:"started,omitempty"`
 	TimeSpent        string `json:"timeSpent,omitempty" structs:"timeSpent,omitempty"`
 	TimeSpentSeconds int    `json:"timeSpentSeconds,omitempty" structs:"timeSpentSeconds,omitempty"`
 	ID               string `json:"id,omitempty" structs:"id,omitempty"`
 	IssueID          string `json:"issueId,omitempty" structs:"issueId,omitempty"`
 }
+
 // TimeTracking represents the timetracking fields of a JIRA issue.
 type TimeTracking struct {
 	OriginalEstimate         string `json:"originalEstimate,omitempty" structs:"originalEstimate,omitempty"`
@@ -674,11 +675,11 @@ func (s *IssueService) Update(issue *Issue) (*Issue, *Response, error) {
 	return &ret, resp, nil
 }
 
-// Update updates an issue from a JSON representation. The issue is found by key.
+// UpdateIssue updates an issue from a JSON representation. The issue is found by key.
 //
 // https://docs.atlassian.com/jira/REST/7.4.0/#api/2/issue-editIssue
-func (s *IssueService) UpdateIssue(jiraId string, data map[string]interface{}) (*Response, error) {
-	apiEndpoint := fmt.Sprintf("rest/api/2/issue/%v", jiraId)
+func (s *IssueService) UpdateIssue(jiraID string, data map[string]interface{}) (*Response, error) {
+	apiEndpoint := fmt.Sprintf("rest/api/2/issue/%v", jiraID)
 	req, err := s.client.NewRequest("PUT", apiEndpoint, data)
 	if err != nil {
 		return nil, err
@@ -741,20 +742,20 @@ func (s *IssueService) UpdateComment(issueID string, comment *Comment) (*Comment
 //
 // https://developer.atlassian.com/cloud/jira/platform/rest/#api-api-2-issue-issueIdOrKey-worklog-post
 func (s *IssueService) AddWorklogRecord(issueID string, record *WorklogRecord) (*WorklogRecord, *Response, error) {
-  apiEndpoint := fmt.Sprintf("rest/api/2/issue/%s/worklog", issueID)
-  req, err := s.client.NewRequest("POST", apiEndpoint, record)
-  if err != nil {
-    return nil, nil, err
-  }
+	apiEndpoint := fmt.Sprintf("rest/api/2/issue/%s/worklog", issueID)
+	req, err := s.client.NewRequest("POST", apiEndpoint, record)
+	if err != nil {
+		return nil, nil, err
+	}
 
-  responseRecord := new(WorklogRecord)
-  resp, err := s.client.Do(req, responseRecord)
-  if err != nil {
-    jerr := NewJiraError(resp, err)
-    return nil, resp, jerr
-  }
+	responseRecord := new(WorklogRecord)
+	resp, err := s.client.Do(req, responseRecord)
+	if err != nil {
+		jerr := NewJiraError(resp, err)
+		return nil, resp, jerr
+	}
 
-  return responseRecord, resp, nil
+	return responseRecord, resp, nil
 }
 
 // AddLink adds a link between two issues.
@@ -949,7 +950,7 @@ func InitIssueWithMetaAndFields(metaProject *MetaProject, metaIssuetype *MetaIss
 	for key, value := range fieldsConfig {
 		jiraKey, found := allFields[key]
 		if !found {
-			return nil, fmt.Errorf("Key %s is not found in the list of fields.", key)
+			return nil, fmt.Errorf("key %s is not found in the list of fields", key)
 		}
 
 		valueType, err := metaIssuetype.Fields.String(jiraKey + "/schema/type")
@@ -1030,9 +1031,9 @@ func (s *IssueService) Delete(issueID string) (*Response, error) {
 //
 // JIRA API docs: https://docs.atlassian.com/software/jira/docs/api/REST/latest/#api/2/issue-getIssueWatchers
 func (s *IssueService) GetWatchers(issueID string) (*[]User, *Response, error) {
-	watchesApiEndPoint := fmt.Sprintf("rest/api/2/issue/%s/watchers", issueID)
+	watchesAPIEndpoint := fmt.Sprintf("rest/api/2/issue/%s/watchers", issueID)
 
-	req, err := s.client.NewRequest("GET", watchesApiEndPoint, nil)
+	req, err := s.client.NewRequest("GET", watchesAPIEndpoint, nil)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -1056,7 +1057,7 @@ func (s *IssueService) GetWatchers(issueID string) (*[]User, *Response, error) {
 	return &result, resp, nil
 }
 
-// SetWatcher adds watcher to the given issue
+// AddWatcher adds watcher to the given issue
 //
 // JIRA API docs: https://docs.atlassian.com/software/jira/docs/api/REST/latest/#api/2/issue-addWatcher
 func (s *IssueService) AddWatcher(issueID string, userName string) (*Response, error) {

--- a/issue_test.go
+++ b/issue_test.go
@@ -112,11 +112,11 @@ func TestIssueService_UpdateIssue(t *testing.T) {
 
 		w.WriteHeader(http.StatusNoContent)
 	})
-	jId := "PROJ-9001"
+	jID := "PROJ-9001"
 	i := make(map[string]interface{})
 	fields := make(map[string]interface{})
 	i["fields"] = fields
-	resp, err := testClient.Issue.UpdateIssue(jId, i)
+	resp, err := testClient.Issue.UpdateIssue(jID, i)
 	if resp == nil {
 		t.Error("Expected resp. resp is nil")
 	}
@@ -182,25 +182,25 @@ func TestIssueService_UpdateComment(t *testing.T) {
 }
 
 func TestIssueService_AddWorklogRecord(t *testing.T) {
-  setup()
-  defer teardown()
-  testMux.HandleFunc("/rest/api/2/issue/10000/worklog", func(w http.ResponseWriter, r *http.Request) {
-    testMethod(t, r, "POST")
-    testRequestURL(t, r, "/rest/api/2/issue/10000/worklog")
+	setup()
+	defer teardown()
+	testMux.HandleFunc("/rest/api/2/issue/10000/worklog", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "POST")
+		testRequestURL(t, r, "/rest/api/2/issue/10000/worklog")
 
-    w.WriteHeader(http.StatusCreated)
-    fmt.Fprint(w, `{"self":"http://www.example.com/jira/rest/api/2/issue/10010/worklog/10000","author":{"self":"http://www.example.com/jira/rest/api/2/user?username=fred","name":"fred","displayName":"Fred F. User","active":false},"updateAuthor":{"self":"http://www.example.com/jira/rest/api/2/user?username=fred","name":"fred","displayName":"Fred F. User","active":false},"comment":"I did some work here.","updated":"2018-02-14T22:14:46.003+0000","visibility":{"type":"group","value":"jira-developers"},"started":"2018-02-14T22:14:46.003+0000","timeSpent":"3h 20m","timeSpentSeconds":12000,"id":"100028","issueId":"10002"}`)
-  })
-  r := &WorklogRecord{
-    TimeSpent: "1h",
-  }
-  record, _, err := testClient.Issue.AddWorklogRecord("10000", r)
-  if record == nil {
-    t.Error("Expected Record. Record is nil")
-  }
-  if err != nil {
-    t.Errorf("Error given: %s", err)
-  }
+		w.WriteHeader(http.StatusCreated)
+		fmt.Fprint(w, `{"self":"http://www.example.com/jira/rest/api/2/issue/10010/worklog/10000","author":{"self":"http://www.example.com/jira/rest/api/2/user?username=fred","name":"fred","displayName":"Fred F. User","active":false},"updateAuthor":{"self":"http://www.example.com/jira/rest/api/2/user?username=fred","name":"fred","displayName":"Fred F. User","active":false},"comment":"I did some work here.","updated":"2018-02-14T22:14:46.003+0000","visibility":{"type":"group","value":"jira-developers"},"started":"2018-02-14T22:14:46.003+0000","timeSpent":"3h 20m","timeSpentSeconds":12000,"id":"100028","issueId":"10002"}`)
+	})
+	r := &WorklogRecord{
+		TimeSpent: "1h",
+	}
+	record, _, err := testClient.Issue.AddWorklogRecord("10000", r)
+	if record == nil {
+		t.Error("Expected Record. Record is nil")
+	}
+	if err != nil {
+		t.Errorf("Error given: %s", err)
+	}
 }
 
 func TestIssueService_AddLink(t *testing.T) {

--- a/metaissue.go
+++ b/metaissue.go
@@ -16,7 +16,7 @@ type CreateMetaInfo struct {
 // MetaProject is the meta information about a project returned from createmeta api
 type MetaProject struct {
 	Expand string `json:"expand,omitempty"`
-	Self   string `json:"self, omitempty"`
+	Self   string `json:"self,omitempty"`
 	Id     string `json:"id,omitempty"`
 	Key    string `json:"key,omitempty"`
 	Name   string `json:"name,omitempty"`

--- a/project.go
+++ b/project.go
@@ -79,7 +79,7 @@ func (s *ProjectService) GetList() (*ProjectList, *Response, error) {
 	return s.ListWithOptions(&GetQueryOptions{})
 }
 
-// GetList gets all projects form JIRA with optional query params, like &GetQueryOptions{Expand: "issueTypes"} to get
+// ListWithOptions gets all projects form JIRA with optional query params, like &GetQueryOptions{Expand: "issueTypes"} to get
 // a list of all projects and their supported issuetypes
 //
 // JIRA API docs: https://docs.atlassian.com/jira/REST/latest/#api/2/project-getAllProjects

--- a/user.go
+++ b/user.go
@@ -99,7 +99,7 @@ func (s *UserService) GetGroups(username string) (*[]UserGroup, *Response, error
 	return userGroups, resp, nil
 }
 
-// Finds user info from JIRA:
+// Find searches for user info from JIRA:
 // It can find users by email, username or name
 //
 // JIRA API docs: https://docs.atlassian.com/jira/REST/cloud/#api/2/user-findUsers


### PR DESCRIPTION
`go vet` enforces Go standards.  There were a couple places where the code didn't comply.  This fixes all of those except about 4 which would break the public API of the library.