### PR TITLE
Add support for context package

### DIFF
--- a/authentication.go
+++ b/authentication.go
@@ -1,6 +1,7 @@
 package jira
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
@@ -56,7 +57,7 @@ type Session struct {
 // JIRA API docs: https://docs.atlassian.com/jira/REST/latest/#auth/1/session
 //
 // Deprecated: Use CookieAuthTransport instead
-func (s *AuthenticationService) AcquireSessionCookie(username, password string) (bool, error) {
+func (s *AuthenticationService) AcquireSessionCookie(ctx context.Context, username, password string) (bool, error) {
 	apiEndpoint := "rest/auth/1/session"
 	body := struct {
 		Username string `json:"username"`
@@ -72,7 +73,7 @@ func (s *AuthenticationService) AcquireSessionCookie(username, password string) 
 	}
 
 	session := new(Session)
-	resp, err := s.client.Do(req, session)
+	resp, err := s.client.Do(ctx, req, session)
 
 	if resp != nil {
 		session.Cookies = resp.Cookies()
@@ -119,7 +120,7 @@ func (s *AuthenticationService) Authenticated() bool {
 //
 // Deprecated: Use CookieAuthTransport to create base client.  Logging out is as simple as not using the
 // client anymore
-func (s *AuthenticationService) Logout() error {
+func (s *AuthenticationService) Logout(ctx context.Context) error {
 	if s.authType != authTypeSession || s.client.session == nil {
 		return fmt.Errorf("no user is authenticated")
 	}
@@ -130,7 +131,7 @@ func (s *AuthenticationService) Logout() error {
 		return fmt.Errorf("Creating the request to log the user out failed : %s", err)
 	}
 
-	resp, err := s.client.Do(req, nil)
+	resp, err := s.client.Do(ctx, req, nil)
 	if err != nil {
 		return fmt.Errorf("Error sending the logout request: %s", err)
 	}
@@ -148,7 +149,7 @@ func (s *AuthenticationService) Logout() error {
 // GetCurrentUser gets the details of the current user.
 //
 // JIRA API docs: https://docs.atlassian.com/jira/REST/latest/#auth/1/session
-func (s *AuthenticationService) GetCurrentUser() (*Session, error) {
+func (s *AuthenticationService) GetCurrentUser(ctx context.Context) (*Session, error) {
 	if s == nil {
 		return nil, fmt.Errorf("AUthenticaiton Service is not instantiated")
 	}
@@ -162,7 +163,7 @@ func (s *AuthenticationService) GetCurrentUser() (*Session, error) {
 		return nil, fmt.Errorf("Could not create request for getting user info : %s", err)
 	}
 
-	resp, err := s.client.Do(req, nil)
+	resp, err := s.client.Do(ctx, req, nil)
 	if err != nil {
 		return nil, fmt.Errorf("Error sending request to get user info : %s", err)
 	}

--- a/authentication_test.go
+++ b/authentication_test.go
@@ -2,6 +2,7 @@ package jira
 
 import (
 	"bytes"
+	"context"
 	"fmt"
 	"io/ioutil"
 	"net/http"
@@ -30,7 +31,7 @@ func TestAuthenticationService_AcquireSessionCookie_Failure(t *testing.T) {
 		w.WriteHeader(http.StatusInternalServerError)
 	})
 
-	res, err := testClient.Authentication.AcquireSessionCookie("foo", "bar")
+	res, err := testClient.Authentication.AcquireSessionCookie(context.Background(), "foo", "bar")
 	if err == nil {
 		t.Errorf("Expected error, but no error given")
 	}
@@ -63,7 +64,7 @@ func TestAuthenticationService_AcquireSessionCookie_Success(t *testing.T) {
 		fmt.Fprint(w, `{"session":{"name":"JSESSIONID","value":"12345678901234567890"},"loginInfo":{"failedLoginCount":10,"loginCount":127,"lastFailedLoginTime":"2016-03-16T04:22:35.386+0000","previousLoginTime":"2016-03-16T04:22:35.386+0000"}}`)
 	})
 
-	res, err := testClient.Authentication.AcquireSessionCookie("foo", "bar")
+	res, err := testClient.Authentication.AcquireSessionCookie(context.Background(), "foo", "bar")
 	if err != nil {
 		t.Errorf("No error expected. Got %s", err)
 	}
@@ -162,9 +163,9 @@ func TestAithenticationService_GetUserInfo_AccessForbidden_Fail(t *testing.T) {
 		}
 	})
 
-	testClient.Authentication.AcquireSessionCookie("foo", "bar")
+	testClient.Authentication.AcquireSessionCookie(context.Background(), "foo", "bar")
 
-	_, err := testClient.Authentication.GetCurrentUser()
+	_, err := testClient.Authentication.GetCurrentUser(context.Background())
 	if err == nil {
 		t.Errorf("Non nil error expect, received nil")
 	}
@@ -200,9 +201,9 @@ func TestAuthenticationService_GetUserInfo_NonOkStatusCode_Fail(t *testing.T) {
 		}
 	})
 
-	testClient.Authentication.AcquireSessionCookie("foo", "bar")
+	testClient.Authentication.AcquireSessionCookie(context.Background(), "foo", "bar")
 
-	_, err := testClient.Authentication.GetCurrentUser()
+	_, err := testClient.Authentication.GetCurrentUser(context.Background())
 	if err == nil {
 		t.Errorf("Non nil error expect, received nil")
 	}
@@ -212,7 +213,7 @@ func TestAuthenticationService_GetUserInfo_FailWithoutLogin(t *testing.T) {
 	// no setup() required here
 	testClient = new(Client)
 
-	_, err := testClient.Authentication.GetCurrentUser()
+	_, err := testClient.Authentication.GetCurrentUser(context.Background())
 	if err == nil {
 		t.Errorf("Expected error, but got %s", err)
 	}
@@ -255,9 +256,9 @@ func TestAuthenticationService_GetUserInfo_Success(t *testing.T) {
 		}
 	})
 
-	testClient.Authentication.AcquireSessionCookie("foo", "bar")
+	testClient.Authentication.AcquireSessionCookie(context.Background(), "foo", "bar")
 
-	userinfo, err := testClient.Authentication.GetCurrentUser()
+	userinfo, err := testClient.Authentication.GetCurrentUser(context.Background())
 	if err != nil {
 		t.Errorf("Nil error expect, received %s", err)
 	}
@@ -296,9 +297,9 @@ func TestAuthenticationService_Logout_Success(t *testing.T) {
 		}
 	})
 
-	testClient.Authentication.AcquireSessionCookie("foo", "bar")
+	testClient.Authentication.AcquireSessionCookie(context.Background(), "foo", "bar")
 
-	err := testClient.Authentication.Logout()
+	err := testClient.Authentication.Logout(context.Background())
 	if err != nil {
 		t.Errorf("Expected nil error, got %s", err)
 	}
@@ -314,7 +315,7 @@ func TestAuthenticationService_Logout_FailWithoutLogin(t *testing.T) {
 			w.WriteHeader(http.StatusUnauthorized)
 		}
 	})
-	err := testClient.Authentication.Logout()
+	err := testClient.Authentication.Logout(context.Background())
 	if err == nil {
 		t.Error("Expected not nil, got nil")
 	}

