### PR TITLE
Add MarshalJSON method for Time type

### DIFF
--- a/issue.go
+++ b/issue.go
@@ -344,6 +344,12 @@ func (t *Time) UnmarshalJSON(b []byte) error {
 	return nil
 }
 
+// MarshalJSON will transform the time.Time into a JIRA time
+// during the creation of a JIRA request
+func (t Time) MarshalJSON() ([]byte, error) {
+	return []byte(time.Time(t).Format("\"2006-01-02T15:04:05.999-0700\"")), nil
+}
+
 // UnmarshalJSON will transform the JIRA date into a time.Time
 // during the transformation of the JIRA JSON response
 func (t *Date) UnmarshalJSON(b []byte) error {


### PR DESCRIPTION
I noticed the Time type has no `MarshalJSON` method when marshaling objects from this library to JSON for storage and later retrieval using `UnmarshalJSON`. `UnmarshalJSON` failed because the marshaled Time fields contained only `{}`, because the Time type had no `MarshalJSON` method.

Having noticed this, I wondered why the unit tests didn't catch this. I noticed that the current design of the unit tests doesn't verify the JSON that is generated in requests with payload (such as `TestIssueService_Create` or `TestIssueService_Update`). The testMux handler in those methods just checks whether method and URL are correct and then responds with a static response. Maybe it would be interesting to add a check whether the request JSON has the correct format as well. (However, I currently lack the time to implement those tests.)