### PR TITLE
Add ComponentService to allow creation of Components

### DIFF
--- a/component.go
+++ b/component.go
@@ -1,0 +1,67 @@
+package jira
+
+import (
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+)
+
+// ComponentService handles components for the JIRA instance / API.
+//
+// JIRA API docs: https://docs.atlassian.com/software/jira/docs/api/REST/7.10.1/#api/2/component
+type ComponentService struct {
+	client *Client
+}
+
+// CreateComponentOptions are passed to the ComponentService.Create function to create a new JIRA component
+type CreateComponentOptions struct {
+	Name         string
+	Description  string
+	LeadUserName string
+	AssigneeType string
+	Lead         *User
+	Assignee     *User
+	Project      string
+	ProjectID    *int
+}
+
+// FullComponent is a JIRA component with all details filled in
+type FullComponent struct {
+	Name                string `json:"name,omitempty" structs:"name,omitempty"`
+	Description         string `json:"description,omitempty" structs:"description,omitempty"`
+	Lead                *User  `json:"lead,omitempty" structs:"lead,omitempty"`
+	Assignee            *User  `json:"assignee,omitempty" structs:"assignee,omitempty"`
+	LeadUserName        string `json:"leadUserName,omitempty" structs:"leadUserName,omitempty"`
+	AssigneeType        string `json:"assigneeType,omitempty" structs:"assigneeType,omitempty"`
+	RealAssigneeType    string `json:"realAssigneeType,omitempty" structs:"realAssigneeType,omitempty"`
+	RealAssignee        *User  `json:"realAssignee,omitempty" structs:"realAssignee,omitempty"`
+	IsAssigneeTypeValid bool   `json:"isAssigneeTypeValid,omitempty" structs:"isAssigneeTypeValid,omitempty"`
+	Project             string `json:"project,omitempty" structs:"project,omitempty"`
+	ProjectID           int    `json:"projectId,omitempty" structs:"projectId,omitempty"`
+}
+
+// Create creates a new JIRA component based on the given options.
+func (s *ComponentService) Create(options *CreateComponentOptions) (*FullComponent, *Response, error) {
+	apiEndpoint := "rest/api/2/component"
+	req, err := s.client.NewRequest("POST", apiEndpoint, options)
+	if err != nil {
+		return nil, nil, err
+	}
+	resp, err := s.client.Do(req, nil)
+	if err != nil {
+		// incase of error return the resp for further inspection
+		return nil, resp, err
+	}
+
+	component := new(FullComponent)
+	defer resp.Body.Close()
+	data, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return nil, resp, fmt.Errorf("Could not read the returned data")
+	}
+	err = json.Unmarshal(data, component)
+	if err != nil {
+		return nil, resp, fmt.Errorf("Could not unmarshall the data into struct")
+	}
+	return component, resp, nil
+}

--- a/component_test.go
+++ b/component_test.go
@@ -1,0 +1,29 @@
+package jira
+
+import (
+	"fmt"
+	"net/http"
+	"testing"
+)
+
+func TestComponentService_Create_Success(t *testing.T) {
+	setup()
+	defer teardown()
+	testMux.HandleFunc("/rest/api/2/component", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "POST")
+		testRequestURL(t, r, "/rest/api/2/component")
+
+		w.WriteHeader(http.StatusCreated)
+		fmt.Fprint(w, `{ "self": "http://www.example.com/jira/rest/api/2/component/10000", "id": "10000", "name": "Component 1", "description": "This is a JIRA component", "lead": { "self": "http://www.example.com/jira/rest/api/2/user?username=fred", "name": "fred", "avatarUrls": { "48x48": "http://www.example.com/jira/secure/useravatar?size=large&ownerId=fred", "24x24": "http://www.example.com/jira/secure/useravatar?size=small&ownerId=fred", "16x16": "http://www.example.com/jira/secure/useravatar?size=xsmall&ownerId=fred", "32x32": "http://www.example.com/jira/secure/useravatar?size=medium&ownerId=fred" }, "displayName": "Fred F. User", "active": false }, "assigneeType": "PROJECT_LEAD", "assignee": { "self": "http://www.example.com/jira/rest/api/2/user?username=fred", "name": "fred", "avatarUrls": { "48x48": "http://www.example.com/jira/secure/useravatar?size=large&ownerId=fred", "24x24": "http://www.example.com/jira/secure/useravatar?size=small&ownerId=fred", "16x16": "http://www.example.com/jira/secure/useravatar?size=xsmall&ownerId=fred", "32x32": "http://www.example.com/jira/secure/useravatar?size=medium&ownerId=fred" }, "displayName": "Fred F. User", "active": false }, "realAssigneeType": "PROJECT_LEAD", "realAssignee": { "self": "http://www.example.com/jira/rest/api/2/user?username=fred", "name": "fred", "avatarUrls": { "48x48": "http://www.example.com/jira/secure/useravatar?size=large&ownerId=fred", "24x24": "http://www.example.com/jira/secure/useravatar?size=small&ownerId=fred", "16x16": "http://www.example.com/jira/secure/useravatar?size=xsmall&ownerId=fred", "32x32": "http://www.example.com/jira/secure/useravatar?size=medium&ownerId=fred" }, "displayName": "Fred F. User", "active": false }, "isAssigneeTypeValid": false, "project": "HSP", "projectId": 10000 }`)
+	})
+
+	component, _, err := testClient.Component.Create(&CreateComponentOptions{
+		Name: "foo-bar",
+	})
+	if component == nil {
+		t.Error("Expected component. Component is nil")
+	}
+	if err != nil {
+		t.Errorf("Error given: %s", err)
+	}
+}

--- a/jira.go
+++ b/jira.go
@@ -37,6 +37,7 @@ type Client struct {
 	Version        *VersionService
 	Priority       *PriorityService
 	Field          *FieldService
+	Component      *ComponentService
 }
 
 // NewClient returns a new JIRA API client.
@@ -75,6 +76,7 @@ func NewClient(httpClient *http.Client, baseURL string) (*Client, error) {
 	c.Version = &VersionService{client: c}
 	c.Priority = &PriorityService{client: c}
 	c.Field = &FieldService{client: c}
+	c.Component = &ComponentService{client: c}
 
 	return c, nil
 }


### PR DESCRIPTION
In my application, I want to programmatically create components. Since this functionality didn't exist in go-jira, I wanted to add it.

I wanted some input on one decision I made - there is already a `Component` type in go-jira used to represent a component that is attached to an issue. Because of this, I created a `FullComponent` type that has all the details of a component added to it already. I thought that was better than creating a backwards-incompatible change by renaming the `Component` type to `IssueComponent` or something like that.