--- a/board.go
+++ b/board.go
@@ -1,6 +1,7 @@
 package jira
 
 import (
+	"context"
 	"fmt"
 	"strconv"
 	"time"
@@ -77,7 +78,7 @@ type Sprint struct {
 // GetAllBoards will returns all boards. This only includes boards that the user has permission to view.
 //
 // JIRA API docs: https://docs.atlassian.com/jira-software/REST/cloud/#agile/1.0/board-getAllBoards
-func (s *BoardService) GetAllBoards(opt *BoardListOptions) (*BoardsList, *Response, error) {
+func (s *BoardService) GetAllBoards(ctx context.Context, opt *BoardListOptions) (*BoardsList, *Response, error) {
 	apiEndpoint := "rest/agile/1.0/board"
 	url, err := addOptions(apiEndpoint, opt)
 	if err != nil {
@@ -89,7 +90,7 @@ func (s *BoardService) GetAllBoards(opt *BoardListOptions) (*BoardsList, *Respon
 	}
 
 	boards := new(BoardsList)
-	resp, err := s.client.Do(req, boards)
+	resp, err := s.client.Do(ctx, req, boards)
 	if err != nil {
 		jerr := NewJiraError(resp, err)
 		return nil, resp, jerr
@@ -102,7 +103,7 @@ func (s *BoardService) GetAllBoards(opt *BoardListOptions) (*BoardsList, *Respon
 // This board will only be returned if the user has permission to view it.
 //
 // JIRA API docs: https://docs.atlassian.com/jira-software/REST/cloud/#agile/1.0/board-getBoard
-func (s *BoardService) GetBoard(boardID int) (*Board, *Response, error) {
+func (s *BoardService) GetBoard(ctx context.Context, boardID int) (*Board, *Response, error) {
 	apiEndpoint := fmt.Sprintf("rest/agile/1.0/board/%v", boardID)
 	req, err := s.client.NewRequest("GET", apiEndpoint, nil)
 	if err != nil {
@@ -110,7 +111,7 @@ func (s *BoardService) GetBoard(boardID int) (*Board, *Response, error) {
 	}
 
 	board := new(Board)
-	resp, err := s.client.Do(req, board)
+	resp, err := s.client.Do(ctx, req, board)
 	if err != nil {
 		jerr := NewJiraError(resp, err)
 		return nil, resp, jerr
@@ -127,7 +128,7 @@ func (s *BoardService) GetBoard(boardID int) (*Board, *Response, error) {
 // board will be created instead (remember that board sharing depends on the filter sharing).
 //
 // JIRA API docs: https://docs.atlassian.com/jira-software/REST/cloud/#agile/1.0/board-createBoard
-func (s *BoardService) CreateBoard(board *Board) (*Board, *Response, error) {
+func (s *BoardService) CreateBoard(ctx context.Context, board *Board) (*Board, *Response, error) {
 	apiEndpoint := "rest/agile/1.0/board"
 	req, err := s.client.NewRequest("POST", apiEndpoint, board)
 	if err != nil {
@@ -135,7 +136,7 @@ func (s *BoardService) CreateBoard(board *Board) (*Board, *Response, error) {
 	}
 
 	responseBoard := new(Board)
-	resp, err := s.client.Do(req, responseBoard)
+	resp, err := s.client.Do(ctx, req, responseBoard)
 	if err != nil {
 		jerr := NewJiraError(resp, err)
 		return nil, resp, jerr
@@ -147,14 +148,14 @@ func (s *BoardService) CreateBoard(board *Board) (*Board, *Response, error) {
 // DeleteBoard will delete an agile board.
 //
 // JIRA API docs: https://docs.atlassian.com/jira-software/REST/cloud/#agile/1.0/board-deleteBoard
-func (s *BoardService) DeleteBoard(boardID int) (*Board, *Response, error) {
+func (s *BoardService) DeleteBoard(ctx context.Context, boardID int) (*Board, *Response, error) {
 	apiEndpoint := fmt.Sprintf("rest/agile/1.0/board/%v", boardID)
 	req, err := s.client.NewRequest("DELETE", apiEndpoint, nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
-	resp, err := s.client.Do(req, nil)
+	resp, err := s.client.Do(ctx, req, nil)
 	if err != nil {
 		err = NewJiraError(resp, err)
 	}
@@ -165,13 +166,13 @@ func (s *BoardService) DeleteBoard(boardID int) (*Board, *Response, error) {
 // This only includes sprints that the user has permission to view.
 //
 // JIRA API docs: https://docs.atlassian.com/jira-software/REST/cloud/#agile/1.0/board/{boardId}/sprint
-func (s *BoardService) GetAllSprints(boardID string) ([]Sprint, *Response, error) {
+func (s *BoardService) GetAllSprints(ctx context.Context, boardID string) ([]Sprint, *Response, error) {
 	id, err := strconv.Atoi(boardID)
 	if err != nil {
 		return nil, nil, err
 	}
 
-	result, response, err := s.GetAllSprintsWithOptions(id, &GetAllSprintsOptions{})
+	result, response, err := s.GetAllSprintsWithOptions(ctx, id, &GetAllSprintsOptions{})
 	if err != nil {
 		return nil, nil, err
 	}
@@ -183,7 +184,7 @@ func (s *BoardService) GetAllSprints(boardID string) ([]Sprint, *Response, error
 // This only includes sprints that the user has permission to view.
 //
 // JIRA API docs: https://docs.atlassian.com/jira-software/REST/cloud/#agile/1.0/board/{boardId}/sprint
-func (s *BoardService) GetAllSprintsWithOptions(boardID int, options *GetAllSprintsOptions) (*SprintsList, *Response, error) {
+func (s *BoardService) GetAllSprintsWithOptions(ctx context.Context, boardID int, options *GetAllSprintsOptions) (*SprintsList, *Response, error) {
 	apiEndpoint := fmt.Sprintf("rest/agile/1.0/board/%d/sprint", boardID)
 	url, err := addOptions(apiEndpoint, options)
 	if err != nil {
@@ -195,7 +196,7 @@ func (s *BoardService) GetAllSprintsWithOptions(boardID int, options *GetAllSpri
 	}
 
 	result := new(SprintsList)
-	resp, err := s.client.Do(req, result)
+	resp, err := s.client.Do(ctx, req, result)
 	if err != nil {
 		err = NewJiraError(resp, err)
 	}

--- a/board_test.go
+++ b/board_test.go
@@ -1,6 +1,7 @@
 package jira
 
 import (
+	"context"
 	"fmt"
 	"io/ioutil"
 	"net/http"
@@ -22,7 +23,7 @@ func TestBoardService_GetAllBoards(t *testing.T) {
 		fmt.Fprint(w, string(raw))
 	})
 
-	projects, _, err := testClient.Board.GetAllBoards(nil)
+	projects, _, err := testClient.Board.GetAllBoards(context.Background(), nil)
 	if projects == nil {
 		t.Error("Expected boards list. Boards list is nil")
 	}
@@ -55,7 +56,7 @@ func TestBoardService_GetAllBoards_WithFilter(t *testing.T) {
 	boardsListOptions.StartAt = 1
 	boardsListOptions.MaxResults = 10
 
-	projects, _, err := testClient.Board.GetAllBoards(boardsListOptions)
+	projects, _, err := testClient.Board.GetAllBoards(context.Background(), boardsListOptions)
 	if projects == nil {
 		t.Error("Expected boards list. Boards list is nil")
 	}
@@ -75,7 +76,7 @@ func TestBoardService_GetBoard(t *testing.T) {
 		fmt.Fprint(w, `{"id":4,"self":"https://test.jira.org/rest/agile/1.0/board/1","name":"Test Weekly","type":"scrum"}`)
 	})
 
-	board, _, err := testClient.Board.GetBoard(1)
+	board, _, err := testClient.Board.GetBoard(context.Background(), 1)
 	if board == nil {
 		t.Error("Expected board list. Board list is nil")
 	}
@@ -95,7 +96,7 @@ func TestBoardService_GetBoard_WrongID(t *testing.T) {
 		fmt.Fprint(w, nil)
 	})
 
-	board, resp, err := testClient.Board.GetBoard(99999999)
+	board, resp, err := testClient.Board.GetBoard(context.Background(), 99999999)
 	if board != nil {
 		t.Errorf("Expected nil. Got %s", err)
 	}
@@ -124,7 +125,7 @@ func TestBoardService_CreateBoard(t *testing.T) {
 		Type:     "kanban",
 		FilterID: 17,
 	}
-	issue, _, err := testClient.Board.CreateBoard(b)
+	issue, _, err := testClient.Board.CreateBoard(context.Background(), b)
 	if issue == nil {
 		t.Error("Expected board. Board is nil")
 	}
@@ -144,7 +145,7 @@ func TestBoardService_DeleteBoard(t *testing.T) {
 		fmt.Fprint(w, `{}`)
 	})
 
-	_, resp, err := testClient.Board.DeleteBoard(1)
+	_, resp, err := testClient.Board.DeleteBoard(context.Background(), 1)
 	if resp.StatusCode != 204 {
 		t.Error("Expected board not deleted.")
 	}
@@ -170,7 +171,7 @@ func TestBoardService_GetAllSprints(t *testing.T) {
 		fmt.Fprint(w, string(raw))
 	})
 
-	sprints, _, err := testClient.Board.GetAllSprints("123")
+	sprints, _, err := testClient.Board.GetAllSprints(context.Background(), "123")
 
 	if err != nil {
 		t.Errorf("Got error: %v", err)
@@ -202,7 +203,7 @@ func TestBoardService_GetAllSprintsWithOptions(t *testing.T) {
 		fmt.Fprint(w, string(raw))
 	})
 
-	sprints, _, err := testClient.Board.GetAllSprintsWithOptions(123, &GetAllSprintsOptions{State: "active,future"})
+	sprints, _, err := testClient.Board.GetAllSprintsWithOptions(context.Background(), 123, &GetAllSprintsOptions{State: "active,future"})
 
 	if err != nil {
 		t.Errorf("Got error: %v", err)

--- a/component.go
+++ b/component.go
@@ -1,5 +1,7 @@
 package jira
 
+import "context"
+
 // ComponentService handles components for the JIRA instance / API.
 //
 // JIRA API docs: https://docs.atlassian.com/software/jira/docs/api/REST/7.10.1/#api/2/component
@@ -20,7 +22,7 @@ type CreateComponentOptions struct {
 }
 
 // Create creates a new JIRA component based on the given options.
-func (s *ComponentService) Create(options *CreateComponentOptions) (*ProjectComponent, *Response, error) {
+func (s *ComponentService) Create(ctx context.Context, options *CreateComponentOptions) (*ProjectComponent, *Response, error) {
 	apiEndpoint := "rest/api/2/component"
 	req, err := s.client.NewRequest("POST", apiEndpoint, options)
 	if err != nil {
@@ -28,7 +30,7 @@ func (s *ComponentService) Create(options *CreateComponentOptions) (*ProjectComp
 	}
 
 	component := new(ProjectComponent)
-	resp, err := s.client.Do(req, component)
+	resp, err := s.client.Do(ctx, req, component)
 
 	if err != nil {
 		return nil, resp, NewJiraError(resp, err)

--- a/component_test.go
+++ b/component_test.go
@@ -1,6 +1,7 @@
 package jira
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 	"testing"
@@ -17,7 +18,7 @@ func TestComponentService_Create_Success(t *testing.T) {
 		fmt.Fprint(w, `{ "self": "http://www.example.com/jira/rest/api/2/component/10000", "id": "10000", "name": "Component 1", "description": "This is a JIRA component", "lead": { "self": "http://www.example.com/jira/rest/api/2/user?username=fred", "name": "fred", "avatarUrls": { "48x48": "http://www.example.com/jira/secure/useravatar?size=large&ownerId=fred", "24x24": "http://www.example.com/jira/secure/useravatar?size=small&ownerId=fred", "16x16": "http://www.example.com/jira/secure/useravatar?size=xsmall&ownerId=fred", "32x32": "http://www.example.com/jira/secure/useravatar?size=medium&ownerId=fred" }, "displayName": "Fred F. User", "active": false }, "assigneeType": "PROJECT_LEAD", "assignee": { "self": "http://www.example.com/jira/rest/api/2/user?username=fred", "name": "fred", "avatarUrls": { "48x48": "http://www.example.com/jira/secure/useravatar?size=large&ownerId=fred", "24x24": "http://www.example.com/jira/secure/useravatar?size=small&ownerId=fred", "16x16": "http://www.example.com/jira/secure/useravatar?size=xsmall&ownerId=fred", "32x32": "http://www.example.com/jira/secure/useravatar?size=medium&ownerId=fred" }, "displayName": "Fred F. User", "active": false }, "realAssigneeType": "PROJECT_LEAD", "realAssignee": { "self": "http://www.example.com/jira/rest/api/2/user?username=fred", "name": "fred", "avatarUrls": { "48x48": "http://www.example.com/jira/secure/useravatar?size=large&ownerId=fred", "24x24": "http://www.example.com/jira/secure/useravatar?size=small&ownerId=fred", "16x16": "http://www.example.com/jira/secure/useravatar?size=xsmall&ownerId=fred", "32x32": "http://www.example.com/jira/secure/useravatar?size=medium&ownerId=fred" }, "displayName": "Fred F. User", "active": false }, "isAssigneeTypeValid": false, "project": "HSP", "projectId": 10000 }`)
 	})
 
-	component, _, err := testClient.Component.Create(&CreateComponentOptions{
+	component, _, err := testClient.Component.Create(context.Background(), &CreateComponentOptions{
 		Name: "foo-bar",
 	})
 	if component == nil {

--- a/error_test.go
+++ b/error_test.go
@@ -1,6 +1,7 @@
 package jira
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"net/http"
@@ -17,7 +18,7 @@ func TestError_NewJiraError(t *testing.T) {
 	})
 
 	req, _ := testClient.NewRequest("GET", "/", nil)
-	resp, _ := testClient.Do(req, nil)
+	resp, _ := testClient.Do(context.Background(), req, nil)
 
 	err := NewJiraError(resp, errors.New("Original http error"))
 	if err, ok := err.(*Error); !ok {
@@ -51,7 +52,7 @@ func TestError_NoJSON(t *testing.T) {
 	})
 
 	req, _ := testClient.NewRequest("GET", "/", nil)
-	resp, _ := testClient.Do(req, nil)
+	resp, _ := testClient.Do(context.Background(), req, nil)
 
 	err := NewJiraError(resp, errors.New("Original http error"))
 	msg := err.Error()

--- a/examples/basicauth/main.go
+++ b/examples/basicauth/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"bufio"
+	"context"
 	"fmt"
 	"os"
 	"strings"
@@ -35,7 +36,8 @@ func main() {
 		return
 	}
 
-	u, _, err := client.User.Get("admin")
+	ctx := context.Background()
+	u, _, err := client.User.Get(ctx, "admin")
 
 	if err != nil {
 		fmt.Printf("\nerror: %v\n", err)

--- a/examples/create/main.go
+++ b/examples/create/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"bufio"
+	"context"
 	"fmt"
 	"os"
 	"strings"
@@ -54,7 +55,7 @@ func main() {
 		},
 	}
 
-	issue, _, err := client.Issue.Create(&i)
+	issue, _, err := client.Issue.Create(context.Background(), &i)
 	if err != nil {
 		panic(err)
 	}

--- a/examples/do/main.go
+++ b/examples/do/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"fmt"
 
 	jira "github.com/andygrunwald/go-jira"
@@ -11,7 +12,7 @@ func main() {
 	req, _ := jiraClient.NewRequest("GET", "/rest/api/2/project", nil)
 
 	projects := new([]jira.Project)
-	_, err := jiraClient.Do(req, projects)
+	_, err := jiraClient.Do(context.Background(), req, projects)
 	if err != nil {
 		panic(err)
 	}

--- a/examples/ignorecerts/main.go
+++ b/examples/ignorecerts/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"crypto/tls"
 	"fmt"
 	"net/http"
@@ -15,7 +16,7 @@ func main() {
 	client := &http.Client{Transport: tr}
 
 	jiraClient, _ := jira.NewClient(client, "https://issues.apache.org/jira/")
-	issue, _, _ := jiraClient.Issue.Get("MESOS-3325", nil)
+	issue, _, _ := jiraClient.Issue.Get(context.Background(), "MESOS-3325", nil)
 
 	fmt.Printf("%s: %+v\n", issue.Key, issue.Fields.Summary)
 	fmt.Printf("Type: %s\n", issue.Fields.Type.Name)

--- a/examples/newclient/main.go
+++ b/examples/newclient/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"fmt"
 
 	jira "github.com/andygrunwald/go-jira"
@@ -8,7 +9,7 @@ import (
 
 func main() {
 	jiraClient, _ := jira.NewClient(nil, "https://issues.apache.org/jira/")
-	issue, _, _ := jiraClient.Issue.Get("MESOS-3325", nil)
+	issue, _, _ := jiraClient.Issue.Get(context.Background(), "MESOS-3325", nil)
 
 	fmt.Printf("%s: %+v\n", issue.Key, issue.Fields.Summary)
 	fmt.Printf("Type: %s\n", issue.Fields.Type.Name)

--- a/examples/renderedfields/main.go
+++ b/examples/renderedfields/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"bufio"
+	"context"
 	"fmt"
 	"net/http"
 	"os"
@@ -51,7 +52,7 @@ func main() {
 	fmt.Printf("Targetting %s for issue %s\n", strings.TrimSpace(jiraURL), key)
 
 	options := &jira.GetQueryOptions{Expand: "renderedFields"}
-	u, _, err := client.Issue.Get(key, options)
+	u, _, err := client.Issue.Get(context.Background(), key, options)
 
 	if err != nil {
 		fmt.Printf("\n==> error: %v\n", err)

--- a/field.go
+++ b/field.go
@@ -1,5 +1,7 @@
 package jira
 
+import "context"
+
 // FieldService handles fields for the JIRA instance / API.
 //
 // JIRA API docs: https://developer.atlassian.com/cloud/jira/platform/rest/#api-Field
@@ -27,7 +29,7 @@ type FieldSchema struct {
 // GetList gets all fields from JIRA
 //
 // JIRA API docs: https://developer.atlassian.com/cloud/jira/platform/rest/#api-api-2-field-get
-func (s *FieldService) GetList() ([]Field, *Response, error) {
+func (s *FieldService) GetList(ctx context.Context) ([]Field, *Response, error) {
 	apiEndpoint := "rest/api/2/field"
 	req, err := s.client.NewRequest("GET", apiEndpoint, nil)
 	if err != nil {
@@ -35,7 +37,7 @@ func (s *FieldService) GetList() ([]Field, *Response, error) {
 	}
 
 	fieldList := []Field{}
-	resp, err := s.client.Do(req, &fieldList)
+	resp, err := s.client.Do(ctx, req, &fieldList)
 	if err != nil {
 		return nil, resp, NewJiraError(resp, err)
 	}

--- a/field_test.go
+++ b/field_test.go
@@ -1,6 +1,7 @@
 package jira
 
 import (
+	"context"
 	"fmt"
 	"io/ioutil"
 	"net/http"
@@ -22,7 +23,7 @@ func TestFieldService_GetList(t *testing.T) {
 		fmt.Fprint(w, string(raw))
 	})
 
-	fields, _, err := testClient.Field.GetList()
+	fields, _, err := testClient.Field.GetList(context.Background())
 	if fields == nil {
 		t.Error("Expected field list. Field list is nil")
 	}

--- a/filter.go
+++ b/filter.go
@@ -1,7 +1,11 @@
 package jira
 
-import "github.com/google/go-querystring/query"
-import "fmt"
+import (
+	"context"
+	"fmt"
+
+	"github.com/google/go-querystring/query"
+)
 
 // FilterService handles fields for the JIRA instance / API.
 //
@@ -33,7 +37,7 @@ type Filter struct {
 }
 
 // GetList retrieves all filters from Jira
-func (fs *FilterService) GetList() ([]*Filter, *Response, error) {
+func (fs *FilterService) GetList(ctx context.Context) ([]*Filter, *Response, error) {
 
 	options := &GetQueryOptions{}
 	apiEndpoint := "rest/api/2/filter"
@@ -51,7 +55,7 @@ func (fs *FilterService) GetList() ([]*Filter, *Response, error) {
 	}
 
 	filters := []*Filter{}
-	resp, err := fs.client.Do(req, &filters)
+	resp, err := fs.client.Do(ctx, req, &filters)
 	if err != nil {
 		jerr := NewJiraError(resp, err)
 		return nil, resp, jerr
@@ -60,14 +64,14 @@ func (fs *FilterService) GetList() ([]*Filter, *Response, error) {
 }
 
 // Get retrieves a single Filter from Jira
-func (fs *FilterService) Get(filterID int) (*Filter, *Response, error) {
+func (fs *FilterService) Get(ctx context.Context, filterID int) (*Filter, *Response, error) {
 	apiEndpoint := fmt.Sprintf("rest/api/2/filter/%d", filterID)
 	req, err := fs.client.NewRequest("GET", apiEndpoint, nil)
 	if err != nil {
 		return nil, nil, err
 	}
 	filter := new(Filter)
-	resp, err := fs.client.Do(req, filter)
+	resp, err := fs.client.Do(ctx, req, filter)
 	if err != nil {
 		jerr := NewJiraError(resp, err)
 		return nil, resp, jerr

--- a/filter_test.go
+++ b/filter_test.go
@@ -1,6 +1,7 @@
 package jira
 
 import (
+	"context"
 	"fmt"
 	"io/ioutil"
 	"net/http"
@@ -21,7 +22,7 @@ func TestFilterService_GetList(t *testing.T) {
 		fmt.Fprint(writer, string(raw))
 	})
 
-	filters, _, err := testClient.Filter.GetList()
+	filters, _, err := testClient.Filter.GetList(context.Background())
 	if filters == nil {
 		t.Error("Expected Filters list. Filters list is nil")
 	}
@@ -44,13 +45,12 @@ func TestFilterService_Get(t *testing.T) {
 		fmt.Fprintf(writer, string(raw))
 	})
 
-	filter, _, err := testClient.Filter.Get(10000)
+	filter, _, err := testClient.Filter.Get(context.Background(), 10000)
 	if filter == nil {
 		t.Errorf("Expected Filter, got nil")
 	}
 	if err != nil {
 		t.Errorf("Error given: %s", err)
 	}
-
 
 }

--- a/group.go
+++ b/group.go
@@ -1,6 +1,7 @@
 package jira
 
 import (
+	"context"
 	"fmt"
 	"net/url"
 )
@@ -63,7 +64,7 @@ type GroupSearchOptions struct {
 // JIRA API docs: https://docs.atlassian.com/jira/REST/server/#api/2/group-getUsersFromGroup
 //
 // WARNING: This API only returns the first page of group members
-func (s *GroupService) Get(name string) ([]GroupMember, *Response, error) {
+func (s *GroupService) Get(ctx context.Context, name string) ([]GroupMember, *Response, error) {
 	apiEndpoint := fmt.Sprintf("/rest/api/2/group/member?groupname=%s", url.QueryEscape(name))
 	req, err := s.client.NewRequest("GET", apiEndpoint, nil)
 	if err != nil {
@@ -71,7 +72,7 @@ func (s *GroupService) Get(name string) ([]GroupMember, *Response, error) {
 	}
 
 	group := new(groupMembersResult)
-	resp, err := s.client.Do(req, group)
+	resp, err := s.client.Do(ctx, req, group)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -84,7 +85,7 @@ func (s *GroupService) Get(name string) ([]GroupMember, *Response, error) {
 // User of this resource is required to have sysadmin or admin permissions.
 //
 // JIRA API docs: https://docs.atlassian.com/jira/REST/server/#api/2/group-getUsersFromGroup
-func (s *GroupService) GetWithOptions(name string, options *GroupSearchOptions) ([]GroupMember, *Response, error) {
+func (s *GroupService) GetWithOptions(ctx context.Context, name string, options *GroupSearchOptions) ([]GroupMember, *Response, error) {
 	var apiEndpoint string
 	if options == nil {
 		apiEndpoint = fmt.Sprintf("/rest/api/2/group/member?groupname=%s", url.QueryEscape(name))
@@ -103,7 +104,7 @@ func (s *GroupService) GetWithOptions(name string, options *GroupSearchOptions) 
 	}
 
 	group := new(groupMembersResult)
-	resp, err := s.client.Do(req, group)
+	resp, err := s.client.Do(ctx, req, group)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -113,7 +114,7 @@ func (s *GroupService) GetWithOptions(name string, options *GroupSearchOptions) 
 // Add adds user to group
 //
 // JIRA API docs: https://docs.atlassian.com/jira/REST/cloud/#api/2/group-addUserToGroup
-func (s *GroupService) Add(groupname string, username string) (*Group, *Response, error) {
+func (s *GroupService) Add(ctx context.Context, groupname string, username string) (*Group, *Response, error) {
 	apiEndpoint := fmt.Sprintf("/rest/api/2/group/user?groupname=%s", groupname)
 	var user struct {
 		Name string `json:"name"`
@@ -125,7 +126,7 @@ func (s *GroupService) Add(groupname string, username string) (*Group, *Response
 	}
 
 	responseGroup := new(Group)
-	resp, err := s.client.Do(req, responseGroup)
+	resp, err := s.client.Do(ctx, req, responseGroup)
 	if err != nil {
 		jerr := NewJiraError(resp, err)
 		return nil, resp, jerr
@@ -137,14 +138,14 @@ func (s *GroupService) Add(groupname string, username string) (*Group, *Response
 // Remove removes user from group
 //
 // JIRA API docs: https://docs.atlassian.com/jira/REST/cloud/#api/2/group-removeUserFromGroup
-func (s *GroupService) Remove(groupname string, username string) (*Response, error) {
+func (s *GroupService) Remove(ctx context.Context, groupname string, username string) (*Response, error) {
 	apiEndpoint := fmt.Sprintf("/rest/api/2/group/user?groupname=%s&username=%s", groupname, username)
 	req, err := s.client.NewRequest("DELETE", apiEndpoint, nil)
 	if err != nil {
 		return nil, err
 	}
 
-	resp, err := s.client.Do(req, nil)
+	resp, err := s.client.Do(ctx, req, nil)
 	if err != nil {
 		jerr := NewJiraError(resp, err)
 		return resp, jerr

--- a/group_test.go
+++ b/group_test.go
@@ -1,6 +1,7 @@
 package jira
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 	"testing"
@@ -14,7 +15,7 @@ func TestGroupService_Get(t *testing.T) {
 		testRequestURL(t, r, "/rest/api/2/group/member?groupname=default")
 		fmt.Fprint(w, `{"self":"http://www.example.com/jira/rest/api/2/group/member?includeInactiveUsers=false&maxResults=50&groupname=default&startAt=0","maxResults":50,"startAt":0,"total":2,"isLast":true,"values":[{"self":"http://www.example.com/jira/rest/api/2/user?username=michael","name":"michael","key":"michael","emailAddress":"michael@example.com","displayName":"MichaelScofield","active":true,"timeZone":"Australia/Sydney"},{"self":"http://www.example.com/jira/rest/api/2/user?username=alex","name":"alex","key":"alex","emailAddress":"alex@example.com","displayName":"AlexanderMahone","active":true,"timeZone":"Australia/Sydney"}]}`)
 	})
-	if members, _, err := testClient.Group.Get("default"); err != nil {
+	if members, _, err := testClient.Group.Get(context.Background(), "default"); err != nil {
 		t.Errorf("Error given: %s", err)
 	} else if members == nil {
 		t.Error("Expected members. Group.Members is nil")
@@ -36,7 +37,7 @@ func TestGroupService_GetPage(t *testing.T) {
 			t.Errorf("startAt %s", startAt)
 		}
 	})
-	if page, resp, err := testClient.Group.GetWithOptions("default", &GroupSearchOptions{
+	if page, resp, err := testClient.Group.GetWithOptions(context.Background(), "default", &GroupSearchOptions{
 		StartAt:              0,
 		MaxResults:           2,
 		IncludeInactiveUsers: false,
@@ -54,7 +55,7 @@ func TestGroupService_GetPage(t *testing.T) {
 		if resp.Total != 4 {
 			t.Errorf("Expect Result Total to be 4, but is %d", resp.Total)
 		}
-		if page, resp, err := testClient.Group.GetWithOptions("default", &GroupSearchOptions{
+		if page, resp, err := testClient.Group.GetWithOptions(context.Background(), "default", &GroupSearchOptions{
 			StartAt:              2,
 			MaxResults:           2,
 			IncludeInactiveUsers: false,
@@ -87,7 +88,7 @@ func TestGroupService_Add(t *testing.T) {
 		fmt.Fprint(w, `{"name":"default","self":"http://www.example.com/jira/rest/api/2/group?groupname=default","users":{"size":1,"items":[],"max-results":50,"start-index":0,"end-index":0},"expand":"users"}`)
 	})
 
-	if group, _, err := testClient.Group.Add("default", "theodore"); err != nil {
+	if group, _, err := testClient.Group.Add(context.Background(), "default", "theodore"); err != nil {
 		t.Errorf("Error given: %s", err)
 	} else if group == nil {
 		t.Error("Expected group. Group is nil")
@@ -105,7 +106,7 @@ func TestGroupService_Remove(t *testing.T) {
 		fmt.Fprint(w, `{"name":"default","self":"http://www.example.com/jira/rest/api/2/group?groupname=default","users":{"size":1,"items":[],"max-results":50,"start-index":0,"end-index":0},"expand":"users"}`)
 	})
 
-	if _, err := testClient.Group.Remove("default", "theodore"); err != nil {
+	if _, err := testClient.Group.Remove(context.Background(), "default", "theodore"); err != nil {
 		t.Errorf("Error given: %s", err)
 	}
 }

--- a/issue_test.go
+++ b/issue_test.go
@@ -1,6 +1,7 @@
 package jira
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -25,7 +26,7 @@ func TestIssueService_Get_Success(t *testing.T) {
 		fmt.Fprint(w, `{"expand":"renderedFields,names,schema,transitions,operations,editmeta,changelog,versionedRepresentations","id":"10002","self":"http://www.example.com/jira/rest/api/2/issue/10002","key":"EX-1","fields":{"watcher":{"self":"http://www.example.com/jira/rest/api/2/issue/EX-1/watchers","isWatching":false,"watchCount":1,"watchers":[{"self":"http://www.example.com/jira/rest/api/2/user?username=fred","name":"fred","displayName":"Fred F. User","active":false}]},"attachment":[{"self":"http://www.example.com/jira/rest/api/2.0/attachments/10000","filename":"picture.jpg","author":{"self":"http://www.example.com/jira/rest/api/2/user?username=fred","name":"fred","avatarUrls":{"48x48":"http://www.example.com/jira/secure/useravatar?size=large&ownerId=fred","24x24":"http://www.example.com/jira/secure/useravatar?size=small&ownerId=fred","16x16":"http://www.example.com/jira/secure/useravatar?size=xsmall&ownerId=fred","32x32":"http://www.example.com/jira/secure/useravatar?size=medium&ownerId=fred"},"displayName":"Fred F. User","active":false},"created":"2016-03-16T04:22:37.461+0000","size":23123,"mimeType":"image/jpeg","content":"http://www.example.com/jira/attachments/10000","thumbnail":"http://www.example.com/jira/secure/thumbnail/10000"}],"sub-tasks":[{"id":"10000","type":{"id":"10000","name":"","inward":"Parent","outward":"Sub-task"},"outwardIssue":{"id":"10003","key":"EX-2","self":"http://www.example.com/jira/rest/api/2/issue/EX-2","fields":{"status":{"iconUrl":"http://www.example.com/jira//images/icons/statuses/open.png","name":"Open"}}}}],"description":"example bug report","project":{"self":"http://www.example.com/jira/rest/api/2/project/EX","id":"10000","key":"EX","name":"Example","avatarUrls":{"48x48":"http://www.example.com/jira/secure/projectavatar?size=large&pid=10000","24x24":"http://www.example.com/jira/secure/projectavatar?size=small&pid=10000","16x16":"http://www.example.com/jira/secure/projectavatar?size=xsmall&pid=10000","32x32":"http://www.example.com/jira/secure/projectavatar?size=medium&pid=10000"},"projectCategory":{"self":"http://www.example.com/jira/rest/api/2/projectCategory/10000","id":"10000","name":"FIRST","description":"First Project Category"}},"comment":{"comments":[{"self":"http://www.example.com/jira/rest/api/2/issue/10010/comment/10000","id":"10000","author":{"self":"http://www.example.com/jira/rest/api/2/user?username=fred","name":"fred","displayName":"Fred F. User","active":false},"body":"Lorem ipsum dolor sit amet, consectetur adipiscing elit. Pellentesque eget venenatis elit. Duis eu justo eget augue iaculis fermentum. Sed semper quam laoreet nisi egestas at posuere augue semper.","updateAuthor":{"self":"http://www.example.com/jira/rest/api/2/user?username=fred","name":"fred","displayName":"Fred F. User","active":false},"created":"2016-03-16T04:22:37.356+0000","updated":"2016-03-16T04:22:37.356+0000","visibility":{"type":"role","value":"Administrators"}}]},"issuelinks":[{"id":"10001","type":{"id":"10000","name":"Dependent","inward":"depends on","outward":"is depended by"},"outwardIssue":{"id":"10004L","key":"PRJ-2","self":"http://www.example.com/jira/rest/api/2/issue/PRJ-2","fields":{"status":{"iconUrl":"http://www.example.com/jira//images/icons/statuses/open.png","name":"Open"}}}},{"id":"10002","type":{"id":"10000","name":"Dependent","inward":"depends on","outward":"is depended by"},"inwardIssue":{"id":"10004","key":"PRJ-3","self":"http://www.example.com/jira/rest/api/2/issue/PRJ-3","fields":{"status":{"iconUrl":"http://www.example.com/jira//images/icons/statuses/open.png","name":"Open"}}}}],"worklog":{"worklogs":[{"self":"http://www.example.com/jira/rest/api/2/issue/10010/worklog/10000","author":{"self":"http://www.example.com/jira/rest/api/2/user?username=fred","name":"fred","displayName":"Fred F. User","active":false},"updateAuthor":{"self":"http://www.example.com/jira/rest/api/2/user?username=fred","name":"fred","displayName":"Fred F. User","active":false},"comment":"I did some work here.","updated":"2016-03-16T04:22:37.471+0000","visibility":{"type":"group","value":"jira-developers"},"started":"2016-03-16T04:22:37.471+0000","timeSpent":"3h 20m","timeSpentSeconds":12000,"id":"100028","issueId":"10002"}]},"updated":"2016-04-06T02:36:53.594-0700","duedate":"2018-01-19","timetracking":{"originalEstimate":"10m","remainingEstimate":"3m","timeSpent":"6m","originalEstimateSeconds":600,"remainingEstimateSeconds":200,"timeSpentSeconds":400}},"names":{"watcher":"watcher","attachment":"attachment","sub-tasks":"sub-tasks","description":"description","project":"project","comment":"comment","issuelinks":"issuelinks","worklog":"worklog","updated":"updated","timetracking":"timetracking"},"schema":{}}`)
 	})
 
-	issue, _, err := testClient.Issue.Get("10002", nil)
+	issue, _, err := testClient.Issue.Get(context.Background(), "10002", nil)
 	if issue == nil {
 		t.Error("Expected issue. Issue is nil")
 	}
@@ -47,7 +48,7 @@ func TestIssueService_Get_WithQuerySuccess(t *testing.T) {
 	opt := &GetQueryOptions{
 		Expand: "foo",
 	}
-	issue, _, err := testClient.Issue.Get("10002", opt)
+	issue, _, err := testClient.Issue.Get(context.Background(), "10002", opt)
 	if issue == nil {
 		t.Error("Expected issue. Issue is nil")
 	}
@@ -72,7 +73,7 @@ func TestIssueService_Create(t *testing.T) {
 			Description: "example bug report",
 		},
 	}
-	issue, _, err := testClient.Issue.Create(i)
+	issue, _, err := testClient.Issue.Create(context.Background(), i)
 	if issue == nil {
 		t.Error("Expected issue. Issue is nil")
 	}
@@ -98,7 +99,7 @@ func TestIssueService_CreateThenGet(t *testing.T) {
 			Created:     Time(time.Now()),
 		},
 	}
-	issue, _, err := testClient.Issue.Create(i)
+	issue, _, err := testClient.Issue.Create(context.Background(), i)
 	if issue == nil {
 		t.Error("Expected issue. Issue is nil")
 	}
@@ -120,7 +121,7 @@ func TestIssueService_CreateThenGet(t *testing.T) {
 		}
 	})
 
-	issue2, _, err := testClient.Issue.Get("10002", nil)
+	issue2, _, err := testClient.Issue.Get(context.Background(), "10002", nil)
 	if issue2 == nil {
 		t.Error("Expected issue. Issue is nil")
 	}
@@ -145,7 +146,7 @@ func TestIssueService_Update(t *testing.T) {
 			Description: "example bug report",
 		},
 	}
-	issue, _, err := testClient.Issue.Update(i)
+	issue, _, err := testClient.Issue.Update(context.Background(), i)
 	if issue == nil {
 		t.Error("Expected issue. Issue is nil")
 	}
@@ -167,7 +168,7 @@ func TestIssueService_UpdateIssue(t *testing.T) {
 	i := make(map[string]interface{})
 	fields := make(map[string]interface{})
 	i["fields"] = fields
-	resp, err := testClient.Issue.UpdateIssue(jID, i)
+	resp, err := testClient.Issue.UpdateIssue(context.Background(), jID, i)
 	if resp == nil {
 		t.Error("Expected resp. resp is nil")
 	}
@@ -195,7 +196,7 @@ func TestIssueService_AddComment(t *testing.T) {
 			Value: "Administrators",
 		},
 	}
-	comment, _, err := testClient.Issue.AddComment("10000", c)
+	comment, _, err := testClient.Issue.AddComment(context.Background(), "10000", c)
 	if comment == nil {
 		t.Error("Expected Comment. Comment is nil")
 	}
@@ -223,7 +224,7 @@ func TestIssueService_UpdateComment(t *testing.T) {
 			Value: "Administrators",
 		},
 	}
-	comment, _, err := testClient.Issue.UpdateComment("10000", c)
+	comment, _, err := testClient.Issue.UpdateComment(context.Background(), "10000", c)
 	if comment == nil {
 		t.Error("Expected Comment. Comment is nil")
 	}
@@ -243,7 +244,7 @@ func TestIssueService_DeleteComment(t *testing.T) {
 		fmt.Fprint(w, `{}`)
 	})
 
-	err := testClient.Issue.DeleteComment("10000", "10001")
+	err := testClient.Issue.DeleteComment(context.Background(), "10000", "10001")
 	if err != nil {
 		t.Errorf("Error given: %s", err)
 	}
@@ -262,7 +263,7 @@ func TestIssueService_AddWorklogRecord(t *testing.T) {
 	r := &WorklogRecord{
 		TimeSpent: "1h",
 	}
-	record, _, err := testClient.Issue.AddWorklogRecord("10000", r)
+	record, _, err := testClient.Issue.AddWorklogRecord(context.Background(), "10000", r)
 	if record == nil {
 		t.Error("Expected Record. Record is nil")
 	}
@@ -299,7 +300,7 @@ func TestIssueService_AddLink(t *testing.T) {
 			},
 		},
 	}
-	resp, err := testClient.Issue.AddLink(il)
+	resp, err := testClient.Issue.AddLink(context.Background(), il)
 	if resp == nil {
 		t.Error("Expected response. Response is nil")
 	}
@@ -321,7 +322,7 @@ func TestIssueService_Get_Fields(t *testing.T) {
 		fmt.Fprint(w, `{"expand":"renderedFields,names,schema,transitions,operations,editmeta,changelog,versionedRepresentations","id":"10002","self":"http://www.example.com/jira/rest/api/2/issue/10002","key":"EX-1","fields":{"labels":["test"],"watcher":{"self":"http://www.example.com/jira/rest/api/2/issue/EX-1/watchers","isWatching":false,"watchCount":1,"watchers":[{"self":"http://www.example.com/jira/rest/api/2/user?username=fred","name":"fred","displayName":"Fred F. User","active":false}]},"epic": {"id": 19415,"key": "EPIC-77","self": "https://example.atlassian.net/rest/agile/1.0/epic/19415","name": "Epic Name","summary": "Do it","color": {"key": "color_11"},"done": false},"attachment":[{"self":"http://www.example.com/jira/rest/api/2.0/attachments/10000","filename":"picture.jpg","author":{"self":"http://www.example.com/jira/rest/api/2/user?username=fred","name":"fred","avatarUrls":{"48x48":"http://www.example.com/jira/secure/useravatar?size=large&ownerId=fred","24x24":"http://www.example.com/jira/secure/useravatar?size=small&ownerId=fred","16x16":"http://www.example.com/jira/secure/useravatar?size=xsmall&ownerId=fred","32x32":"http://www.example.com/jira/secure/useravatar?size=medium&ownerId=fred"},"displayName":"Fred F. User","active":false},"created":"2016-03-16T04:22:37.461+0000","size":23123,"mimeType":"image/jpeg","content":"http://www.example.com/jira/attachments/10000","thumbnail":"http://www.example.com/jira/secure/thumbnail/10000"}],"sub-tasks":[{"id":"10000","type":{"id":"10000","name":"","inward":"Parent","outward":"Sub-task"},"outwardIssue":{"id":"10003","key":"EX-2","self":"http://www.example.com/jira/rest/api/2/issue/EX-2","fields":{"status":{"iconUrl":"http://www.example.com/jira//images/icons/statuses/open.png","name":"Open"}}}}],"description":"example bug report","project":{"self":"http://www.example.com/jira/rest/api/2/project/EX","id":"10000","key":"EX","name":"Example","avatarUrls":{"48x48":"http://www.example.com/jira/secure/projectavatar?size=large&pid=10000","24x24":"http://www.example.com/jira/secure/projectavatar?size=small&pid=10000","16x16":"http://www.example.com/jira/secure/projectavatar?size=xsmall&pid=10000","32x32":"http://www.example.com/jira/secure/projectavatar?size=medium&pid=10000"},"projectCategory":{"self":"http://www.example.com/jira/rest/api/2/projectCategory/10000","id":"10000","name":"FIRST","description":"First Project Category"}},"comment":{"comments":[{"self":"http://www.example.com/jira/rest/api/2/issue/10010/comment/10000","id":"10000","author":{"self":"http://www.example.com/jira/rest/api/2/user?username=fred","name":"fred","displayName":"Fred F. User","active":false},"body":"Lorem ipsum dolor sit amet, consectetur adipiscing elit. Pellentesque eget venenatis elit. Duis eu justo eget augue iaculis fermentum. Sed semper quam laoreet nisi egestas at posuere augue semper.","updateAuthor":{"self":"http://www.example.com/jira/rest/api/2/user?username=fred","name":"fred","displayName":"Fred F. User","active":false},"created":"2016-03-16T04:22:37.356+0000","updated":"2016-03-16T04:22:37.356+0000","visibility":{"type":"role","value":"Administrators"}}]},"issuelinks":[{"id":"10001","type":{"id":"10000","name":"Dependent","inward":"depends on","outward":"is depended by"},"outwardIssue":{"id":"10004L","key":"PRJ-2","self":"http://www.example.com/jira/rest/api/2/issue/PRJ-2","fields":{"status":{"iconUrl":"http://www.example.com/jira//images/icons/statuses/open.png","name":"Open"}}}},{"id":"10002","type":{"id":"10000","name":"Dependent","inward":"depends on","outward":"is depended by"},"inwardIssue":{"id":"10004","key":"PRJ-3","self":"http://www.example.com/jira/rest/api/2/issue/PRJ-3","fields":{"status":{"iconUrl":"http://www.example.com/jira//images/icons/statuses/open.png","name":"Open"}}}}],"worklog":{"worklogs":[{"self":"http://www.example.com/jira/rest/api/2/issue/10010/worklog/10000","author":{"self":"http://www.example.com/jira/rest/api/2/user?username=fred","name":"fred","displayName":"Fred F. User","active":false},"updateAuthor":{"self":"http://www.example.com/jira/rest/api/2/user?username=fred","name":"fred","displayName":"Fred F. User","active":false},"comment":"I did some work here.","updated":"2016-03-16T04:22:37.471+0000","visibility":{"type":"group","value":"jira-developers"},"started":"2016-03-16T04:22:37.471+0000","timeSpent":"3h 20m","timeSpentSeconds":12000,"id":"100028","issueId":"10002"}]},"updated":"2016-04-06T02:36:53.594-0700","duedate":"2018-01-19","timetracking":{"originalEstimate":"10m","remainingEstimate":"3m","timeSpent":"6m","originalEstimateSeconds":600,"remainingEstimateSeconds":200,"timeSpentSeconds":400}},"names":{"watcher":"watcher","attachment":"attachment","sub-tasks":"sub-tasks","description":"description","project":"project","comment":"comment","issuelinks":"issuelinks","worklog":"worklog","updated":"updated","timetracking":"timetracking"},"schema":{}}`)
 	})
 
-	issue, _, err := testClient.Issue.Get("10002", nil)
+	issue, _, err := testClient.Issue.Get(context.Background(), "10002", nil)
 	if issue == nil {
 		t.Error("Expected issue. Issue is nil")
 	}
@@ -351,7 +352,7 @@ func TestIssueService_Get_RenderedFields(t *testing.T) {
 		fmt.Fprint(w, `{"expand":"renderedFields,names,schema,transitions,operations,editmeta,changelog,versionedRepresentations","id":"10002","self":"http://www.example.com/jira/rest/api/2/issue/10002","key":"EX-1","fields":{"labels":["test"],"watcher":{"self":"http://www.example.com/jira/rest/api/2/issue/EX-1/watchers","isWatching":false,"watchCount":1,"watchers":[{"self":"http://www.example.com/jira/rest/api/2/user?username=fred","name":"fred","displayName":"Fred F. User","active":false}]},"epic": {"id": 19415,"key": "EPIC-77","self": "https://example.atlassian.net/rest/agile/1.0/epic/19415","name": "Epic Name","summary": "Do it","color": {"key": "color_11"},"done": false},"attachment":[{"self":"http://www.example.com/jira/rest/api/2.0/attachments/10000","filename":"picture.jpg","author":{"self":"http://www.example.com/jira/rest/api/2/user?username=fred","name":"fred","avatarUrls":{"48x48":"http://www.example.com/jira/secure/useravatar?size=large&ownerId=fred","24x24":"http://www.example.com/jira/secure/useravatar?size=small&ownerId=fred","16x16":"http://www.example.com/jira/secure/useravatar?size=xsmall&ownerId=fred","32x32":"http://www.example.com/jira/secure/useravatar?size=medium&ownerId=fred"},"displayName":"Fred F. User","active":false},"created":"2016-03-16T04:22:37.461+0000","size":23123,"mimeType":"image/jpeg","content":"http://www.example.com/jira/attachments/10000","thumbnail":"http://www.example.com/jira/secure/thumbnail/10000"}],"sub-tasks":[{"id":"10000","type":{"id":"10000","name":"","inward":"Parent","outward":"Sub-task"},"outwardIssue":{"id":"10003","key":"EX-2","self":"http://www.example.com/jira/rest/api/2/issue/EX-2","fields":{"status":{"iconUrl":"http://www.example.com/jira//images/icons/statuses/open.png","name":"Open"}}}}],"description":"example bug report","project":{"self":"http://www.example.com/jira/rest/api/2/project/EX","id":"10000","key":"EX","name":"Example","avatarUrls":{"48x48":"http://www.example.com/jira/secure/projectavatar?size=large&pid=10000","24x24":"http://www.example.com/jira/secure/projectavatar?size=small&pid=10000","16x16":"http://www.example.com/jira/secure/projectavatar?size=xsmall&pid=10000","32x32":"http://www.example.com/jira/secure/projectavatar?size=medium&pid=10000"},"projectCategory":{"self":"http://www.example.com/jira/rest/api/2/projectCategory/10000","id":"10000","name":"FIRST","description":"First Project Category"}},"comment":{"comments":[{"self":"http://www.example.com/jira/rest/api/2/issue/10010/comment/10000","id":"10000","author":{"self":"http://www.example.com/jira/rest/api/2/user?username=fred","name":"fred","displayName":"Fred F. User","active":false},"body":"Lorem ipsum dolor sit amet, consectetur adipiscing elit. Pellentesque eget venenatis elit. Duis eu justo eget augue iaculis fermentum. Sed semper quam laoreet nisi egestas at posuere augue semper.","updateAuthor":{"self":"http://www.example.com/jira/rest/api/2/user?username=fred","name":"fred","displayName":"Fred F. User","active":false},"created":"2016-03-16T04:22:37.356+0000","updated":"2016-03-16T04:22:37.356+0000","visibility":{"type":"role","value":"Administrators"}}]},"issuelinks":[{"id":"10001","type":{"id":"10000","name":"Dependent","inward":"depends on","outward":"is depended by"},"outwardIssue":{"id":"10004L","key":"PRJ-2","self":"http://www.example.com/jira/rest/api/2/issue/PRJ-2","fields":{"status":{"iconUrl":"http://www.example.com/jira//images/icons/statuses/open.png","name":"Open"}}}},{"id":"10002","type":{"id":"10000","name":"Dependent","inward":"depends on","outward":"is depended by"},"inwardIssue":{"id":"10004","key":"PRJ-3","self":"http://www.example.com/jira/rest/api/2/issue/PRJ-3","fields":{"status":{"iconUrl":"http://www.example.com/jira//images/icons/statuses/open.png","name":"Open"}}}}],"worklog":{"worklogs":[{"self":"http://www.example.com/jira/rest/api/2/issue/10010/worklog/10000","author":{"self":"http://www.example.com/jira/rest/api/2/user?username=fred","name":"fred","displayName":"Fred F. User","active":false},"updateAuthor":{"self":"http://www.example.com/jira/rest/api/2/user?username=fred","name":"fred","displayName":"Fred F. User","active":false},"comment":"I did some work here.","updated":"2016-03-16T04:22:37.471+0000","visibility":{"type":"group","value":"jira-developers"},"started":"2016-03-16T04:22:37.471+0000","timeSpent":"3h 20m","timeSpentSeconds":12000,"id":"100028","issueId":"10002"}]},"updated":"2016-04-06T02:36:53.594-0700","duedate":"2018-01-19","timetracking":{"originalEstimate":"10m","remainingEstimate":"3m","timeSpent":"6m","originalEstimateSeconds":600,"remainingEstimateSeconds":200,"timeSpentSeconds":400}},"names":{"watcher":"watcher","attachment":"attachment","sub-tasks":"sub-tasks","description":"description","project":"project","comment":"comment","issuelinks":"issuelinks","worklog":"worklog","updated":"updated","timetracking":"timetracking"},"schema":{},"renderedFields":{"resolutiondate":"In 1 week","updated":"2 hours ago","comment":{"comments":[{"body":"This <strong>is</strong> HTML"}]}}}`)
 	})
 
-	issue, _, err := testClient.Issue.Get("10002", nil)
+	issue, _, err := testClient.Issue.Get(context.Background(), "10002", nil)
 	if issue == nil {
 		t.Error("Expected issue. Issue is nil")
 	}
@@ -385,7 +386,7 @@ func TestIssueService_DownloadAttachment(t *testing.T) {
 		w.Write([]byte(testAttachment))
 	})
 
-	resp, err := testClient.Issue.DownloadAttachment("10000")
+	resp, err := testClient.Issue.DownloadAttachment(context.Background(), "10000")
 	if resp == nil {
 		t.Error("Expected response. Response is nil")
 	}
@@ -418,7 +419,7 @@ func TestIssueService_DownloadAttachment_BadStatus(t *testing.T) {
 		w.WriteHeader(http.StatusForbidden)
 	})
 
-	resp, err := testClient.Issue.DownloadAttachment("10000")
+	resp, err := testClient.Issue.DownloadAttachment(context.Background(), "10000")
 	if resp == nil {
 		t.Error("Expected response. Response is nil")
 	}
@@ -467,7 +468,7 @@ func TestIssueService_PostAttachment(t *testing.T) {
 
 	reader := strings.NewReader(testAttachment)
 
-	issue, resp, err := testClient.Issue.PostAttachment("10000", reader, "attachment")
+	issue, resp, err := testClient.Issue.PostAttachment(context.Background(), "10000", reader, "attachment")
 
 	if issue == nil {
 		t.Error("Expected response. Response is nil")
@@ -494,7 +495,7 @@ func TestIssueService_PostAttachment_NoResponse(t *testing.T) {
 	})
 	reader := strings.NewReader(testAttachment)
 
-	_, _, err := testClient.Issue.PostAttachment("10000", reader, "attachment")
+	_, _, err := testClient.Issue.PostAttachment(context.Background(), "10000", reader, "attachment")
 
 	if err == nil {
 		t.Errorf("Error expected: %s", err)
@@ -514,7 +515,7 @@ func TestIssueService_PostAttachment_NoFilename(t *testing.T) {
 	})
 	reader := strings.NewReader(testAttachment)
 
-	_, _, err := testClient.Issue.PostAttachment("10000", reader, "")
+	_, _, err := testClient.Issue.PostAttachment(context.Background(), "10000", reader, "")
 
 	if err != nil {
 		t.Errorf("Error expected: %s", err)
@@ -531,7 +532,7 @@ func TestIssueService_PostAttachment_NoAttachment(t *testing.T) {
 		fmt.Fprint(w, `[{"self":"http://jira/jira/rest/api/2/attachment/228924","id":"228924","filename":"example.jpg","author":{"self":"http://jira/jira/rest/api/2/user?username=test","name":"test","emailAddress":"test@test.com","avatarUrls":{"16x16":"http://jira/jira/secure/useravatar?size=small&avatarId=10082","48x48":"http://jira/jira/secure/useravatar?avatarId=10082"},"displayName":"Tester","active":true},"created":"2016-05-24T00:25:17.000-0700","size":32280,"mimeType":"image/jpeg","content":"http://jira/jira/secure/attachment/228924/example.jpg","thumbnail":"http://jira/jira/secure/thumbnail/228924/_thumb_228924.png"}]`)
 	})
 
-	_, _, err := testClient.Issue.PostAttachment("10000", nil, "attachment")
+	_, _, err := testClient.Issue.PostAttachment(context.Background(), "10000", nil, "attachment")
 
 	if err != nil {
 		t.Errorf("Error given: %s", err)
@@ -549,7 +550,7 @@ func TestIssueService_Search(t *testing.T) {
 	})
 
 	opt := &SearchOptions{StartAt: 1, MaxResults: 40, Expand: "foo"}
-	_, resp, err := testClient.Issue.Search("something", opt)
+	_, resp, err := testClient.Issue.Search(context.Background(), "something", opt)
 
 	if resp == nil {
 		t.Errorf("Response given: %+v", resp)
@@ -579,7 +580,7 @@ func TestIssueService_Search_WithoutPaging(t *testing.T) {
 		fmt.Fprint(w, `{"expand": "schema,names","startAt": 0,"maxResults": 50,"total": 6,"issues": [{"expand": "html","id": "10230","self": "http://kelpie9:8081/rest/api/2/issue/BULK-62","key": "BULK-62","fields": {"summary": "testing","timetracking": null,"issuetype": {"self": "http://kelpie9:8081/rest/api/2/issuetype/5","id": "5","description": "The sub-task of the issue","iconUrl": "http://kelpie9:8081/images/icons/issue_subtask.gif","name": "Sub-task","subtask": true},"customfield_10071": null}},{"expand": "html","id": "10004","self": "http://kelpie9:8081/rest/api/2/issue/BULK-47","key": "BULK-47","fields": {"summary": "Cheese v1 2.0 issue","timetracking": null,"issuetype": {"self": "http://kelpie9:8081/rest/api/2/issuetype/3","id": "3","description": "A task that needs to be done.","iconUrl": "http://kelpie9:8081/images/icons/task.gif","name": "Task","subtask": false}}}]}`)
 	})
 
-	_, resp, err := testClient.Issue.Search("something", nil)
+	_, resp, err := testClient.Issue.Search(context.Background(), "something", nil)
 
 	if resp == nil {
 		t.Errorf("Response given: %+v", resp)
@@ -623,7 +624,7 @@ func TestIssueService_SearchPages(t *testing.T) {
 
 	opt := &SearchOptions{StartAt: 1, MaxResults: 2, Expand: "foo", ValidateQuery: "warn"}
 	issues := make([]Issue, 0)
-	err := testClient.Issue.SearchPages("something", opt, func(issue Issue) error {
+	err := testClient.Issue.SearchPages(context.Background(), "something", opt, func(issue Issue) error {
 		issues = append(issues, issue)
 		return nil
 	})
@@ -646,7 +647,7 @@ func TestIssueService_GetCustomFields(t *testing.T) {
 		fmt.Fprint(w, `{"expand":"renderedFields,names,schema,transitions,operations,editmeta,changelog,versionedRepresentations","id":"10002","self":"http://www.example.com/jira/rest/api/2/issue/10002","key":"EX-1","fields":{"customfield_123":"test","watcher":{"self":"http://www.example.com/jira/rest/api/2/issue/EX-1/watchers","isWatching":false,"watchCount":1,"watchers":[{"self":"http://www.example.com/jira/rest/api/2/user?username=fred","name":"fred","displayName":"Fred F. User","active":false}]},"attachment":[{"self":"http://www.example.com/jira/rest/api/2.0/attachments/10000","filename":"picture.jpg","author":{"self":"http://www.example.com/jira/rest/api/2/user?username=fred","name":"fred","avatarUrls":{"48x48":"http://www.example.com/jira/secure/useravatar?size=large&ownerId=fred","24x24":"http://www.example.com/jira/secure/useravatar?size=small&ownerId=fred","16x16":"http://www.example.com/jira/secure/useravatar?size=xsmall&ownerId=fred","32x32":"http://www.example.com/jira/secure/useravatar?size=medium&ownerId=fred"},"displayName":"Fred F. User","active":false},"created":"2016-03-16T04:22:37.461+0000","size":23123,"mimeType":"image/jpeg","content":"http://www.example.com/jira/attachments/10000","thumbnail":"http://www.example.com/jira/secure/thumbnail/10000"}],"sub-tasks":[{"id":"10000","type":{"id":"10000","name":"","inward":"Parent","outward":"Sub-task"},"outwardIssue":{"id":"10003","key":"EX-2","self":"http://www.example.com/jira/rest/api/2/issue/EX-2","fields":{"status":{"iconUrl":"http://www.example.com/jira//images/icons/statuses/open.png","name":"Open"}}}}],"description":"example bug report","project":{"self":"http://www.example.com/jira/rest/api/2/project/EX","id":"10000","key":"EX","name":"Example","avatarUrls":{"48x48":"http://www.example.com/jira/secure/projectavatar?size=large&pid=10000","24x24":"http://www.example.com/jira/secure/projectavatar?size=small&pid=10000","16x16":"http://www.example.com/jira/secure/projectavatar?size=xsmall&pid=10000","32x32":"http://www.example.com/jira/secure/projectavatar?size=medium&pid=10000"},"projectCategory":{"self":"http://www.example.com/jira/rest/api/2/projectCategory/10000","id":"10000","name":"FIRST","description":"First Project Category"}},"comment":{"comments":[{"self":"http://www.example.com/jira/rest/api/2/issue/10010/comment/10000","id":"10000","author":{"self":"http://www.example.com/jira/rest/api/2/user?username=fred","name":"fred","displayName":"Fred F. User","active":false},"body":"Lorem ipsum dolor sit amet, consectetur adipiscing elit. Pellentesque eget venenatis elit. Duis eu justo eget augue iaculis fermentum. Sed semper quam laoreet nisi egestas at posuere augue semper.","updateAuthor":{"self":"http://www.example.com/jira/rest/api/2/user?username=fred","name":"fred","displayName":"Fred F. User","active":false},"created":"2016-03-16T04:22:37.356+0000","updated":"2016-03-16T04:22:37.356+0000","visibility":{"type":"role","value":"Administrators"}}]},"issuelinks":[{"id":"10001","type":{"id":"10000","name":"Dependent","inward":"depends on","outward":"is depended by"},"outwardIssue":{"id":"10004L","key":"PRJ-2","self":"http://www.example.com/jira/rest/api/2/issue/PRJ-2","fields":{"status":{"iconUrl":"http://www.example.com/jira//images/icons/statuses/open.png","name":"Open"}}}},{"id":"10002","type":{"id":"10000","name":"Dependent","inward":"depends on","outward":"is depended by"},"inwardIssue":{"id":"10004","key":"PRJ-3","self":"http://www.example.com/jira/rest/api/2/issue/PRJ-3","fields":{"status":{"iconUrl":"http://www.example.com/jira//images/icons/statuses/open.png","name":"Open"}}}}],"worklog":{"worklogs":[{"self":"http://www.example.com/jira/rest/api/2/issue/10010/worklog/10000","author":{"self":"http://www.example.com/jira/rest/api/2/user?username=fred","name":"fred","displayName":"Fred F. User","active":false},"updateAuthor":{"self":"http://www.example.com/jira/rest/api/2/user?username=fred","name":"fred","displayName":"Fred F. User","active":false},"comment":"I did some work here.","updated":"2016-03-16T04:22:37.471+0000","visibility":{"type":"group","value":"jira-developers"},"started":"2016-03-16T04:22:37.471+0000","timeSpent":"3h 20m","timeSpentSeconds":12000,"id":"100028","issueId":"10002"}]},"updated":"2016-04-06T02:36:53.594-0700","duedate":"2018-01-19","timetracking":{"originalEstimate":"10m","remainingEstimate":"3m","timeSpent":"6m","originalEstimateSeconds":600,"remainingEstimateSeconds":200,"timeSpentSeconds":400}},"names":{"watcher":"watcher","attachment":"attachment","sub-tasks":"sub-tasks","description":"description","project":"project","comment":"comment","issuelinks":"issuelinks","worklog":"worklog","updated":"updated","timetracking":"timetracking"},"schema":{}}`)
 	})
 
-	issue, _, err := testClient.Issue.GetCustomFields("10002")
+	issue, _, err := testClient.Issue.GetCustomFields(context.Background(), "10002")
 	if err != nil {
 		t.Errorf("Error given: %s", err)
 	}
@@ -668,7 +669,7 @@ func TestIssueService_GetComplexCustomFields(t *testing.T) {
 		fmt.Fprint(w, `{"expand":"renderedFields,names,schema,transitions,operations,editmeta,changelog,versionedRepresentations","id":"10002","self":"http://www.example.com/jira/rest/api/2/issue/10002","key":"EX-1","fields":{"customfield_123":{"self":"http://www.example.com/jira/rest/api/2/customFieldOption/123","value":"test","id":"123"},"watcher":{"self":"http://www.example.com/jira/rest/api/2/issue/EX-1/watchers","isWatching":false,"watchCount":1,"watchers":[{"self":"http://www.example.com/jira/rest/api/2/user?username=fred","name":"fred","displayName":"Fred F. User","active":false}]},"attachment":[{"self":"http://www.example.com/jira/rest/api/2.0/attachments/10000","filename":"picture.jpg","author":{"self":"http://www.example.com/jira/rest/api/2/user?username=fred","name":"fred","avatarUrls":{"48x48":"http://www.example.com/jira/secure/useravatar?size=large&ownerId=fred","24x24":"http://www.example.com/jira/secure/useravatar?size=small&ownerId=fred","16x16":"http://www.example.com/jira/secure/useravatar?size=xsmall&ownerId=fred","32x32":"http://www.example.com/jira/secure/useravatar?size=medium&ownerId=fred"},"displayName":"Fred F. User","active":false},"created":"2016-03-16T04:22:37.461+0000","size":23123,"mimeType":"image/jpeg","content":"http://www.example.com/jira/attachments/10000","thumbnail":"http://www.example.com/jira/secure/thumbnail/10000"}],"sub-tasks":[{"id":"10000","type":{"id":"10000","name":"","inward":"Parent","outward":"Sub-task"},"outwardIssue":{"id":"10003","key":"EX-2","self":"http://www.example.com/jira/rest/api/2/issue/EX-2","fields":{"status":{"iconUrl":"http://www.example.com/jira//images/icons/statuses/open.png","name":"Open"}}}}],"description":"example bug report","project":{"self":"http://www.example.com/jira/rest/api/2/project/EX","id":"10000","key":"EX","name":"Example","avatarUrls":{"48x48":"http://www.example.com/jira/secure/projectavatar?size=large&pid=10000","24x24":"http://www.example.com/jira/secure/projectavatar?size=small&pid=10000","16x16":"http://www.example.com/jira/secure/projectavatar?size=xsmall&pid=10000","32x32":"http://www.example.com/jira/secure/projectavatar?size=medium&pid=10000"},"projectCategory":{"self":"http://www.example.com/jira/rest/api/2/projectCategory/10000","id":"10000","name":"FIRST","description":"First Project Category"}},"comment":{"comments":[{"self":"http://www.example.com/jira/rest/api/2/issue/10010/comment/10000","id":"10000","author":{"self":"http://www.example.com/jira/rest/api/2/user?username=fred","name":"fred","displayName":"Fred F. User","active":false},"body":"Lorem ipsum dolor sit amet, consectetur adipiscing elit. Pellentesque eget venenatis elit. Duis eu justo eget augue iaculis fermentum. Sed semper quam laoreet nisi egestas at posuere augue semper.","updateAuthor":{"self":"http://www.example.com/jira/rest/api/2/user?username=fred","name":"fred","displayName":"Fred F. User","active":false},"created":"2016-03-16T04:22:37.356+0000","updated":"2016-03-16T04:22:37.356+0000","visibility":{"type":"role","value":"Administrators"}}]},"issuelinks":[{"id":"10001","type":{"id":"10000","name":"Dependent","inward":"depends on","outward":"is depended by"},"outwardIssue":{"id":"10004L","key":"PRJ-2","self":"http://www.example.com/jira/rest/api/2/issue/PRJ-2","fields":{"status":{"iconUrl":"http://www.example.com/jira//images/icons/statuses/open.png","name":"Open"}}}},{"id":"10002","type":{"id":"10000","name":"Dependent","inward":"depends on","outward":"is depended by"},"inwardIssue":{"id":"10004","key":"PRJ-3","self":"http://www.example.com/jira/rest/api/2/issue/PRJ-3","fields":{"status":{"iconUrl":"http://www.example.com/jira//images/icons/statuses/open.png","name":"Open"}}}}],"worklog":{"worklogs":[{"self":"http://www.example.com/jira/rest/api/2/issue/10010/worklog/10000","author":{"self":"http://www.example.com/jira/rest/api/2/user?username=fred","name":"fred","displayName":"Fred F. User","active":false},"updateAuthor":{"self":"http://www.example.com/jira/rest/api/2/user?username=fred","name":"fred","displayName":"Fred F. User","active":false},"comment":"I did some work here.","updated":"2016-03-16T04:22:37.471+0000","visibility":{"type":"group","value":"jira-developers"},"started":"2016-03-16T04:22:37.471+0000","timeSpent":"3h 20m","timeSpentSeconds":12000,"id":"100028","issueId":"10002"}]},"updated":"2016-04-06T02:36:53.594-0700","duedate":"2018-01-19","timetracking":{"originalEstimate":"10m","remainingEstimate":"3m","timeSpent":"6m","originalEstimateSeconds":600,"remainingEstimateSeconds":200,"timeSpentSeconds":400}},"names":{"watcher":"watcher","attachment":"attachment","sub-tasks":"sub-tasks","description":"description","project":"project","comment":"comment","issuelinks":"issuelinks","worklog":"worklog","updated":"updated","timetracking":"timetracking"},"schema":{}}`)
 	})
 
-	issue, _, err := testClient.Issue.GetCustomFields("10002")
+	issue, _, err := testClient.Issue.GetCustomFields(context.Background(), "10002")
 	if err != nil {
 		t.Errorf("Error given: %s", err)
 	}
@@ -698,7 +699,7 @@ func TestIssueService_GetTransitions(t *testing.T) {
 		fmt.Fprint(w, string(raw))
 	})
 
-	transitions, _, err := testClient.Issue.GetTransitions("123")
+	transitions, _, err := testClient.Issue.GetTransitions(context.Background(), "123")
 
 	if err != nil {
 		t.Errorf("Got error: %v", err)
@@ -740,7 +741,7 @@ func TestIssueService_DoTransition(t *testing.T) {
 			t.Errorf("Expected %s to be in payload, got %s instead", transitionID, payload.Transition.ID)
 		}
 	})
-	_, err := testClient.Issue.DoTransition("123", transitionID)
+	_, err := testClient.Issue.DoTransition(context.Background(), "123", transitionID)
 
 	if err != nil {
 		t.Errorf("Got error: %v", err)
@@ -799,7 +800,7 @@ func TestIssueService_DoTransitionWithPayload(t *testing.T) {
 			t.Errorf("Expected %s to be in payload, got %s instead", transitionID, transition["id"])
 		}
 	})
-	_, err := testClient.Issue.DoTransitionWithPayload("123", customPayload)
+	_, err := testClient.Issue.DoTransitionWithPayload(context.Background(), "123", customPayload)
 
 	if err != nil {
 		t.Errorf("Got error: %v", err)
@@ -1299,7 +1300,7 @@ func TestIssueService_Delete(t *testing.T) {
 		fmt.Fprint(w, `{}`)
 	})
 
-	resp, err := testClient.Issue.Delete("10002")
+	resp, err := testClient.Issue.Delete(context.Background(), "10002")
 	if resp.StatusCode != 204 {
 		t.Error("Expected issue not deleted.")
 	}
@@ -1318,7 +1319,7 @@ func TestIssueService_GetWorklogs(t *testing.T) {
 		fmt.Fprint(w, `{"startAt": 1,"maxResults": 40,"total": 1,"worklogs": [{"id": "3","self": "http://kelpie9:8081/rest/api/2/issue/10002/worklog/3","author":{"self":"http://www.example.com/jira/rest/api/2/user?username=fred","name":"fred","displayName":"Fred F. User","active":false},"updateAuthor":{"self":"http://www.example.com/jira/rest/api/2/user?username=fred","name":"fred","displayName":"Fred F. User","active":false},"created":"2016-03-16T04:22:37.356+0000","updated":"2016-03-16T04:22:37.356+0000","comment":"","started":"2016-03-16T04:22:37.356+0000","timeSpent": "1h","timeSpentSeconds": 3600,"issueId":"10002"}]}`)
 	})
 
-	worklog, _, err := testClient.Issue.GetWorklogs("10002")
+	worklog, _, err := testClient.Issue.GetWorklogs(context.Background(), "10002")
 	if worklog == nil {
 		t.Error("Expected worklog. Worklog is nil")
 	}
@@ -1359,7 +1360,7 @@ func TestIssueService_GetWatchers(t *testing.T) {
         }]},"applicationRoles":{"size":1,"items":[]},"expand":"groups,applicationRoles"}`)
 	})
 
-	watchers, _, err := testClient.Issue.GetWatchers("10002")
+	watchers, _, err := testClient.Issue.GetWatchers(context.Background(), "10002")
 	if err != nil {
 		t.Errorf("Error given: %s", err)
 		return
@@ -1387,7 +1388,7 @@ func TestIssueService_UpdateAssignee(t *testing.T) {
 		w.WriteHeader(http.StatusNoContent)
 	})
 
-	resp, err := testClient.Issue.UpdateAssignee("10002", &User{
+	resp, err := testClient.Issue.UpdateAssignee(context.Background(), "10002", &User{
 		Name: "test-username",
 	})
 
@@ -1409,7 +1410,7 @@ func TestIssueService_Get_Fields_Changelog(t *testing.T) {
 		fmt.Fprint(w, `{"expand":"changelog","id":"10002","self":"http://www.example.com/jira/rest/api/2/issue/10002","key":"EX-1","changelog":{"startAt": 0,"maxResults": 1, "total": 1, "histories": [{"id": "10002", "author": {"self": "http://www.example.com/jira/rest/api/2/user?username=fred", "name": "fred", "key": "fred", "emailAddress": "fred@example.com", "avatarUrls": {"48x48": "http://www.example.com/secure/useravatar?ownerId=fred&avatarId=33072", "24x24": "http://www.example.com/secure/useravatar?size=small&ownerId=fred&avatarId=33072", "16x16": "http://www.example.com/secure/useravatar?size=xsmall&ownerId=fred&avatarId=33072", "32x32": "http://www.example.com/secure/useravatar?size=medium&ownerId=fred&avatarId=33072"},"displayName":"Fred","active": true,"timeZone":"Australia/Sydney"},"created":"2018-06-20T16:50:35.000+0300","items":[{"field":"Rank","fieldtype":"custom","from":"","fromString":"","to":"","toString":"Ranked higher"}]}]}}`)
 	})
 
-	issue, _, _ := testClient.Issue.Get("10002", &GetQueryOptions{Expand: "changelog"})
+	issue, _, _ := testClient.Issue.Get(context.Background(), "10002", &GetQueryOptions{Expand: "changelog"})
 	if issue == nil {
 		t.Error("Expected issue. Issue is nil")
 	}

--- a/jira_test.go
+++ b/jira_test.go
@@ -2,6 +2,7 @@ package jira
 
 import (
 	"bytes"
+	"context"
 	"fmt"
 	"io/ioutil"
 	"net/http"
@@ -350,7 +351,7 @@ func TestClient_Do(t *testing.T) {
 
 	req, _ := testClient.NewRequest("GET", "/", nil)
 	body := new(foo)
-	testClient.Do(req, body)
+	testClient.Do(context.Background(), req, body)
 
 	want := &foo{"a"}
 	if !reflect.DeepEqual(body, want) {
@@ -374,7 +375,7 @@ func TestClient_Do_HTTPResponse(t *testing.T) {
 	})
 
 	req, _ := testClient.NewRequest("GET", "/", nil)
-	res, _ := testClient.Do(req, nil)
+	res, _ := testClient.Do(context.Background(), req, nil)
 	_, err := ioutil.ReadAll(res.Body)
 
 	if err != nil {
@@ -393,7 +394,7 @@ func TestClient_Do_HTTPError(t *testing.T) {
 	})
 
 	req, _ := testClient.NewRequest("GET", "/", nil)
-	_, err := testClient.Do(req, nil)
+	_, err := testClient.Do(context.Background(), req, nil)
 
 	if err == nil {
 		t.Error("Expected HTTP 400 error.")
@@ -411,7 +412,7 @@ func TestClient_Do_RedirectLoop(t *testing.T) {
 	})
 
 	req, _ := testClient.NewRequest("GET", "/", nil)
-	_, err := testClient.Do(req, nil)
+	_, err := testClient.Do(context.Background(), req, nil)
 
 	if err == nil {
 		t.Error("Expected error to be returned.")
@@ -466,7 +467,7 @@ func TestBasicAuthTransport(t *testing.T) {
 
 	basicAuthClient, _ := NewClient(tp.Client(), testServer.URL)
 	req, _ := basicAuthClient.NewRequest("GET", ".", nil)
-	basicAuthClient.Do(req, nil)
+	basicAuthClient.Do(context.Background(), req, nil)
 }
 
 func TestBasicAuthTransport_transport(t *testing.T) {
@@ -517,7 +518,7 @@ func TestCookieAuthTransport_SessionObject_Exists(t *testing.T) {
 
 	basicAuthClient, _ := NewClient(tp.Client(), testServer.URL)
 	req, _ := basicAuthClient.NewRequest("GET", ".", nil)
-	basicAuthClient.Do(req, nil)
+	basicAuthClient.Do(context.Background(), req, nil)
 }
 
 // Test that an empty cookie in the transport is not returned in the header
@@ -553,7 +554,7 @@ func TestCookieAuthTransport_SessionObject_ExistsWithEmptyCookie(t *testing.T) {
 
 	basicAuthClient, _ := NewClient(tp.Client(), testServer.URL)
 	req, _ := basicAuthClient.NewRequest("GET", ".", nil)
-	basicAuthClient.Do(req, nil)
+	basicAuthClient.Do(context.Background(), req, nil)
 }
 
 // Test that if no cookie is in the transport, it checks for a cookie
@@ -594,5 +595,5 @@ func TestCookieAuthTransport_SessionObject_DoesNotExist(t *testing.T) {
 
 	basicAuthClient, _ := NewClient(tp.Client(), testServer.URL)
 	req, _ := basicAuthClient.NewRequest("GET", ".", nil)
-	basicAuthClient.Do(req, nil)
+	basicAuthClient.Do(context.Background(), req, nil)
 }

--- a/metaissue.go
+++ b/metaissue.go
@@ -1,6 +1,7 @@
 package jira
 
 import (
+	"context"
 	"fmt"
 	"strings"
 
@@ -43,12 +44,12 @@ type MetaIssueType struct {
 }
 
 // GetCreateMeta makes the api call to get the meta information required to create a ticket
-func (s *IssueService) GetCreateMeta(projectkeys string) (*CreateMetaInfo, *Response, error) {
-	return s.GetCreateMetaWithOptions(&GetQueryOptions{ProjectKeys: projectkeys, Expand: "projects.issuetypes.fields"})
+func (s *IssueService) GetCreateMeta(ctx context.Context, projectkeys string) (*CreateMetaInfo, *Response, error) {
+	return s.GetCreateMetaWithOptions(ctx, &GetQueryOptions{ProjectKeys: projectkeys, Expand: "projects.issuetypes.fields"})
 }
 
 // GetCreateMetaWithOptions makes the api call to get the meta information without requiring to have a projectKey
-func (s *IssueService) GetCreateMetaWithOptions(options *GetQueryOptions) (*CreateMetaInfo, *Response, error) {
+func (s *IssueService) GetCreateMetaWithOptions(ctx context.Context, options *GetQueryOptions) (*CreateMetaInfo, *Response, error) {
 	apiEndpoint := "rest/api/2/issue/createmeta"
 
 	req, err := s.client.NewRequest("GET", apiEndpoint, nil)
@@ -64,7 +65,7 @@ func (s *IssueService) GetCreateMetaWithOptions(options *GetQueryOptions) (*Crea
 	}
 
 	meta := new(CreateMetaInfo)
-	resp, err := s.client.Do(req, meta)
+	resp, err := s.client.Do(ctx, req, meta)
 
 	if err != nil {
 		return nil, resp, err

--- a/metaissue_test.go
+++ b/metaissue_test.go
@@ -1,6 +1,7 @@
 package jira
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 	"testing"
@@ -347,7 +348,7 @@ func TestIssueService_GetCreateMeta_Success(t *testing.T) {
     }`)
 	})
 
-	issue, _, err := testClient.Issue.GetCreateMeta("SPN")
+	issue, _, err := testClient.Issue.GetCreateMeta(context.Background(), "SPN")
 	if err != nil {
 		t.Errorf("Expected nil error but got %s", err)
 	}
@@ -719,7 +720,7 @@ func TestMetaIssueType_GetCreateMetaWithOptions(t *testing.T) {
     }`)
 	})
 
-	issue, _, err := testClient.Issue.GetCreateMetaWithOptions(&GetQueryOptions{Expand: "projects.issuetypes.fields"})
+	issue, _, err := testClient.Issue.GetCreateMetaWithOptions(context.Background(), &GetQueryOptions{Expand: "projects.issuetypes.fields"})
 	if err != nil {
 		t.Errorf("Expected nil error but got %s", err)
 	}

--- a/priority.go
+++ b/priority.go
@@ -1,5 +1,7 @@
 package jira
 
+import "context"
+
 // PriorityService handles priorities for the JIRA instance / API.
 //
 // JIRA API docs: https://developer.atlassian.com/cloud/jira/platform/rest/#api-Priority
@@ -21,7 +23,7 @@ type Priority struct {
 // GetList gets all priorities from JIRA
 //
 // JIRA API docs: https://developer.atlassian.com/cloud/jira/platform/rest/#api-api-2-priority-get
-func (s *PriorityService) GetList() ([]Priority, *Response, error) {
+func (s *PriorityService) GetList(ctx context.Context) ([]Priority, *Response, error) {
 	apiEndpoint := "rest/api/2/priority"
 	req, err := s.client.NewRequest("GET", apiEndpoint, nil)
 	if err != nil {
@@ -29,7 +31,7 @@ func (s *PriorityService) GetList() ([]Priority, *Response, error) {
 	}
 
 	priorityList := []Priority{}
-	resp, err := s.client.Do(req, &priorityList)
+	resp, err := s.client.Do(ctx, req, &priorityList)
 	if err != nil {
 		return nil, resp, NewJiraError(resp, err)
 	}

--- a/priority_test.go
+++ b/priority_test.go
@@ -1,6 +1,7 @@
 package jira
 
 import (
+	"context"
 	"fmt"
 	"io/ioutil"
 	"net/http"
@@ -22,7 +23,7 @@ func TestPriorityService_GetList(t *testing.T) {
 		fmt.Fprint(w, string(raw))
 	})
 
-	priorities, _, err := testClient.Priority.GetList()
+	priorities, _, err := testClient.Priority.GetList(context.Background())
 	if priorities == nil {
 		t.Error("Expected priority list. Priority list is nil")
 	}

--- a/project.go
+++ b/project.go
@@ -1,6 +1,7 @@
 package jira
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/google/go-querystring/query"
@@ -84,15 +85,15 @@ type PermissionScheme struct {
 // GetList gets all projects form JIRA
 //
 // JIRA API docs: https://docs.atlassian.com/jira/REST/latest/#api/2/project-getAllProjects
-func (s *ProjectService) GetList() (*ProjectList, *Response, error) {
-	return s.ListWithOptions(&GetQueryOptions{})
+func (s *ProjectService) GetList(ctx context.Context) (*ProjectList, *Response, error) {
+	return s.ListWithOptions(ctx, &GetQueryOptions{})
 }
 
 // ListWithOptions gets all projects form JIRA with optional query params, like &GetQueryOptions{Expand: "issueTypes"} to get
 // a list of all projects and their supported issuetypes
 //
 // JIRA API docs: https://docs.atlassian.com/jira/REST/latest/#api/2/project-getAllProjects
-func (s *ProjectService) ListWithOptions(options *GetQueryOptions) (*ProjectList, *Response, error) {
+func (s *ProjectService) ListWithOptions(ctx context.Context, options *GetQueryOptions) (*ProjectList, *Response, error) {
 	apiEndpoint := "rest/api/2/project"
 	req, err := s.client.NewRequest("GET", apiEndpoint, nil)
 	if err != nil {
@@ -108,7 +109,7 @@ func (s *ProjectService) ListWithOptions(options *GetQueryOptions) (*ProjectList
 	}
 
 	projectList := new(ProjectList)
-	resp, err := s.client.Do(req, projectList)
+	resp, err := s.client.Do(ctx, req, projectList)
 	if err != nil {
 		jerr := NewJiraError(resp, err)
 		return nil, resp, jerr
@@ -122,7 +123,7 @@ func (s *ProjectService) ListWithOptions(options *GetQueryOptions) (*ProjectList
 // This can be an project id, or an project key.
 //
 // JIRA API docs: https://docs.atlassian.com/jira/REST/latest/#api/2/project-getProject
-func (s *ProjectService) Get(projectID string) (*Project, *Response, error) {
+func (s *ProjectService) Get(ctx context.Context, projectID string) (*Project, *Response, error) {
 	apiEndpoint := fmt.Sprintf("rest/api/2/project/%s", projectID)
 	req, err := s.client.NewRequest("GET", apiEndpoint, nil)
 	if err != nil {
@@ -130,7 +131,7 @@ func (s *ProjectService) Get(projectID string) (*Project, *Response, error) {
 	}
 
 	project := new(Project)
-	resp, err := s.client.Do(req, project)
+	resp, err := s.client.Do(ctx, req, project)
 	if err != nil {
 		jerr := NewJiraError(resp, err)
 		return nil, resp, jerr
@@ -144,7 +145,7 @@ func (s *ProjectService) Get(projectID string) (*Project, *Response, error) {
 // This can be an project id, or an project key.
 //
 // JIRA API docs: https://docs.atlassian.com/jira/REST/latest/#api/2/project-getProject
-func (s *ProjectService) GetPermissionScheme(projectID string) (*PermissionScheme, *Response, error) {
+func (s *ProjectService) GetPermissionScheme(ctx context.Context, projectID string) (*PermissionScheme, *Response, error) {
 	apiEndpoint := fmt.Sprintf("/rest/api/2/project/%s/permissionscheme", projectID)
 	req, err := s.client.NewRequest("GET", apiEndpoint, nil)
 	if err != nil {
@@ -152,7 +153,7 @@ func (s *ProjectService) GetPermissionScheme(projectID string) (*PermissionSchem
 	}
 
 	ps := new(PermissionScheme)
-	resp, err := s.client.Do(req, ps)
+	resp, err := s.client.Do(ctx, req, ps)
 	if err != nil {
 		jerr := NewJiraError(resp, err)
 		return nil, resp, jerr

--- a/project_test.go
+++ b/project_test.go
@@ -1,6 +1,7 @@
 package jira
 
 import (
+	"context"
 	"fmt"
 	"io/ioutil"
 	"net/http"
@@ -22,7 +23,7 @@ func TestProjectService_GetList(t *testing.T) {
 		fmt.Fprint(w, string(raw))
 	})
 
-	projects, _, err := testClient.Project.GetList()
+	projects, _, err := testClient.Project.GetList(context.Background())
 	if projects == nil {
 		t.Error("Expected project list. Project list is nil")
 	}
@@ -46,7 +47,7 @@ func TestProjectService_ListWithOptions(t *testing.T) {
 		fmt.Fprint(w, string(raw))
 	})
 
-	projects, _, err := testClient.Project.ListWithOptions(&GetQueryOptions{Expand: "issueTypes"})
+	projects, _, err := testClient.Project.ListWithOptions(context.Background(), &GetQueryOptions{Expand: "issueTypes"})
 	if projects == nil {
 		t.Error("Expected project list. Project list is nil")
 	}
@@ -70,7 +71,7 @@ func TestProjectService_Get(t *testing.T) {
 		fmt.Fprint(w, string(raw))
 	})
 
-	projects, _, err := testClient.Project.Get("12310505")
+	projects, _, err := testClient.Project.Get(context.Background(), "12310505")
 	if projects == nil {
 		t.Error("Expected project list. Project list is nil")
 	}
@@ -90,7 +91,7 @@ func TestProjectService_Get_NoProject(t *testing.T) {
 		fmt.Fprint(w, nil)
 	})
 
-	projects, resp, err := testClient.Project.Get("99999999")
+	projects, resp, err := testClient.Project.Get(context.Background(), "99999999")
 	if projects != nil {
 		t.Errorf("Expected nil. Got %+v", projects)
 	}
@@ -114,7 +115,7 @@ func TestProjectService_GetPermissionScheme_Failure(t *testing.T) {
 		fmt.Fprint(w, nil)
 	})
 
-	permissionScheme, resp, err := testClient.Project.GetPermissionScheme("99999999")
+	permissionScheme, resp, err := testClient.Project.GetPermissionScheme(context.Background(), "99999999")
 	if permissionScheme != nil {
 		t.Errorf("Expected nil. Got %+v", permissionScheme)
 	}
@@ -144,7 +145,7 @@ func TestProjectService_GetPermissionScheme_Success(t *testing.T) {
 		}`)
 	})
 
-	permissionScheme, resp, err := testClient.Project.GetPermissionScheme("99999999")
+	permissionScheme, resp, err := testClient.Project.GetPermissionScheme(context.Background(), "99999999")
 	if permissionScheme.ID != 10201 {
 		t.Errorf("Expected Permission Scheme ID. Got %+v", permissionScheme)
 	}

--- a/resolution.go
+++ b/resolution.go
@@ -1,5 +1,7 @@
 package jira
 
+import "context"
+
 // ResolutionService handles resolutions for the JIRA instance / API.
 //
 // JIRA API docs: https://developer.atlassian.com/cloud/jira/platform/rest/#api-Resolution
@@ -19,7 +21,7 @@ type Resolution struct {
 // GetList gets all resolutions from JIRA
 //
 // JIRA API docs: https://developer.atlassian.com/cloud/jira/platform/rest/#api-api-2-resolution-get
-func (s *ResolutionService) GetList() ([]Resolution, *Response, error) {
+func (s *ResolutionService) GetList(ctx context.Context) ([]Resolution, *Response, error) {
 	apiEndpoint := "rest/api/2/resolution"
 	req, err := s.client.NewRequest("GET", apiEndpoint, nil)
 	if err != nil {
@@ -27,7 +29,7 @@ func (s *ResolutionService) GetList() ([]Resolution, *Response, error) {
 	}
 
 	resolutionList := []Resolution{}
-	resp, err := s.client.Do(req, &resolutionList)
+	resp, err := s.client.Do(ctx, req, &resolutionList)
 	if err != nil {
 		return nil, resp, NewJiraError(resp, err)
 	}

--- a/resolution_test.go
+++ b/resolution_test.go
@@ -1,6 +1,7 @@
 package jira
 
 import (
+	"context"
 	"fmt"
 	"io/ioutil"
 	"net/http"
@@ -22,7 +23,7 @@ func TestResolutionService_GetList(t *testing.T) {
 		fmt.Fprint(w, string(raw))
 	})
 
-	resolution, _, err := testClient.Resolution.GetList()
+	resolution, _, err := testClient.Resolution.GetList(context.Background())
 	if resolution == nil {
 		t.Error("Expected resolution list. Resolution list is nil")
 	}

--- a/sprint.go
+++ b/sprint.go
@@ -1,6 +1,7 @@
 package jira
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/google/go-querystring/query"
@@ -27,7 +28,7 @@ type IssuesInSprintResult struct {
 // The maximum number of issues that can be moved in one operation is 50.
 //
 // JIRA API docs: https://docs.atlassian.com/jira-software/REST/cloud/#agile/1.0/sprint-moveIssuesToSprint
-func (s *SprintService) MoveIssuesToSprint(sprintID int, issueIDs []string) (*Response, error) {
+func (s *SprintService) MoveIssuesToSprint(ctx context.Context, sprintID int, issueIDs []string) (*Response, error) {
 	apiEndpoint := fmt.Sprintf("rest/agile/1.0/sprint/%d/issue", sprintID)
 
 	payload := IssuesWrapper{Issues: issueIDs}
@@ -38,7 +39,7 @@ func (s *SprintService) MoveIssuesToSprint(sprintID int, issueIDs []string) (*Re
 		return nil, err
 	}
 
-	resp, err := s.client.Do(req, nil)
+	resp, err := s.client.Do(ctx, req, nil)
 	if err != nil {
 		err = NewJiraError(resp, err)
 	}
@@ -50,7 +51,7 @@ func (s *SprintService) MoveIssuesToSprint(sprintID int, issueIDs []string) (*Re
 // By default, the returned issues are ordered by rank.
 //
 //  JIRA API Docs: https://docs.atlassian.com/jira-software/REST/cloud/#agile/1.0/sprint-getIssuesForSprint
-func (s *SprintService) GetIssuesForSprint(sprintID int) ([]Issue, *Response, error) {
+func (s *SprintService) GetIssuesForSprint(ctx context.Context, sprintID int) ([]Issue, *Response, error) {
 	apiEndpoint := fmt.Sprintf("rest/agile/1.0/sprint/%d/issue", sprintID)
 
 	req, err := s.client.NewRequest("GET", apiEndpoint, nil)
@@ -60,7 +61,7 @@ func (s *SprintService) GetIssuesForSprint(sprintID int) ([]Issue, *Response, er
 	}
 
 	result := new(IssuesInSprintResult)
-	resp, err := s.client.Do(req, result)
+	resp, err := s.client.Do(ctx, req, result)
 	if err != nil {
 		err = NewJiraError(resp, err)
 	}
@@ -78,7 +79,7 @@ func (s *SprintService) GetIssuesForSprint(sprintID int) ([]Issue, *Response, er
 // JIRA API docs: https://docs.atlassian.com/jira-software/REST/7.3.1/#agile/1.0/issue-getIssue
 //
 // TODO: create agile service for holding all agile apis' implementation
-func (s *SprintService) GetIssue(issueID string, options *GetQueryOptions) (*Issue, *Response, error) {
+func (s *SprintService) GetIssue(ctx context.Context, issueID string, options *GetQueryOptions) (*Issue, *Response, error) {
 	apiEndpoint := fmt.Sprintf("rest/agile/1.0/issue/%s", issueID)
 
 	req, err := s.client.NewRequest("GET", apiEndpoint, nil)
@@ -96,7 +97,7 @@ func (s *SprintService) GetIssue(issueID string, options *GetQueryOptions) (*Iss
 	}
 
 	issue := new(Issue)
-	resp, err := s.client.Do(req, issue)
+	resp, err := s.client.Do(ctx, req, issue)
 
 	if err != nil {
 		jerr := NewJiraError(resp, err)

--- a/sprint_test.go
+++ b/sprint_test.go
@@ -1,6 +1,7 @@
 package jira
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
@@ -32,7 +33,7 @@ func TestSprintService_MoveIssuesToSprint(t *testing.T) {
 			t.Errorf("Expected %s to be in payload, got %s instead", issuesToMove[0], payload.Issues[0])
 		}
 	})
-	_, err := testClient.Sprint.MoveIssuesToSprint(123, issuesToMove)
+	_, err := testClient.Sprint.MoveIssuesToSprint(context.Background(), 123, issuesToMove)
 
 	if err != nil {
 		t.Errorf("Got error: %v", err)
@@ -54,7 +55,7 @@ func TestSprintService_GetIssuesForSprint(t *testing.T) {
 		fmt.Fprint(w, string(raw))
 	})
 
-	issues, _, err := testClient.Sprint.GetIssuesForSprint(123)
+	issues, _, err := testClient.Sprint.GetIssuesForSprint(context.Background(), 123)
 	if err != nil {
 		t.Errorf("Error given: %v", err)
 	}
@@ -79,7 +80,7 @@ func TestSprintService_GetIssue(t *testing.T) {
 		fmt.Fprint(w, `{"expand":"renderedFields,names,schema,transitions,operations,editmeta,changelog,versionedRepresentations","id":"10002","self":"http://www.example.com/jira/rest/api/2/issue/10002","key":"EX-1","fields":{"labels":["test"],"watcher":{"self":"http://www.example.com/jira/rest/api/2/issue/EX-1/watchers","isWatching":false,"watchCount":1,"watchers":[{"self":"http://www.example.com/jira/rest/api/2/user?username=fred","name":"fred","displayName":"Fred F. User","active":false}]},"sprint": {"id": 37,"self": "http://www.example.com/jira/rest/agile/1.0/sprint/13", "state": "future", "name": "sprint 2"}, "epic": {"id": 19415,"key": "EPIC-77","self": "https://example.atlassian.net/rest/agile/1.0/epic/19415","name": "Epic Name","summary": "Do it","color": {"key": "color_11"},"done": false},"attachment":[{"self":"http://www.example.com/jira/rest/api/2.0/attachments/10000","filename":"picture.jpg","author":{"self":"http://www.example.com/jira/rest/api/2/user?username=fred","name":"fred","avatarUrls":{"48x48":"http://www.example.com/jira/secure/useravatar?size=large&ownerId=fred","24x24":"http://www.example.com/jira/secure/useravatar?size=small&ownerId=fred","16x16":"http://www.example.com/jira/secure/useravatar?size=xsmall&ownerId=fred","32x32":"http://www.example.com/jira/secure/useravatar?size=medium&ownerId=fred"},"displayName":"Fred F. User","active":false},"created":"2016-03-16T04:22:37.461+0000","size":23123,"mimeType":"image/jpeg","content":"http://www.example.com/jira/attachments/10000","thumbnail":"http://www.example.com/jira/secure/thumbnail/10000"}],"sub-tasks":[{"id":"10000","type":{"id":"10000","name":"","inward":"Parent","outward":"Sub-task"},"outwardIssue":{"id":"10003","key":"EX-2","self":"http://www.example.com/jira/rest/api/2/issue/EX-2","fields":{"status":{"iconUrl":"http://www.example.com/jira//images/icons/statuses/open.png","name":"Open"}}}}],"description":"example bug report","project":{"self":"http://www.example.com/jira/rest/api/2/project/EX","id":"10000","key":"EX","name":"Example","avatarUrls":{"48x48":"http://www.example.com/jira/secure/projectavatar?size=large&pid=10000","24x24":"http://www.example.com/jira/secure/projectavatar?size=small&pid=10000","16x16":"http://www.example.com/jira/secure/projectavatar?size=xsmall&pid=10000","32x32":"http://www.example.com/jira/secure/projectavatar?size=medium&pid=10000"},"projectCategory":{"self":"http://www.example.com/jira/rest/api/2/projectCategory/10000","id":"10000","name":"FIRST","description":"First Project Category"}},"comment":{"comments":[{"self":"http://www.example.com/jira/rest/api/2/issue/10010/comment/10000","id":"10000","author":{"self":"http://www.example.com/jira/rest/api/2/user?username=fred","name":"fred","displayName":"Fred F. User","active":false},"body":"Lorem ipsum dolor sit amet, consectetur adipiscing elit. Pellentesque eget venenatis elit. Duis eu justo eget augue iaculis fermentum. Sed semper quam laoreet nisi egestas at posuere augue semper.","updateAuthor":{"self":"http://www.example.com/jira/rest/api/2/user?username=fred","name":"fred","displayName":"Fred F. User","active":false},"created":"2016-03-16T04:22:37.356+0000","updated":"2016-03-16T04:22:37.356+0000","visibility":{"type":"role","value":"Administrators"}}]},"issuelinks":[{"id":"10001","type":{"id":"10000","name":"Dependent","inward":"depends on","outward":"is depended by"},"outwardIssue":{"id":"10004L","key":"PRJ-2","self":"http://www.example.com/jira/rest/api/2/issue/PRJ-2","fields":{"status":{"iconUrl":"http://www.example.com/jira//images/icons/statuses/open.png","name":"Open"}}}},{"id":"10002","type":{"id":"10000","name":"Dependent","inward":"depends on","outward":"is depended by"},"inwardIssue":{"id":"10004","key":"PRJ-3","self":"http://www.example.com/jira/rest/api/2/issue/PRJ-3","fields":{"status":{"iconUrl":"http://www.example.com/jira//images/icons/statuses/open.png","name":"Open"}}}}],"worklog":{"worklogs":[{"self":"http://www.example.com/jira/rest/api/2/issue/10010/worklog/10000","author":{"self":"http://www.example.com/jira/rest/api/2/user?username=fred","name":"fred","displayName":"Fred F. User","active":false},"updateAuthor":{"self":"http://www.example.com/jira/rest/api/2/user?username=fred","name":"fred","displayName":"Fred F. User","active":false},"comment":"I did some work here.","updated":"2016-03-16T04:22:37.471+0000","visibility":{"type":"group","value":"jira-developers"},"started":"2016-03-16T04:22:37.471+0000","timeSpent":"3h 20m","timeSpentSeconds":12000,"id":"100028","issueId":"10002"}]},"updated":"2016-04-06T02:36:53.594-0700","duedate":"2018-01-19","timetracking":{"originalEstimate":"10m","remainingEstimate":"3m","timeSpent":"6m","originalEstimateSeconds":600,"remainingEstimateSeconds":200,"timeSpentSeconds":400}},"names":{"watcher":"watcher","attachment":"attachment","sub-tasks":"sub-tasks","description":"description","project":"project","comment":"comment","issuelinks":"issuelinks","worklog":"worklog","updated":"updated","timetracking":"timetracking"},"schema":{}}`)
 	})
 
-	issue, _, err := testClient.Sprint.GetIssue("10002", nil)
+	issue, _, err := testClient.Sprint.GetIssue(context.Background(), "10002", nil)
 	if issue == nil {
 		t.Errorf("Expected issue. Issue is nil %v", err)
 	}

--- a/statuscategory.go
+++ b/statuscategory.go
@@ -1,5 +1,7 @@
 package jira
 
+import "context"
+
 // StatusCategoryService handles status categories for the JIRA instance / API.
 //
 // JIRA API docs: https://developer.atlassian.com/cloud/jira/platform/rest/#api-Statuscategory
@@ -28,7 +30,7 @@ const (
 // GetList gets all status categories from JIRA
 //
 // JIRA API docs: https://developer.atlassian.com/cloud/jira/platform/rest/#api-api-2-statuscategory-get
-func (s *StatusCategoryService) GetList() ([]StatusCategory, *Response, error) {
+func (s *StatusCategoryService) GetList(ctx context.Context) ([]StatusCategory, *Response, error) {
 	apiEndpoint := "rest/api/2/statuscategory"
 	req, err := s.client.NewRequest("GET", apiEndpoint, nil)
 	if err != nil {
@@ -36,7 +38,7 @@ func (s *StatusCategoryService) GetList() ([]StatusCategory, *Response, error) {
 	}
 
 	statusCategoryList := []StatusCategory{}
-	resp, err := s.client.Do(req, &statusCategoryList)
+	resp, err := s.client.Do(ctx, req, &statusCategoryList)
 	if err != nil {
 		return nil, resp, NewJiraError(resp, err)
 	}

--- a/statuscategory_test.go
+++ b/statuscategory_test.go
@@ -1,6 +1,7 @@
 package jira
 
 import (
+	"context"
 	"fmt"
 	"io/ioutil"
 	"net/http"
@@ -22,7 +23,7 @@ func TestStatusCategoryService_GetList(t *testing.T) {
 		fmt.Fprint(w, string(raw))
 	})
 
-	statusCategory, _, err := testClient.StatusCategory.GetList()
+	statusCategory, _, err := testClient.StatusCategory.GetList(context.Background())
 	if statusCategory == nil {
 		t.Error("Expected statusCategory list. StatusCategory list is nil")
 	}

--- a/user.go
+++ b/user.go
@@ -1,6 +1,7 @@
 package jira
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
@@ -45,7 +46,7 @@ type userSearchF func(userSearch) userSearch
 // Get gets user info from JIRA
 //
 // JIRA API docs: https://docs.atlassian.com/jira/REST/cloud/#api/2/user-getUser
-func (s *UserService) Get(username string) (*User, *Response, error) {
+func (s *UserService) Get(ctx context.Context, username string) (*User, *Response, error) {
 	apiEndpoint := fmt.Sprintf("/rest/api/2/user?username=%s", username)
 	req, err := s.client.NewRequest("GET", apiEndpoint, nil)
 	if err != nil {
@@ -53,7 +54,7 @@ func (s *UserService) Get(username string) (*User, *Response, error) {
 	}
 
 	user := new(User)
-	resp, err := s.client.Do(req, user)
+	resp, err := s.client.Do(ctx, req, user)
 	if err != nil {
 		return nil, resp, NewJiraError(resp, err)
 	}
@@ -63,14 +64,14 @@ func (s *UserService) Get(username string) (*User, *Response, error) {
 // Create creates an user in JIRA.
 //
 // JIRA API docs: https://docs.atlassian.com/jira/REST/cloud/#api/2/user-createUser
-func (s *UserService) Create(user *User) (*User, *Response, error) {
+func (s *UserService) Create(ctx context.Context, user *User) (*User, *Response, error) {
 	apiEndpoint := "/rest/api/2/user"
 	req, err := s.client.NewRequest("POST", apiEndpoint, user)
 	if err != nil {
 		return nil, nil, err
 	}
 
-	resp, err := s.client.Do(req, nil)
+	resp, err := s.client.Do(ctx, req, nil)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -94,14 +95,14 @@ func (s *UserService) Create(user *User) (*User, *Response, error) {
 // Returns http.StatusNoContent on success.
 //
 // JIRA API docs: https://developer.atlassian.com/cloud/jira/platform/rest/#api-api-2-user-delete
-func (s *UserService) Delete(username string) (*Response, error) {
+func (s *UserService) Delete(ctx context.Context, username string) (*Response, error) {
 	apiEndpoint := fmt.Sprintf("/rest/api/2/user?username=%s", username)
 	req, err := s.client.NewRequest("DELETE", apiEndpoint, nil)
 	if err != nil {
 		return nil, err
 	}
 
-	resp, err := s.client.Do(req, nil)
+	resp, err := s.client.Do(ctx, req, nil)
 	if err != nil {
 		return resp, NewJiraError(resp, err)
 	}
@@ -111,7 +112,7 @@ func (s *UserService) Delete(username string) (*Response, error) {
 // GetGroups returns the groups which the user belongs to
 //
 // JIRA API docs: https://docs.atlassian.com/jira/REST/cloud/#api/2/user-getUserGroups
-func (s *UserService) GetGroups(username string) (*[]UserGroup, *Response, error) {
+func (s *UserService) GetGroups(ctx context.Context, username string) (*[]UserGroup, *Response, error) {
 	apiEndpoint := fmt.Sprintf("/rest/api/2/user/groups?username=%s", username)
 	req, err := s.client.NewRequest("GET", apiEndpoint, nil)
 	if err != nil {
@@ -119,7 +120,7 @@ func (s *UserService) GetGroups(username string) (*[]UserGroup, *Response, error
 	}
 
 	userGroups := new([]UserGroup)
-	resp, err := s.client.Do(req, userGroups)
+	resp, err := s.client.Do(ctx, req, userGroups)
 	if err != nil {
 		return nil, resp, NewJiraError(resp, err)
 	}
@@ -129,14 +130,14 @@ func (s *UserService) GetGroups(username string) (*[]UserGroup, *Response, error
 // Get information about the current logged-in user
 //
 // JIRA API docs: https://developer.atlassian.com/cloud/jira/platform/rest/#api-api-2-myself-get
-func (s *UserService) GetSelf() (*User, *Response, error) {
+func (s *UserService) GetSelf(ctx context.Context) (*User, *Response, error) {
 	const apiEndpoint = "rest/api/2/myself"
 	req, err := s.client.NewRequest("GET", apiEndpoint, nil)
 	if err != nil {
 		return nil, nil, err
 	}
 	var user User
-	resp, err := s.client.Do(req, &user)
+	resp, err := s.client.Do(ctx, req, &user)
 	if err != nil {
 		return nil, resp, NewJiraError(resp, err)
 	}
@@ -179,7 +180,7 @@ func WithInactive(inactive bool) userSearchF {
 // It can find users by email, username or name
 //
 // JIRA API docs: https://docs.atlassian.com/jira/REST/cloud/#api/2/user-findUsers
-func (s *UserService) Find(property string, tweaks ...userSearchF) ([]User, *Response, error) {
+func (s *UserService) Find(ctx context.Context, property string, tweaks ...userSearchF) ([]User, *Response, error) {
 	search := []userSearchParam{
 		{
 			name:  "username",
@@ -202,7 +203,7 @@ func (s *UserService) Find(property string, tweaks ...userSearchF) ([]User, *Res
 	}
 
 	users := []User{}
-	resp, err := s.client.Do(req, &users)
+	resp, err := s.client.Do(ctx, req, &users)
 	if err != nil {
 		return nil, resp, NewJiraError(resp, err)
 	}

--- a/user_test.go
+++ b/user_test.go
@@ -1,6 +1,7 @@
 package jira
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 	"testing"
@@ -22,7 +23,7 @@ func TestUserService_Get_Success(t *testing.T) {
         }]},"applicationRoles":{"size":1,"items":[]},"expand":"groups,applicationRoles"}`)
 	})
 
-	if user, _, err := testClient.User.Get("fred"); err != nil {
+	if user, _, err := testClient.User.Get(context.Background(), "fred"); err != nil {
 		t.Errorf("Error given: %s", err)
 	} else if user == nil {
 		t.Error("Expected user. User is nil")
@@ -49,7 +50,7 @@ func TestUserService_Create(t *testing.T) {
 		ApplicationKeys: []string{"jira-core"},
 	}
 
-	if user, _, err := testClient.User.Create(u); err != nil {
+	if user, _, err := testClient.User.Create(context.Background(), u); err != nil {
 		t.Errorf("Error given: %s", err)
 	} else if user == nil {
 		t.Error("Expected user. User is nil")
@@ -66,7 +67,7 @@ func TestUserService_Delete(t *testing.T) {
 		w.WriteHeader(http.StatusNoContent)
 	})
 
-	resp, err := testClient.User.Delete("fred")
+	resp, err := testClient.User.Delete(context.Background(), "fred")
 	if err != nil {
 		t.Errorf("Error given: %s", err)
 	}
@@ -87,7 +88,7 @@ func TestUserService_GetGroups(t *testing.T) {
 		fmt.Fprint(w, `[{"name":"jira-software-users","self":"http://www.example.com/jira/rest/api/2/user?username=fred"}]`)
 	})
 
-	if groups, _, err := testClient.User.GetGroups("fred"); err != nil {
+	if groups, _, err := testClient.User.GetGroups(context.Background(), "fred"); err != nil {
 		t.Errorf("Error given: %s", err)
 	} else if groups == nil {
 		t.Error("Expected user groups. []UserGroup is nil")
@@ -111,7 +112,7 @@ func TestUserService_GetSelf(t *testing.T) {
         }]},"applicationRoles":{"size":1,"items":[]},"expand":"groups,applicationRoles"}`)
 	})
 
-	if user, _, err := testClient.User.GetSelf(); err != nil {
+	if user, _, err := testClient.User.GetSelf(context.Background()); err != nil {
 		t.Errorf("Error given: %s", err)
 	} else if user == nil {
 		t.Error("Expected user groups. []UserGroup is nil")
@@ -138,7 +139,7 @@ func TestUserService_Find_Success(t *testing.T) {
         }]},"applicationRoles":{"size":1,"items":[]},"expand":"groups,applicationRoles"}]`)
 	})
 
-	if user, _, err := testClient.User.Find("fred@example.com"); err != nil {
+	if user, _, err := testClient.User.Find(context.Background(), "fred@example.com"); err != nil {
 		t.Errorf("Error given: %s", err)
 	} else if user == nil {
 		t.Error("Expected user. User is nil")
@@ -161,7 +162,7 @@ func TestUserService_Find_SuccessParams(t *testing.T) {
         }]},"applicationRoles":{"size":1,"items":[]},"expand":"groups,applicationRoles"}]`)
 	})
 
-	if user, _, err := testClient.User.Find("fred@example.com", WithStartAt(100), WithMaxResults(1000)); err != nil {
+	if user, _, err := testClient.User.Find(context.Background(), "fred@example.com", WithStartAt(100), WithMaxResults(1000)); err != nil {
 		t.Errorf("Error given: %s", err)
 	} else if user == nil {
 		t.Error("Expected user. User is nil")

--- a/version.go
+++ b/version.go
@@ -1,6 +1,7 @@
 package jira
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
@@ -30,7 +31,7 @@ type Version struct {
 // Get gets version info from JIRA
 //
 // JIRA API docs: https://developer.atlassian.com/cloud/jira/platform/rest/#api-api-2-version-id-get
-func (s *VersionService) Get(versionID int) (*Version, *Response, error) {
+func (s *VersionService) Get(ctx context.Context, versionID int) (*Version, *Response, error) {
 	apiEndpoint := fmt.Sprintf("/rest/api/2/version/%v", versionID)
 	req, err := s.client.NewRequest("GET", apiEndpoint, nil)
 	if err != nil {
@@ -38,7 +39,7 @@ func (s *VersionService) Get(versionID int) (*Version, *Response, error) {
 	}
 
 	version := new(Version)
-	resp, err := s.client.Do(req, version)
+	resp, err := s.client.Do(ctx, req, version)
 	if err != nil {
 		return nil, resp, NewJiraError(resp, err)
 	}
@@ -48,14 +49,14 @@ func (s *VersionService) Get(versionID int) (*Version, *Response, error) {
 // Create creates a version in JIRA.
 //
 // JIRA API docs: https://developer.atlassian.com/cloud/jira/platform/rest/#api-api-2-version-post
-func (s *VersionService) Create(version *Version) (*Version, *Response, error) {
+func (s *VersionService) Create(ctx context.Context, version *Version) (*Version, *Response, error) {
 	apiEndpoint := "/rest/api/2/version"
 	req, err := s.client.NewRequest("POST", apiEndpoint, version)
 	if err != nil {
 		return nil, nil, err
 	}
 
-	resp, err := s.client.Do(req, nil)
+	resp, err := s.client.Do(ctx, req, nil)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -78,13 +79,13 @@ func (s *VersionService) Create(version *Version) (*Version, *Response, error) {
 // Update updates a version from a JSON representation.
 //
 // JIRA API docs: https://developer.atlassian.com/cloud/jira/platform/rest/#api-api-2-version-id-put
-func (s *VersionService) Update(version *Version) (*Version, *Response, error) {
+func (s *VersionService) Update(ctx context.Context, version *Version) (*Version, *Response, error) {
 	apiEndpoint := fmt.Sprintf("rest/api/2/version/%v", version.ID)
 	req, err := s.client.NewRequest("PUT", apiEndpoint, version)
 	if err != nil {
 		return nil, nil, err
 	}
-	resp, err := s.client.Do(req, nil)
+	resp, err := s.client.Do(ctx, req, nil)
 	if err != nil {
 		jerr := NewJiraError(resp, err)
 		return nil, resp, jerr

--- a/version_test.go
+++ b/version_test.go
@@ -1,6 +1,7 @@
 package jira
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 	"testing"
@@ -28,7 +29,7 @@ func TestVersionService_Get_Success(t *testing.T) {
 		}`)
 	})
 
-	version, _, err := testClient.Version.Get(10002)
+	version, _, err := testClient.Version.Get(context.Background(), 10002)
 	if version == nil {
 		t.Error("Expected version. Issue is nil")
 	}
@@ -67,7 +68,7 @@ func TestVersionService_Create(t *testing.T) {
 		StartDate:       "2018-07-01",
 	}
 
-	version, _, err := testClient.Version.Create(v)
+	version, _, err := testClient.Version.Create(context.Background(), v)
 	if version == nil {
 		t.Error("Expected version. Version is nil")
 	}
@@ -101,7 +102,7 @@ func TestServiceService_Update(t *testing.T) {
 		Description: "An excellent updated version",
 	}
 
-	version, _, err := testClient.Version.Update(v)
+	version, _, err := testClient.Version.Update(context.Background(), v)
 	if version == nil {
 		t.Error("Expected version. Version is nil")
 	}


### PR DESCRIPTION
The PR changes the API go-jira adding support for "context" package. This will enable golang applications coordinate cancellation accross many different goroutines.

PR breaks backwards compatibility (added `ctx context.Context` as first parameter to all methods), so maybe it should be part of next major release.