### PR TITLE
Set variable type of ticketID from interface{} to string

### DIFF
--- a/issue.go
+++ b/issue.go
@@ -1065,7 +1065,7 @@ func (s *IssueService) DoTransition(ticketID, transitionID string) (*Response, e
 // When performing the transition you can update or set other issue fields.
 //
 // JIRA API docs: https://docs.atlassian.com/jira/REST/latest/#api/2/issue-doTransition
-func (s *IssueService) DoTransitionWithPayload(ticketID, payload interface{}) (*Response, error) {
+func (s *IssueService) DoTransitionWithPayload(ticketID string, payload interface{}) (*Response, error) {
 	apiEndpoint := fmt.Sprintf("rest/api/2/issue/%s/transitions", ticketID)
 
 	req, err := s.client.NewRequest("POST", apiEndpoint, payload)


### PR DESCRIPTION
# PR Description

The variable type of `ticketID` should be `string` not `interface{}`

# Checklist

* [ ] Tests added
  * [ ] Good Path
  * [ ] Error Path
* [ ] Commits follow conventions described here:
  * [ ] [https://conventionalcommits.org/en/v1.0.0-beta.4/#summary](https://conventionalcommits.org/en/v1.0.0-beta.4/#summary)
  * [ ] [https://chris.beams.io/posts/git-commit/#seven-rules](https://chris.beams.io/posts/git-commit/#seven-rules)
* [ ] Commits are squashed such that
  * [ ] There is 1 commit per isolated change
* [ ] I've not made extraneous commits/changes that are unrelated to my change.
