### PR TITLE
Support state filter for GetAllSprints call

### DIFF
--- a/board.go
+++ b/board.go
@@ -2,6 +2,7 @@ package jira
 
 import (
 	"fmt"
+	"strconv"
 	"time"
 )
 
@@ -44,9 +45,21 @@ type BoardListOptions struct {
 	SearchOptions
 }
 
-// Wrapper struct for search result
-type sprintsResult struct {
-	Sprints []Sprint `json:"values" structs:"values"`
+// GetAllSprintsOptions specifies the optional parameters to the BoardService.GetList
+type GetAllSprintsOptions struct {
+	// State filters results to sprints in the specified states, comma-separate list
+	State string `url:"state,omitempty"`
+
+	SearchOptions
+}
+
+// SprintsList reflects a list of agile sprints
+type SprintsList struct {
+	MaxResults int      `json:"maxResults" structs:"maxResults"`
+	StartAt    int      `json:"startAt" structs:"startAt"`
+	Total      int      `json:"total" structs:"total"`
+	IsLast     bool     `json:"isLast" structs:"isLast"`
+	Values     []Sprint `json:"values" structs:"values"`
 }
 
 // Sprint represents a sprint on JIRA agile board
@@ -67,6 +80,9 @@ type Sprint struct {
 func (s *BoardService) GetAllBoards(opt *BoardListOptions) (*BoardsList, *Response, error) {
 	apiEndpoint := "rest/agile/1.0/board"
 	url, err := addOptions(apiEndpoint, opt)
+	if err != nil {
+		return nil, nil, err
+	}
 	req, err := s.client.NewRequest("GET", url, nil)
 	if err != nil {
 		return nil, nil, err
@@ -145,22 +161,44 @@ func (s *BoardService) DeleteBoard(boardID int) (*Board, *Response, error) {
 	return nil, resp, err
 }
 
-// GetAllSprints will returns all sprints from a board, for a given board Id.
+// GetAllSprints will return all sprints from a board, for a given board Id.
 // This only includes sprints that the user has permission to view.
 //
 // JIRA API docs: https://docs.atlassian.com/jira-software/REST/cloud/#agile/1.0/board/{boardId}/sprint
 func (s *BoardService) GetAllSprints(boardID string) ([]Sprint, *Response, error) {
-	apiEndpoint := fmt.Sprintf("rest/agile/1.0/board/%s/sprint", boardID)
-	req, err := s.client.NewRequest("GET", apiEndpoint, nil)
+	id, err := strconv.Atoi(boardID)
 	if err != nil {
 		return nil, nil, err
 	}
 
-	result := new(sprintsResult)
+	result, response, err := s.GetAllSprintsWithOptions(id, &GetAllSprintsOptions{})
+	if err != nil {
+		return nil, nil, err
+	}
+
+	return result.Values, response, nil
+}
+
+// GetAllSprintsWithOptions will return sprints from a board, for a given board Id and filtering options
+// This only includes sprints that the user has permission to view.
+//
+// JIRA API docs: https://docs.atlassian.com/jira-software/REST/cloud/#agile/1.0/board/{boardId}/sprint
+func (s *BoardService) GetAllSprintsWithOptions(boardID int, options *GetAllSprintsOptions) (*SprintsList, *Response, error) {
+	apiEndpoint := fmt.Sprintf("rest/agile/1.0/board/%d/sprint", boardID)
+	url, err := addOptions(apiEndpoint, options)
+	if err != nil {
+		return nil, nil, err
+	}
+	req, err := s.client.NewRequest("GET", url, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	result := new(SprintsList)
 	resp, err := s.client.Do(req, result)
 	if err != nil {
 		err = NewJiraError(resp, err)
 	}
 
-	return result.Sprints, resp, err
+	return result, resp, err
 }

--- a/board_test.go
+++ b/board_test.go
@@ -184,3 +184,35 @@ func TestBoardService_GetAllSprints(t *testing.T) {
 		t.Errorf("Expected 4 transitions. Got %d", len(sprints))
 	}
 }
+
+func TestBoardService_GetAllSprintsWithOptions(t *testing.T) {
+	setup()
+	defer teardown()
+
+	testAPIEndpoint := "/rest/agile/1.0/board/123/sprint"
+
+	raw, err := ioutil.ReadFile("./mocks/sprints_filtered.json")
+	if err != nil {
+		t.Error(err.Error())
+	}
+
+	testMux.HandleFunc(testAPIEndpoint, func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "GET")
+		testRequestURL(t, r, testAPIEndpoint)
+		fmt.Fprint(w, string(raw))
+	})
+
+	sprints, _, err := testClient.Board.GetAllSprintsWithOptions(123, &GetAllSprintsOptions{State: "active,future"})
+
+	if err != nil {
+		t.Errorf("Got error: %v", err)
+	}
+
+	if sprints == nil {
+		t.Error("Expected sprint list. Got nil.")
+	}
+
+	if len(sprints.Values) != 1 {
+		t.Errorf("Expected 1 transition. Got %d", len(sprints.Values))
+	}
+}

--- a/mocks/sprints_filtered.json
+++ b/mocks/sprints_filtered.json
@@ -1,0 +1,16 @@
+{
+    "isLast": true,
+    "maxResults": 50,
+    "startAt": 0,
+    "values": [
+        {
+            "endDate": "2016-06-28T14:24:00.000-07:00",
+            "id": 832,
+            "name": "Iteration-13-2",
+            "originBoardId": 734,
+            "self": "https://jira.com/rest/agile/1.0/sprint/832",
+            "startDate": "2016-06-20T13:24:39.161-07:00",
+            "state": "active"
+        }
+    ]
+}


### PR DESCRIPTION
I'd like to be able to filter the Sprints received from the GetAllSprints call.

* creates a `GetAllSprintsOptions` structure
* adds a new `GetAllSprintsWithOptions` method to accept an `int` boardID and new options structure
* adds filtering functionality to `GetAllSprintsWithOptions` method
* adds `SprintsList` type for handling pagination results data from `GetAllSprints` request
* updates tests