### PR TITLE
Fix fixversion description field

### DIFF
--- a/issue.go
+++ b/issue.go
@@ -479,7 +479,7 @@ type FixVersion struct {
 	Self            string `json:"self,omitempty" structs:"self,omitempty"`
 	ID              string `json:"id,omitempty" structs:"id,omitempty"`
 	Name            string `json:"name,omitempty" structs:"name,omitempty"`
-	Description     string `json:"description,omitempty" structs:"name,omitempty"`
+	Description     string `json:"description,omitempty" structs:"description,omitempty"`
 	Archived        *bool  `json:"archived,omitempty" structs:"archived,omitempty"`
 	Released        *bool  `json:"released,omitempty" structs:"released,omitempty"`
 	ReleaseDate     string `json:"releaseDate,omitempty" structs:"releaseDate,omitempty"`


### PR DESCRIPTION
There's an error: description filed has structs:name, instead of structs:description