### PR TITLE
Issue#198, Fix panic for unauthorized response with nil error

### DIFF
--- a/error.go
+++ b/error.go
@@ -38,6 +38,9 @@ func NewJiraError(resp *Response, httpError error) error {
 			return errors.Wrap(err, httpError.Error())
 		}
 	} else {
+        if httpError == nil {
+            return fmt.Errorf("Got Response Status %s:%s", resp.Status, string(body))
+        }
 		return errors.Wrap(httpError, fmt.Sprintf("%s: %s", resp.Status, string(body)))
 	}
 

--- a/error_test.go
+++ b/error_test.go
@@ -62,6 +62,25 @@ func TestError_NoJSON(t *testing.T) {
 	}
 }
 
+func TestError_Unauthorized_NilError(t *testing.T) {
+	setup()
+	defer teardown()
+
+	testMux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+        w.WriteHeader(http.StatusUnauthorized)
+		fmt.Fprint(w, `User is not authorized`)
+	})
+
+	req, _ := testClient.NewRequest("GET", "/", nil)
+	resp, _ := testClient.Do(req, nil)
+
+	err := NewJiraError(resp, nil)
+	msg := err.Error()
+    if !strings.Contains(msg, "401 Unauthorized:User is not authorized") {
+		t.Errorf("Expected Unauthorized HTTP status: Got\n%s\n", msg)
+    }
+}
+
 func TestError_BadJSON(t *testing.T) {
 	setup()
 	defer teardown()


### PR DESCRIPTION
This fixes the panic when a response with invalid status is returned by Jira with nil error.