### PR TITLE
Allow import/export of session

### DIFF
--- a/authentication.go
+++ b/authentication.go
@@ -44,7 +44,19 @@ type Session struct {
 		LastFailedLoginTime string `json:"lastFailedLoginTime"`
 		PreviousLoginTime   string `json:"previousLoginTime"`
 	} `json:"loginInfo"`
-	Cookies []*http.Cookie
+	Cookies []*http.Cookie `json:"cookies"`
+}
+
+// ExportSession exports the current session so it can be reused later
+func (s *AuthenticationService) ExportSession() []byte {
+	session, _ := json.Marshal(s.client.session)
+	return session
+}
+
+// ImportSession imports a session
+func (s *AuthenticationService) ImportSession(session []byte) {
+	_ = json.Unmarshal(session, &s.client.session)
+	s.authType = authTypeSession
 }
 
 // AcquireSessionCookie creates a new session for a user in JIRA.


### PR DESCRIPTION
# PR Description
This adds two methods ImportSession and ExportSession.  This allows caching the authentication token so that a short lived script does not need to re-authenticate every time it runs.  This allows for fewer requests.

# Checklist

* [ ] Tests added
  * [ ] Good Path
  * [ ] Error Path
* [ ] Commits follow conventions described here:
  * [ ] [https://conventionalcommits.org/en/v1.0.0-beta.4/#summary](https://conventionalcommits.org/en/v1.0.0-beta.4/#summary)
  * [ ] [https://chris.beams.io/posts/git-commit/#seven-rules](https://chris.beams.io/posts/git-commit/#seven-rules)
* [ ] Commits are squashed such that
  * [ ] There is 1 commit per isolated change
* [ ] I've not made extraneous commits/changes that are unrelated to my change.
