### PR TITLE
fix: change millisecond time format

### DIFF
--- a/issue.go
+++ b/issue.go
@@ -351,7 +351,7 @@ func (t *Time) UnmarshalJSON(b []byte) error {
 // MarshalJSON will transform the time.Time into a JIRA time
 // during the creation of a JIRA request
 func (t Time) MarshalJSON() ([]byte, error) {
-	return []byte(time.Time(t).Format("\"2006-01-02T15:04:05.999-0700\"")), nil
+	return []byte(time.Time(t).Format("\"2006-01-02T15:04:05.000-0700\"")), nil
 }
 
 // UnmarshalJSON will transform the JIRA date into a time.Time

--- a/issue_test.go
+++ b/issue_test.go
@@ -9,11 +9,9 @@ import (
 	"reflect"
 	"strings"
 	"testing"
-
-	"github.com/google/go-cmp/cmp"
-
 	"time"
 
+	"github.com/google/go-cmp/cmp"
 	"github.com/trivago/tgo/tcontainer"
 )
 
@@ -1797,5 +1795,36 @@ func TestIssueService_AddRemoteLink(t *testing.T) {
 	}
 	if err != nil {
 		t.Errorf("Error given: %s", err)
+	}
+}
+
+func TestTime_MarshalJSON(t *testing.T) {
+	timeFormatParseFrom := "2006-01-02T15:04:05.999Z"
+	testCases := []struct {
+		name      string
+		inputTime string
+		expected  string
+	}{
+		{
+			name:      "test without ms",
+			inputTime: "2020-04-01T01:01:01.000Z",
+			expected:  "\"2020-04-01T01:01:01.000+0000\"",
+		},
+		{
+			name:      "test with ms",
+			inputTime: "2020-04-01T01:01:01.001Z",
+			expected:  "\"2020-04-01T01:01:01.001+0000\"",
+		},
+	}
+
+	for _, tt := range testCases {
+		t.Run(tt.name, func(t *testing.T) {
+			rawTime, _ := time.Parse(timeFormatParseFrom, tt.inputTime)
+			time := Time(rawTime)
+			got, _ := time.MarshalJSON()
+			if string(got) != tt.expected {
+				t.Errorf("Time.MarshalJSON() = %v, want %v", string(got), tt.expected)
+			}
+		})
 	}
 }


### PR DESCRIPTION
# PR Description

If millisecond in go time is empty
they will be not exist in result string
if using "999" in format. And jira api
will response with error in the case.

Using "000" fix the problem.

Add test.

# Checklist

* [x] Tests added – do not needed
  * [x] Good Path
  * [x] Error Path
* [x] Commits follow conventions described here:
  * [x] [https://conventionalcommits.org/en/v1.0.0-beta.4/#summary](https://conventionalcommits.org/en/v1.0.0-beta.4/#summary)
  * [x] [https://chris.beams.io/posts/git-commit/#seven-rules](https://chris.beams.io/posts/git-commit/#seven-rules)
* [x] Commits are squashed such that
  * [x] There is 1 commit per isolated change
* [x] I've not made extraneous commits/changes that are unrelated to my change.
