### PR TITLE
Support for CookieTransportAuth for IssueService and check for empty cookies

### DIFF
--- a/issue.go
+++ b/issue.go
@@ -543,6 +543,26 @@ func (s *IssueService) Get(issueID string, options *GetQueryOptions) (*Issue, *R
 	return issue, resp, nil
 }
 
+// GetSession gets the session if logged in or not via cookies
+// This enables client.NewRequest to work with CookieAuthTransport for Issues
+// Gets an existing cookie session and returns it
+// The caller should check for error incase the session is invalid
+func (s *IssueService) GetSession() (*Response, error) {
+	apiEndpoint := "rest/auth/1/session"
+	req, err := s.client.NewRequest("GET", apiEndpoint, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	resp, err := s.client.Do(req, nil)
+	if err != nil {
+		jerr := NewJiraError(resp, err)
+		return resp, jerr
+	}
+
+	return resp, nil
+}
+
 // DownloadAttachment returns a Response of an attachment for a given attachmentID.
 // The attachment is in the Response.Body of the response.
 // This is an io.ReadCloser.

--- a/issue_test.go
+++ b/issue_test.go
@@ -53,6 +53,25 @@ func TestIssueService_Get_WithQuerySuccess(t *testing.T) {
 	}
 }
 
+func TestIssueService_GetSession_Success(t *testing.T) {
+	setup()
+	defer teardown()
+	testMux.HandleFunc("/rest/auth/1/session", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "GET")
+		testRequestURL(t, r, "/rest/auth/1/session")
+
+		fmt.Fprint(w, `{"self":"https://jira.splunk.com/rest/api/latest/user?username=jirauser","name":"jirauser","loginInfo":{"failedLoginCount":6,"loginCount":559,"lastFailedLoginTime":"2018-07-24T15:48:00.299-0700","previousLoginTime":"2018-09-05T09:31:54.871-0700"}}`)
+	})
+
+	res, err := testClient.Issue.GetSession()
+	if res == nil {
+		t.Error("Expected Session. Session is nil")
+	}
+	if err != nil {
+		t.Errorf("Error given: %s", err)
+	}
+}
+
 func TestIssueService_Create(t *testing.T) {
 	setup()
 	defer teardown()

--- a/jira.go
+++ b/jira.go
@@ -375,7 +375,10 @@ func (t *CookieAuthTransport) RoundTrip(req *http.Request) (*http.Response, erro
 
 	req2 := cloneRequest(req) // per RoundTripper contract
 	for _, cookie := range t.SessionObject {
-		req2.AddCookie(cookie)
+		// Don't add empty cookies to the request
+		if cookie.Value != "" {
+			req2.AddCookie(cookie)
+		}
 	}
 
 	return t.transport().RoundTrip(req2)

--- a/jira_test.go
+++ b/jira_test.go
@@ -544,6 +544,42 @@ func TestCookieAuthTransport_SessionObject_Exists(t *testing.T) {
 	basicAuthClient.Do(req, nil)
 }
 
+// Test that an empty cookie in the transport is not returned in the header
+func TestCookieAuthTransport_SessionObject_ExistsWithEmptyCookie(t *testing.T) {
+	setup()
+	defer teardown()
+
+	emptyCookie := &http.Cookie{Name: "empty_cookie", Value: ""}
+	testCookie := &http.Cookie{Name: "test", Value: "test"}
+
+	testMux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		cookies := r.Cookies()
+
+		if len(cookies) > 1 {
+			t.Errorf("The empty cookie should not have been added")
+		}
+
+		if cookies[0].Name != testCookie.Name {
+			t.Errorf("Cookie names don't match, expected %v, got %v", testCookie.Name, cookies[0].Name)
+		}
+
+		if cookies[0].Value != testCookie.Value {
+			t.Errorf("Cookie values don't match, expected %v, got %v", testCookie.Value, cookies[0].Value)
+		}
+	})
+
+	tp := &CookieAuthTransport{
+		Username:      "username",
+		Password:      "password",
+		AuthURL:       "https://some.jira.com/rest/auth/1/session",
+		SessionObject: []*http.Cookie{emptyCookie, testCookie},
+	}
+
+	basicAuthClient, _ := NewClient(tp.Client(), testServer.URL)
+	req, _ := basicAuthClient.NewRequest("GET", ".", nil)
+	basicAuthClient.Do(req, nil)
+}
+
 // Test that if no cookie is in the transport, it checks for a cookie
 func TestCookieAuthTransport_SessionObject_DoesNotExist(t *testing.T) {
 	setup()


### PR DESCRIPTION
## Context
_Why does this change need to be made?_

The JIRA instance I am working with prefers the use of cookies for Auth, not `BasicAuth` nor `OAuth`.

As part of my application, I needed a way to have check to see if the current session is expired or not for the `IssueService`. If the session is expired I wanted to know so I can fetch a new session.

Another quirk is for whatever reason, my JIRA instance's session has cookies that have empty values. Because of this, when the `CookieAuthTransport` was getting cookies from the session object, it would carry the empty value cookie into the request and subsequent requests would fail due to invalid cookie sessions.

## Objective

_What is this MR trying to do_

* **Adding the `GetSession()` function to `IssueService`**
By adding the `GetSession()` function, it enables users to use a `CookieAuthTransport` for the `IssueService`. This enables the application to see if it needs to fetch a new session once the session expires.

An example of using this for `IssueService`:

```golang
// Create a new authentication via session cookie
tp := jira.CookieAuthTransport{
	Username: "username",
	Password: "password",
	AuthURL:  "https://my.jira.com/rest/auth/1/session",
}

client, err := jira.NewClient(tp.Client(), "https://my.jira.com")
res, err := client.Issue.GetSession()
// If `res != nil && res.Response != nil && res.Response.StatusCode == 200`, this means it was able to get a valid session
// Otherwise, the session is invalid and need to get a new session (code above)

issue, _, err := client.Issue.Get("FOO-1234")
fmt.Printf("JIRA Ticket Assignee: %v", issue.Fields.Assignee.Name)
```

* **Skip empty value cookies**
As mentioned in the context, this change simply checks if the value of the cookie is empty, and does not add it to the request object.


----------------------------

Hmm..

The build for my pull-request failed with:
```
$ go env
$ go get -t ./...
# golang.org/x/sys/unix
../../../golang.org/x/sys/unix/ioctl.go:18: undefined: runtime.KeepAlive
../../../golang.org/x/sys/unix/ioctl.go:28: undefined: runtime.KeepAlive
The command "go get -t ./..." failed and exited with 2 during .
```

Which is failing for `golang 1.4, 1.5, 1.6` for other pull-requests which doesn't seem to be related to my code change, but with the `go get...` in the beginning of the build.