### PR TITLE
Issue link type service

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -11,8 +11,10 @@ github.com/pkg/errors v0.8.0/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINE
 github.com/trivago/tgo v1.0.1 h1:bxatjJIXNIpV18bucU4Uk/LaoxvxuOlp/oowRHyncLQ=
 github.com/trivago/tgo v1.0.1/go.mod h1:w4dpD+3tzNIIiIfkWWa85w5/B77tlvdZckQ+6PkFnhc=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
+golang.org/x/crypto v0.0.0-20190426145343-a29dc8fdc734 h1:p/H982KKEjUnLJkM3tt/LemDnOc1GiZL5FCVlORJ5zo=
 golang.org/x/crypto v0.0.0-20190426145343-a29dc8fdc734/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
 golang.org/x/net v0.0.0-20190404232315-eb5bcb51f2a3/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
 golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
+golang.org/x/sys v0.0.0-20190412213103-97732733099d h1:+R4KGOnez64A81RvjARKc4UT5/tI9ujCIVX+P5KiHuI=
 golang.org/x/sys v0.0.0-20190412213103-97732733099d/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=

--- a/issuelinktype.go
+++ b/issuelinktype.go
@@ -1,5 +1,7 @@
 package jira
 
+import "fmt"
+
 // IssueLinkTypeService handles issue link types for the JIRA instance / API.
 //
 // JIRA API docs: https://developer.atlassian.com/cloud/jira/platform/rest/v2/#api-group-Issue-link-types
@@ -23,4 +25,22 @@ func (s *IssueLinkTypeService) GetList() ([]IssueLinkType, *Response, error) {
 		return nil, resp, NewJiraError(resp, err)
 	}
 	return linkTypeList, resp, nil
