### PR TITLE
Let the BoardService.GetAllSprints() return all the sprints.

### DIFF
--- a/board.go
+++ b/board.go
@@ -81,6 +81,9 @@ type Sprint struct {
 func (s *BoardService) GetAllBoards(opt *BoardListOptions) (*BoardsList, *Response, error) {
 	apiEndpoint := "rest/agile/1.0/board"
 	url, err := addOptions(apiEndpoint, opt)
+	if err != nil {
+		return nil, nil, err
+	}
 	req, err := s.client.NewRequest("GET", url, nil)
 	if err != nil {
 		return nil, nil, err


### PR DESCRIPTION
GetAllSprints() method was returning only the last 50 sprints by
default. This is adding a pagination to the
GET /rest/agile/1.0/board/{boardId}/sprint request and is iterating
over the responses until the `isLast` flag indicating that we've
fetched all the sprints is set.