### PR TITLE
 Fix of Project.Roles Unmarshal Bug

### DIFF
--- a/project.go
+++ b/project.go
@@ -36,24 +36,22 @@ type ProjectCategory struct {
 
 // Project represents a JIRA Project.
 type Project struct {
-	Expand       string             `json:"expand,omitempty" structs:"expand,omitempty"`
-	Self         string             `json:"self,omitempty" structs:"self,omitempty"`
-	ID           string             `json:"id,omitempty" structs:"id,omitempty"`
-	Key          string             `json:"key,omitempty" structs:"key,omitempty"`
-	Description  string             `json:"description,omitempty" structs:"description,omitempty"`
-	Lead         User               `json:"lead,omitempty" structs:"lead,omitempty"`
-	Components   []ProjectComponent `json:"components,omitempty" structs:"components,omitempty"`
-	IssueTypes   []IssueType        `json:"issueTypes,omitempty" structs:"issueTypes,omitempty"`
-	URL          string             `json:"url,omitempty" structs:"url,omitempty"`
-	Email        string             `json:"email,omitempty" structs:"email,omitempty"`
-	AssigneeType string             `json:"assigneeType,omitempty" structs:"assigneeType,omitempty"`
-	Versions     []Version          `json:"versions,omitempty" structs:"versions,omitempty"`
-	Name         string             `json:"name,omitempty" structs:"name,omitempty"`
-	Roles        struct {
-		Developers string `json:"Developers,omitempty" structs:"Developers,omitempty"`
-	} `json:"roles,omitempty" structs:"roles,omitempty"`
-	AvatarUrls      AvatarUrls      `json:"avatarUrls,omitempty" structs:"avatarUrls,omitempty"`
-	ProjectCategory ProjectCategory `json:"projectCategory,omitempty" structs:"projectCategory,omitempty"`
+	Expand          string             `json:"expand,omitempty" structs:"expand,omitempty"`
+	Self            string             `json:"self,omitempty" structs:"self,omitempty"`
+	ID              string             `json:"id,omitempty" structs:"id,omitempty"`
+	Key             string             `json:"key,omitempty" structs:"key,omitempty"`
+	Description     string             `json:"description,omitempty" structs:"description,omitempty"`
+	Lead            User               `json:"lead,omitempty" structs:"lead,omitempty"`
+	Components      []ProjectComponent `json:"components,omitempty" structs:"components,omitempty"`
+	IssueTypes      []IssueType        `json:"issueTypes,omitempty" structs:"issueTypes,omitempty"`
+	URL             string             `json:"url,omitempty" structs:"url,omitempty"`
+	Email           string             `json:"email,omitempty" structs:"email,omitempty"`
+	AssigneeType    string             `json:"assigneeType,omitempty" structs:"assigneeType,omitempty"`
+	Versions        []Version          `json:"versions,omitempty" structs:"versions,omitempty"`
+	Name            string             `json:"name,omitempty" structs:"name,omitempty"`
+	Roles           map[string]string  `json:"roles,omitempty" structs:"roles,omitempty"`
+	AvatarUrls      AvatarUrls         `json:"avatarUrls,omitempty" structs:"avatarUrls,omitempty"`
+	ProjectCategory ProjectCategory    `json:"projectCategory,omitempty" structs:"projectCategory,omitempty"`
 }
 
 // ProjectComponent represents a single component of a project

--- a/project_test.go
+++ b/project_test.go
@@ -77,6 +77,9 @@ func TestProjectService_Get(t *testing.T) {
 	if err != nil {
 		t.Errorf("Error given: %s", err)
 	}
+	if len(projects.Roles) != 9 {
+		t.Errorf("Expected 9 roles but got %d", len(projects.Roles))
+	}
 }
 
 func TestProjectService_Get_NoProject(t *testing.T) {


### PR DESCRIPTION
Add test case to check for completeness of roles unmarshal.
There should be 9 roles in the test, because of the mock/project.json. There are 9 roles given.
Should i comment this in the test?