+}
+
+// Get gets info of a specific issue link type from JIRA.
+//
+// JIRA API docs: https://developer.atlassian.com/cloud/jira/platform/rest/v2/#api-rest-api-2-issueLinkType-issueLinkTypeId-get
+func (s *IssueLinkTypeService) Get(ID string) (*IssueLinkType, *Response, error) {
+	apiEndPoint := fmt.Sprintf("rest/api/2/issueLinkType/%s", ID)
+	req, err := s.client.NewRequest("GET", apiEndPoint, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	linkType := new(IssueLinkType)
+	resp, err := s.client.Do(req, linkType)
+	if err != nil {
+		return nil, resp, NewJiraError(resp, err)
+	}
+	return linkType, resp, nil
 }

--- a/issuelinktype.go
+++ b/issuelinktype.go
@@ -95,3 +95,17 @@ func (s *IssueLinkTypeService) Update(linkType *IssueLinkType) (*IssueLinkType, 
 	ret := *linkType
 	return &ret, resp, nil
 }
+
+// Delete deletes an issue link type based on provided ID.
+//
+// JIRA API docs: https://developer.atlassian.com/cloud/jira/platform/rest/v2/#api-rest-api-2-issueLinkType-issueLinkTypeId-delete
+func (s *IssueLinkTypeService) Delete(ID string) (*Response, error) {
+	apiEndpoint := fmt.Sprintf("rest/api/2/issueLinkType/%s", ID)
+	req, err := s.client.NewRequest("DELETE", apiEndpoint, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	resp, err := s.client.Do(req, nil)
+	return resp, err
+}

--- a/issuelinktype.go
+++ b/issuelinktype.go
@@ -78,3 +78,20 @@ func (s *IssueLinkTypeService) Create(linkType *IssueLinkType) (*IssueLinkType, 
 	}
 	return linkType, resp, nil
 }
+
+// Update updates an issue link type.  The issue is found by key.
+//
+// JIRA API docs: https://developer.atlassian.com/cloud/jira/platform/rest/v2/#api-rest-api-2-issueLinkType-issueLinkTypeId-put
+func (s *IssueLinkTypeService) Update(linkType *IssueLinkType) (*IssueLinkType, *Response, error) {
+	apiEndpoint := fmt.Sprintf("rest/api/2/issueLinkType/%s", linkType.ID)
+	req, err := s.client.NewRequest("PUT", apiEndpoint, linkType)
+	if err != nil {
+		return nil, nil, err
+	}
+	resp, err := s.client.Do(req, nil)
+	if err != nil {
+		return nil, resp, NewJiraError(resp, err)
+	}
+	ret := *linkType
+	return &ret, resp, nil
+}

--- a/issuelinktype.go
+++ b/issuelinktype.go
@@ -1,0 +1,26 @@
+package jira
+
+// IssueLinkTypeService handles issue link types for the JIRA instance / API.
+//
+// JIRA API docs: https://developer.atlassian.com/cloud/jira/platform/rest/v2/#api-group-Issue-link-types
+type IssueLinkTypeService struct {
+	client *Client
+}
+
+// GetList gets all of the issue link types from JIRA.
+//
+// JIRA API docs: https://developer.atlassian.com/cloud/jira/platform/rest/v2/#api-rest-api-2-issueLinkType-get
+func (s *IssueLinkTypeService) GetList() ([]IssueLinkType, *Response, error) {
+	apiEndpoint := "rest/api/2/issueLinkType"
+	req, err := s.client.NewRequest("GET", apiEndpoint, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	linkTypeList := []IssueLinkType{}
+	resp, err := s.client.Do(req, &linkTypeList)
+	if err != nil {
+		return nil, resp, NewJiraError(resp, err)
+	}
+	return linkTypeList, resp, nil
+}

--- a/issuelinktype_test.go
+++ b/issuelinktype_test.go
@@ -30,3 +30,21 @@ func TestIssueLinkTypeService_GetList(t *testing.T) {
 		t.Errorf("Error give: %s", err)
 	}
 }
+
+func TestIssueLinkTypeService_Get(t *testing.T) {
+	setup()
+	defer teardown()
+	testMux.HandleFunc("/rest/api/2/issueLinkType/123", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "GET")
+		testRequestURL(t, r, "/rest/api/2/issueLinkType/123")
+
+		fmt.Fprint(w, `{"id": "123","name": "Blocked","inward": "Blocked","outward": "Blocked",
+		"self": "https://www.example.com/jira/rest/api/2/issueLinkType/123"}`)
+	})
+
+	if linkType, _, err := testClient.IssueLinkType.Get("123"); err != nil {
+		t.Errorf("Error given: %s", err)
+	} else if linkType == nil {
+		t.Error("Expected linkType. LinkType is nil")
+	}
+}

--- a/issuelinktype_test.go
+++ b/issuelinktype_test.go
@@ -73,3 +73,27 @@ func TestIssueLinkTypeService_Create(t *testing.T) {
 		t.Error("Expected linkType. LinkType is nil")
 	}
 }
+
+func TestIssueLinkTypeService_Update(t *testing.T) {
+	setup()
+	defer teardown()
+	testMux.HandleFunc("/rest/api/2/issueLinkType/100", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "PUT")
+		testRequestURL(t, r, "/rest/api/2/issueLinkType/100")
+
+		w.WriteHeader(http.StatusNoContent)
+	})
+
+	lt := &IssueLinkType{
+		ID:      "100",
+		Name:    "Problem/Incident",
+		Inward:  "is caused by",
+		Outward: "causes",
+	}
+
+	if linkType, _, err := testClient.IssueLinkType.Update(lt); err != nil {
+		t.Errorf("Error given: %s", err)
+	} else if linkType == nil {
+		t.Error("Expected linkType. LinkType is nil")
+	}
+}

--- a/issuelinktype_test.go
+++ b/issuelinktype_test.go
@@ -97,3 +97,22 @@ func TestIssueLinkTypeService_Update(t *testing.T) {
 		t.Error("Expected linkType. LinkType is nil")
 	}
 }
