### PR TITLE
make NotifyUsers switchable to false

### DIFF
--- a/issue.go
+++ b/issue.go
@@ -32,7 +32,7 @@ type IssueService struct {
 
 // UpdateQueryOptions specifies the optional parameters to the Edit issue
 type UpdateQueryOptions struct {
-	NotifyUsers            bool `url:"notifyUsers,omitempty"`
+	NotifyUsers            bool `url:"notifyUsers"`
 	OverrideScreenSecurity bool `url:"overrideScreenSecurity,omitempty"`
 	OverrideEditableFlag   bool `url:"overrideEditableFlag,omitempty"`
 }


### PR DESCRIPTION
Since `notifyUsers` is true by default (https://developer.atlassian.com/cloud/jira/platform/rest/v3/?utm_source=%2Fcloud%2Fjira%2Fplatform%2Frest%2F&utm_medium=302#api-rest-api-3-issue-issueIdOrKey-put) it's not possible to set the `notifyUsers` to `false` if the `omitempty` tag is there.