### PR TITLE
Provide access to issue transitions obtained from JIRA API response

### DIFF
--- a/issue.go
+++ b/issue.go
@@ -46,6 +46,7 @@ type Issue struct {
 	Fields         *IssueFields         `json:"fields,omitempty" structs:"fields,omitempty"`
 	RenderedFields *IssueRenderedFields `json:"renderedFields,omitempty" structs:"renderedFields,omitempty"`
 	Changelog      *Changelog           `json:"changelog,omitempty" structs:"changelog,omitempty"`
+	Transitions    []Transition         `json:"transitions,omitempty" structs:"transitions,omitempty"`
 }
 
 // ChangelogItems reflects one single changelog item of a history item

--- a/issue_test.go
+++ b/issue_test.go
@@ -1564,6 +1564,37 @@ func TestIssueService_Get_Fields_Changelog(t *testing.T) {
 		t.Errorf("Expected CreatedTime func return %v time, %v got", tm, ct)
 	}
 }
+
+func TestIssueService_Get_Transitions(t *testing.T) {
+	setup()
+	defer teardown()
+	testMux.HandleFunc("/rest/api/2/issue/10002", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "GET")
+		testRequestURL(t, r, "/rest/api/2/issue/10002")
+
+		fmt.Fprint(w, `{"expand":"renderedFields,names,schema,transitions,operations,editmeta,changelog,versionedRepresentations","id":"10002","self":"http://www.example.com/jira/api/latest/issue/10002","key":"EX-1","transitions":[{"id":"121","name":"Start","to":{"self":"http://www.example.com/rest/api/2/status/10444","description":"","iconUrl":"http://www.example.com/images/icons/statuses/inprogress.png","name":"In progress","id":"10444","statusCategory":{"self":"http://www.example.com/rest/api/2/statuscategory/4","id":4,"key":"indeterminate","colorName":"yellow","name":"In Progress"}}}]}`)
+	})
+
+	issue, _, _ := testClient.Issue.Get("10002", &GetQueryOptions{Expand: "transitions"})
+	if issue == nil {
+		t.Error("Expected issue. Issue is nil")
+	}
+
+	if len(issue.Transitions) != 1 {
+		t.Errorf("Expected one transition item, %v found", len(issue.Transitions))
+	}
+
+	transition := issue.Transitions[0]
+
+	if transition.Name != "Start" {
+		t.Errorf("Expected 'Start' transition to be available, got %q", transition.Name)
+	}
+
+	if transition.To.Name != "In progress" {
+		t.Errorf("Expected transition to lead to status 'In progress', got %q", transition.To.Name)
+	}
+}
+
 func TestIssueService_Get_Fields_AffectsVersions(t *testing.T) {
 	setup()
 	defer teardown()


### PR DESCRIPTION
# Provide access to issue transitions obtained from JIRA API response

JIRA API is able to provide clients with list of transitions available
for issue in its current state (this is shown in [JIRA API reference](https://docs.atlassian.com/software/jira/docs/api/REST/8.4.3/#api/2/issue-getIssue))
to get this info client should send 'transitions' expand to JIRA API.

Now Go-Jira client does not throw away this information when it sees it
in JSON response from JIRA API

# Checklist

* [x] Tests added
  * [x] Good Path - added
  * [x] Error Path - no additional tests needed
* [x] Commits follow conventions described here:
  * [x] [https://conventionalcommits.org/en/v1.0.0-beta.4/#summary](https://conventionalcommits.org/en/v1.0.0-beta.4/#summary)
  * [x] [https://chris.beams.io/posts/git-commit/#seven-rules](https://chris.beams.io/posts/git-commit/#seven-rules)
* [x] Commits are squashed such that
  * [x] There is 1 commit per isolated change
* [x] I've not made extraneous commits/changes that are unrelated to my change.
