### PR TITLE
fix version struct description tags error

### DIFF
--- a/version.go
+++ b/version.go
@@ -18,7 +18,7 @@ type Version struct {
 	Self            string `json:"self,omitempty" structs:"self,omitempty"`
 	ID              string `json:"id,omitempty" structs:"id,omitempty"`
 	Name            string `json:"name,omitempty" structs:"name,omitempty"`
-	Description     string `json:"description,omitempty" structs:"name,omitempty"`
+	Description     string `json:"description,omitempty" structs:"description,omitempty"`
 	Archived        bool   `json:"archived,omitempty" structs:"archived,omitempty"`
 	Released        bool   `json:"released,omitempty" structs:"released,omitempty"`
 	ReleaseDate     string `json:"releaseDate,omitempty" structs:"releaseDate,omitempty"`


### PR DESCRIPTION
# PR Description

Fix `Version` struct `Description` tag. It incorrectly references `name` instead of `description`.

# Checklist

* [ ] Tests added
  * [ ] Good Path
  * [ ] Error Path
* [ ] Commits follow conventions described here:
  * [ ] [https://conventionalcommits.org/en/v1.0.0-beta.4/#summary](https://conventionalcommits.org/en/v1.0.0-beta.4/#summary)
  * [ ] [https://chris.beams.io/posts/git-commit/#seven-rules](https://chris.beams.io/posts/git-commit/#seven-rules)
* [ ] Commits are squashed such that
  * [ ] There is 1 commit per isolated change
* [ ] I've not made extraneous commits/changes that are unrelated to my change.