+
+func TestIssueLinkTypeService_Delete(t *testing.T) {
+	setup()
+	defer teardown()
+	testMux.HandleFunc("/rest/api/2/issueLinkType/100", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "DELETE")
+		testRequestURL(t, r, "/rest/api/2/issueLinkType/100")
+
+		w.WriteHeader(http.StatusNoContent)
+	})
+
+	resp, err := testClient.IssueLinkType.Delete("100")
+	if resp.StatusCode != http.StatusNoContent {
+		t.Error("Expected issue not deleted.")
+	}
+	if err != nil {
+		t.Errorf("Error given: %s", err)
+	}
+}

--- a/issuelinktype_test.go
+++ b/issuelinktype_test.go
@@ -1,0 +1,32 @@
+package jira
+
+import (
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"testing"
+)
+
+func TestIssueLinkTypeService_GetList(t *testing.T) {
+	setup()
+	defer teardown()
+	testAPIEndpoint := "/rest/api/2/issueLinkType"
+
+	raw, err := ioutil.ReadFile("./mocks/all_issuelinktypes.json")
+	if err != nil {
+		t.Error(err.Error())
+	}
+	testMux.HandleFunc(testAPIEndpoint, func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "GET")
+		testRequestURL(t, r, testAPIEndpoint)
+		fmt.Fprint(w, string(raw))
+	})
+
+	linkTypes, _, err := testClient.IssueLinkType.GetList()
+	if linkTypes == nil {
+		t.Error("Expected issueLinkType list. LinkTypes is nil")
+	}
+	if err != nil {
+		t.Errorf("Error give: %s", err)
+	}
+}

--- a/issuelinktype_test.go
+++ b/issuelinktype_test.go
@@ -48,3 +48,28 @@ func TestIssueLinkTypeService_Get(t *testing.T) {
 		t.Error("Expected linkType. LinkType is nil")
 	}
 }
+
+func TestIssueLinkTypeService_Create(t *testing.T) {
+	setup()
+	defer teardown()
+	testMux.HandleFunc("/rest/api/2/issueLinkType", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "POST")
+		testRequestURL(t, r, "/rest/api/2/issueLinkType")
+
+		w.WriteHeader(http.StatusCreated)
+		fmt.Fprint(w, `{"id":"10021","name":"Problem/Incident","inward":"is caused by",
+		"outward":"causes","self":"https://www.example.com/jira/rest/api/2/issueLinkType/10021"}`)
+	})
+
+	lt := &IssueLinkType{
+		Name:    "Problem/Incident",
+		Inward:  "is caused by",
+		Outward: "causes",
+	}
+
+	if linkType, _, err := testClient.IssueLinkType.Create(lt); err != nil {
+		t.Errorf("Error given: %s", err)
+	} else if linkType == nil {
+		t.Error("Expected linkType. LinkType is nil")
+	}
+}

--- a/jira.go
+++ b/jira.go
@@ -54,6 +54,7 @@ type Client struct {
 	Role             *RoleService
 	PermissionScheme *PermissionSchemeService
 	Status           *StatusService
+	IssueLinkType    *IssueLinkTypeService
 }
 
 // NewClient returns a new JIRA API client.
@@ -99,6 +100,7 @@ func NewClient(httpClient httpClient, baseURL string) (*Client, error) {
 	c.Role = &RoleService{client: c}
 	c.PermissionScheme = &PermissionSchemeService{client: c}
 	c.Status = &StatusService{client: c}
+	c.IssueLinkType = &IssueLinkTypeService{client: c}
 
 	return c, nil
 }

