### PR TITLE
Manage versions startDate

### DIFF
--- a/version.go
+++ b/version.go
@@ -24,6 +24,7 @@ type Version struct {
 	ReleaseDate     string `json:"releaseDate,omitempty" structs:"releaseDate,omitempty"`
 	UserReleaseDate string `json:"userReleaseDate,omitempty" structs:"userReleaseDate,omitempty"`
 	ProjectID       int    `json:"projectId,omitempty" structs:"projectId,omitempty"` // Unlike other IDs, this is returned as a number
+	StartDate       string `json:"startDate,omitempty" structs:"startDate,omitempty"`
 }
 
 // Get gets version info from JIRA

--- a/version_test.go
+++ b/version_test.go
@@ -23,6 +23,7 @@ func TestVersionService_Get_Success(t *testing.T) {
 			"releaseDate": "2010-07-06",
 			"overdue": true,
 			"userReleaseDate": "6/Jul/2010",
+			"startDate" : "2010-07-01",
 			"projectId": 10000
 		}`)
 	})
@@ -63,6 +64,7 @@ func TestVersionService_Create(t *testing.T) {
 		Released:        true,
 		ReleaseDate:     "2010-07-06",
 		UserReleaseDate: "6/Jul/2010",
+		StartDate:       "2018-07-01",
 	}
 
 	version, _, err := testClient.Version.Create(v)
@@ -87,6 +89,7 @@ func TestServiceService_Update(t *testing.T) {
 			"released": true,
 			"releaseDate": "2010-07-06",
 			"userReleaseDate": "6/Jul/2010",
+			"startDate" : "2010-07-01",
 			"project": "PXA",
 			"projectId": 10000
 		  }`)


### PR DESCRIPTION
It seems the start date is missing on the version interface : https://developer.atlassian.com/cloud/jira/platform/rest/v3/#api-group-Version

The goal of this pr is to declare it. It add the field on the tests but I'm not sure if it's enough.