### PR TITLE
Fix error in the example code in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,7 +193,7 @@ func main() {
 	req, _ := jiraClient.NewRequest("GET", "rest/api/2/project", nil)
 
 	projects := new([]jira.Project)
-	_, err := jiraClient.Do(req, projects)
+	_, err = jiraClient.Do(req, projects)
 	if err != nil {
 		panic(err)
 	}


### PR DESCRIPTION
I found tiny bug in the example described in README.

```
./main.go:19:9: no new variables on left side of :=
```