### PR TITLE
Check for empty cookies for CookieAuthTransport

### DIFF
--- a/jira.go
+++ b/jira.go
@@ -375,7 +375,10 @@ func (t *CookieAuthTransport) RoundTrip(req *http.Request) (*http.Response, erro
 
 	req2 := cloneRequest(req) // per RoundTripper contract
 	for _, cookie := range t.SessionObject {
-		req2.AddCookie(cookie)
+		// Don't add an empty value cookie to the request
+		if cookie.Value != "" {
+			req2.AddCookie(cookie)
+		}
 	}
 
 	return t.transport().RoundTrip(req2)

--- a/jira_test.go
+++ b/jira_test.go
@@ -544,6 +544,42 @@ func TestCookieAuthTransport_SessionObject_Exists(t *testing.T) {
 	basicAuthClient.Do(req, nil)
 }
 
+// Test that an empty cookie in the transport is not returned in the header
+func TestCookieAuthTransport_SessionObject_ExistsWithEmptyCookie(t *testing.T) {
+	setup()
+	defer teardown()
+
+	emptyCookie := &http.Cookie{Name: "empty_cookie", Value: ""}
+	testCookie := &http.Cookie{Name: "test", Value: "test"}
+
+	testMux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		cookies := r.Cookies()
+
+		if len(cookies) > 1 {
+			t.Errorf("The empty cookie should not have been added")
+		}
+
+		if cookies[0].Name != testCookie.Name {
+			t.Errorf("Cookie names don't match, expected %v, got %v", testCookie.Name, cookies[0].Name)
+		}
+
+		if cookies[0].Value != testCookie.Value {
+			t.Errorf("Cookie values don't match, expected %v, got %v", testCookie.Value, cookies[0].Value)
+		}
+	})
+
+	tp := &CookieAuthTransport{
+		Username:      "username",
+		Password:      "password",
+		AuthURL:       "https://some.jira.com/rest/auth/1/session",
+		SessionObject: []*http.Cookie{emptyCookie, testCookie},
+	}
+
+	basicAuthClient, _ := NewClient(tp.Client(), testServer.URL)
+	req, _ := basicAuthClient.NewRequest("GET", ".", nil)
+	basicAuthClient.Do(req, nil)
+}
+
 // Test that if no cookie is in the transport, it checks for a cookie
 func TestCookieAuthTransport_SessionObject_DoesNotExist(t *testing.T) {
 	setup()


### PR DESCRIPTION
## Context
_Why does this change need to be made?_

Splitting up change from #166 

The JIRA instance I am working with prefers the use of cookies for Auth, not `BasicAuth` nor `OAuth`.

For whatever reason, my JIRA instance's session has cookies that have empty values. Because of this, when the `CookieAuthTransport` was getting cookies from the session object, it would carry the empty value cookie into the request and subsequent requests would fail due to invalid cookie sessions.

## Objective

_What is this MR trying to do_

* **Skip empty value cookies**
As mentioned in the context, this change simply checks if the value of the cookie is empty, and does not add it to the request object.