--- a/mocks/all_issuelinktypes.json
+++ b/mocks/all_issuelinktypes.json
@@ -1,0 +1,121 @@
+[
+  {
+    "id": "12310361",
+    "name": "Blocked",
+    "inward": "Blocked",
+    "outward": "Blocked",
+    "self": "https://issues.apache.org/jira/rest/api/2/issueLinkType/12310361"
+  },
+  {
+    "id": "10032",
+    "name": "Blocker",
+    "inward": "is blocked by",
+    "outward": "blocks",
+    "self": "https://issues.apache.org/jira/rest/api/2/issueLinkType/10032"
+  },
+  {
+    "id": "12310460",
+    "name": "Child-Issue",
+    "inward": "is a child of",
+    "outward": "is a parent of",
+    "self": "https://issues.apache.org/jira/rest/api/2/issueLinkType/12310460"
+  },
+  {
+    "id": "10020",
+    "name": "Cloners",
+    "inward": "is cloned by",
+    "outward": "is a clone of",
+    "self": "https://issues.apache.org/jira/rest/api/2/issueLinkType/10020"
+  },
+  {
+    "id": "12310060",
+    "name": "Container",
+    "inward": "Is contained by",
+    "outward": "contains",
+    "self": "https://issues.apache.org/jira/rest/api/2/issueLinkType/12310060"
+  },
+  {
+    "id": "12310461",
+    "name": "Dependency",
+    "inward": "Dependency",
+    "outward": "Dependency",
+    "self": "https://issues.apache.org/jira/rest/api/2/issueLinkType/12310461"
+  },
+  {
+    "id": "12310360",
+    "name": "Dependent",
+    "inward": "Dependent",
+    "outward": "Dependent",
+    "self": "https://issues.apache.org/jira/rest/api/2/issueLinkType/12310360"
+  },
+  {
+    "id": "12310000",
+    "name": "Duplicate",
+    "inward": "is duplicated by",
+    "outward": "duplicates",
+    "self": "https://issues.apache.org/jira/rest/api/2/issueLinkType/12310000"
+  },
+  {
+    "id": "12310010",
+    "name": "Incorporates",
+    "inward": "is part of",
+    "outward": "incorporates",
+    "self": "https://issues.apache.org/jira/rest/api/2/issueLinkType/12310010"
+  },
+  {
+    "id": "12310462",
+    "name": "Parent Feature",
+    "inward": "Parent Feature",
+    "outward": "Parent Feature",
+    "self": "https://issues.apache.org/jira/rest/api/2/issueLinkType/12310462"
+  },
+  {
+    "id": "12310560",
+    "name": "Problem/Incident",
+    "inward": "is caused by",
+    "outward": "causes",
+    "self": "https://issues.apache.org/jira/rest/api/2/issueLinkType/12310560"
+  },
+  {
+    "id": "10030",
+    "name": "Reference",
+    "inward": "is related to",
+    "outward": "relates to",
+    "self": "https://issues.apache.org/jira/rest/api/2/issueLinkType/10030"
+  },
+  {
+    "id": "12310050",
+    "name": "Regression",
+    "inward": "is broken by",
+    "outward": "breaks",
+    "self": "https://issues.apache.org/jira/rest/api/2/issueLinkType/12310050"
+  },
+  {
+    "id": "12310260",
+    "name": "Related",
+    "inward": "is related to",
+    "outward": "relates to",
+    "self": "https://issues.apache.org/jira/rest/api/2/issueLinkType/12310260"
+  },
+  {
+    "id": "12310040",
+    "name": "Required",
+    "inward": "is required by",
+    "outward": "requires",
+    "self": "https://issues.apache.org/jira/rest/api/2/issueLinkType/12310040"
+  },
+  {
+    "id": "12310051",
+    "name": "Supercedes",
+    "inward": "is superceded by",
+    "outward": "supercedes",
+    "self": "https://issues.apache.org/jira/rest/api/2/issueLinkType/12310051"
+  },
+  {
+    "id": "10001",
+    "name": "dependent",
+    "inward": "is depended upon by",
+    "outward": "depends upon",
+    "self": "https://issues.apache.org/jira/rest/api/2/issueLinkType/10001"
+  }
+]


### PR DESCRIPTION
# PR Description

This PR adds the `IssueLinkTypeService` for working with issue link type endpoints on JIRA.  Most of the work is based on how things are currently done on other endpoints (e.g. status categories, issues, users).

# Checklist

* [x] Tests added
  * [x] Good Path
  * [x] Error Path
* [x] Commits follow conventions described here:
  * [x] https://conventionalcommits.org/en/v1.0.0-beta.4/#summary
  * [x] chris.beams.io/posts/git-commit/#seven-rules
* [x] Commits are squashed such that
  * [x] There is 1 commit per isolated change
* [x] I've not made extraneous commits/changes that are unrelated to my change.
