### PR TITLE
Fix board request parameter

### DIFF
--- a/board.go
+++ b/board.go
@@ -35,7 +35,7 @@ type Board struct {
 type BoardListOptions struct {
 	// BoardType filters results to boards of the specified type.
 	// Valid values: scrum, kanban.
-	BoardType string `url:"boardType,omitempty"`
+	BoardType string `url:"type,omitempty"`
 	// Name filters results to boards that match or partially match the specified name.
 	Name string `url:"name,omitempty"`
 	// ProjectKeyOrID filters results to boards that are relevant to a project.

--- a/board_test.go
+++ b/board_test.go
@@ -44,6 +44,7 @@ func TestBoardService_GetAllBoards_WithFilter(t *testing.T) {
 	testMux.HandleFunc(testAPIEdpoint, func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
 		testRequestURL(t, r, testAPIEdpoint)
+		testRequestParams(t, r, map[string]string{"type": "scrum", "name": "Test", "startAt": "1", "maxResults": "10", "projectKeyOrId": "TE"})
 		fmt.Fprint(w, string(raw))
 	})
 

--- a/jira_test.go
+++ b/jira_test.go
@@ -58,6 +58,22 @@ func testRequestURL(t *testing.T, r *http.Request, want string) {
 	}
 }
 
+func testRequestParams(t *testing.T, r *http.Request, want map[string]string) {
+	params := r.URL.Query()
+
+	if len(params) != len(want) {
+		t.Errorf("Request params: %d, want %d", len(params), len(want))
+	}
+
+	for key, val := range want {
+		if got := params.Get(key); val != got {
+			t.Errorf("Request params: %s, want %s", got, val)
+		}
+
+	}
+
+}
+
 func TestNewClient_WrongUrl(t *testing.T) {
 	c, err := NewClient(nil, "://issues.apache.org/jira/")
 


### PR DESCRIPTION
The BoardListOption field BoardType was incorrectly mapped to boardType
instead of type. This commit fixes it. A generic test helper
function (testRequestParams) is added in order to improve the
effectiveness of the unit test.

Fixes #213