### PR TITLE
Stopped adding empty params to url

### DIFF
--- a/issue.go
+++ b/issue.go
@@ -823,8 +823,22 @@ func (s *IssueService) Search(jql string, options *SearchOptions) ([]Issue, *Res
 	if options == nil {
 		u = fmt.Sprintf("rest/api/2/search?jql=%s", url.QueryEscape(jql))
 	} else {
-		u = fmt.Sprintf("rest/api/2/search?jql=%s&startAt=%d&maxResults=%d&expand=%s&fields=%s&validateQuery=%s", url.QueryEscape(jql),
-			options.StartAt, options.MaxResults, options.Expand, strings.Join(options.Fields, ","), options.ValidateQuery)
+		u = "rest/api/2/search?jql=" + url.QueryEscape(jql)
+		if options.StartAt != 0 {
+			u += fmt.Sprintf("&startAt=%d", options.StartAt)
+		}
+		if options.MaxResults != 0 {
+			u += fmt.Sprintf("&maxResults=%d", options.MaxResults)
+		}
+		if options.Expand != "" {
+			u += fmt.Sprintf("&expand=%s", options.Expand)
+		}
+		if strings.Join(options.Fields, ",") != "" {
+			u += fmt.Sprintf("&fields=%s", strings.Join(options.Fields, ","))
+		}
+		if options.ValidateQuery != "" {
+			u += fmt.Sprintf("&validateQuery=%s", options.ValidateQuery)
+		}
 	}
 
 	req, err := s.client.NewRequest("GET", u, nil)


### PR DESCRIPTION
Currently the query parameters become malformed on usage:

``` go
u, x, err := client.Issue.Search("assignee = currentUser() AND resolution = Unresolved order by updated DESC", &jira.SearchOptions{Expand: "renderedFields"})
```

yields:

``` bash
jql=assignee+%3D+currentUser%28%29+AND+resolution+%3D+Unresolved+order+by+updated+DESC&startAt=0&maxResults=0&expand=renderedFields&fields=&validateQuery=
```

which does not return any data.

This is an example fix that avoids appending those query parameters when they are empty. I couldn't find a neat way of doing that without turning all struct types to pointers. 

It breaks the spec here https://github.com/andygrunwald/go-jira/blob/master/issue_test.go#L607

because it now won't pass empty parameters in. This fixes my use case, but the current implementation is a little gross.

