### PR TITLE
Add GetEditMeta

### DIFF
--- a/metaissue.go
+++ b/metaissue.go
@@ -14,6 +14,11 @@ type CreateMetaInfo struct {
 	Projects []*MetaProject `json:"projects,omitempty"`
 }
 
+// EditMetaInfo contains information about fields and their attributed to edit a ticket.
+type EditMetaInfo struct {
+	Fields tcontainer.MarshalMap `json:"fields,omitempty"`
+}
+
 // MetaProject is the meta information about a project returned from createmeta api
 type MetaProject struct {
 	Expand string `json:"expand,omitempty"`
@@ -64,6 +69,25 @@ func (s *IssueService) GetCreateMetaWithOptions(options *GetQueryOptions) (*Crea
 	}
 
 	meta := new(CreateMetaInfo)
+	resp, err := s.client.Do(req, meta)
+
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return meta, resp, nil
+}
+
+// GetEditMeta makes the api call to get the edit meta information for an issue
+func (s *IssueService) GetEditMeta(issue *Issue) (*EditMetaInfo, *Response, error) {
+	apiEndpoint := fmt.Sprintf("/rest/api/2/issue/%s/editmeta", issue.Key)
+
+	req, err := s.client.NewRequest("GET", apiEndpoint, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	meta := new(EditMetaInfo)
 	resp, err := s.client.Do(req, meta)
 
 	if err != nil {

--- a/metaissue_test.go
+++ b/metaissue_test.go
@@ -3,6 +3,7 @@ package jira
 import (
 	"fmt"
 	"net/http"
+	"strings"
 	"testing"
 )
 
@@ -376,6 +377,84 @@ func TestIssueService_GetCreateMeta_Success(t *testing.T) {
 		}
 	}
 
+}
+
+func TestIssueService_GetEditMeta_Success(t *testing.T) {
+	setup()
+	defer teardown()
+
+	testAPIEndpoint := "/rest/api/2/issue/PROJ-9001/editmeta"
+
+	testMux.HandleFunc(testAPIEndpoint, func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "GET")
+		testRequestURL(t, r, testAPIEndpoint)
+
+		fmt.Fprint(w, `{
+	"fields": {
+		"summary": {
+			"required": true,
+			"schema": {
+				"type": "string",
+				"system": "summary"
+			},
+			"name": "Summary",
+			"hasDefaultValue": false,
+			"operations": [
+				"set"
+			]
+		},
+		"attachment": {
+			"required": false,
+			"schema": {
+				"type": "array",
+				"items": "attachment",
+				"system": "attachment"
+			},
+			"name": "Attachment",
+			"hasDefaultValue": false,
+			"operations": [
+
+			]
+		}
+	}
+	}`)
+	})
+
+	editMeta, _, err := testClient.Issue.GetEditMeta(&Issue{Key: "PROJ-9001"})
+	if err != nil {
+		t.Errorf("Expected nil error but got %s", err)
+	}
+
+	requiredFields := 0
+	fields := editMeta.Fields
+	for _, value := range fields {
+		for key, value := range value.(map[string]interface{}) {
+			if key == "required" && value == true {
+				requiredFields = requiredFields + 1
+			}
+		}
+
+	}
+	summary := fields["summary"].(map[string]interface{})
+	attachment := fields["attachment"].(map[string]interface{})
+	if summary["required"] != true {
+		t.Error("Expected summary to be required")
+	}
+	if attachment["required"] != false {
+		t.Error("Expected attachment to not be required")
+	}
+}
+
+func TestIssueService_GetEditMeta_Fail(t *testing.T) {
+	_, _, err := testClient.Issue.GetEditMeta(&Issue{Key: "PROJ-9001"})
+	if err == nil {
+		t.Error("Expected to receive an error, received nil instead")
+	}
+
+	expectedError := "connection refused"
+	if !strings.Contains(err.Error(), expectedError) {
+		t.Errorf("Expected to receive error containing %s, received %v instead", expectedError, err.Error())
+	}
 }
 
 func TestMetaIssueType_GetCreateMetaWithOptions(t *testing.T) {


### PR DESCRIPTION
# PR Description
This adds the GetEditMeta function.  API docs: https://docs.atlassian.com/DAC/rest/jira/6.1.html#d2e1364

# Checklist

* [x] Tests added
  * [x] Good Path
  * [x] Error Path
* [x] Commits follow conventions described here:
  * [x] [https://conventionalcommits.org/en/v1.0.0-beta.4/#summary](https://conventionalcommits.org/en/v1.0.0-beta.4/#summary)
  * [x] [https://chris.beams.io/posts/git-commit/#seven-rules](https://chris.beams.io/posts/git-commit/#seven-rules)
* [x] Commits are squashed such that
  * [x] There is 1 commit per isolated change
* [x] I've not made extraneous commits/changes that are unrelated to my change.
