### PR TITLE
Add ISSUE_TEMPLATES to guide users and contributors (for bugs and feature requests)

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,51 @@
+---
+name: Bug report
+about: Create a report to help us improve
+title: ''
+labels: ''
+assignees: ''
+
+---
+
+## Describe the bug
+
+A clear and concise description of what the bug is.
+
+Formatting tips: GitHub supports Markdown: https://guides.github.com/features/mastering-markdown/
+
+## To Reproduce
+
+Provide a link to a live example, or an unambiguous set of steps to reproduce this bug. Include configuration, logs, etc. to reproduce, if relevant.
+
+1.
+2.
+3.
+4.
+
+## Expected behavior
+
+A clear and concise description of what you expected to happen.
+
+## Possible Solution
+
+Not obligatory, but suggest a fix/reason for the bug, or ideas how to implement: the addition or change.
+
+## Your Environment
+
+Include as many relevant details about the environment you experienced the problem in
+
+* go-jira version (git tag or sha):
+* Go version (`go version`):
+* Jira version:
+* Jira type (cloud or on-premise):
+* Involved Jira plugins:
+* Operating System and version:
+
+## Additional context
+
+Add any other context about the problem here.
+
+How has this issue affected you? What are you trying to accomplish?
+Providing context helps us come up with a solution that is most useful in the real world.
+
+

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,4 @@
+contact_links:
+  - name: Report a bug/feature request for the Jira Command Line Client
+    url: https://github.com/go-jira/jira/issues
+    about: This is the issue tracker for the Jira command-line client in Go. If you are using this, please report issues there.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,24 @@
+---
+name: Feature request
+about: Suggest an idea for this project
+title: ''
+labels: ''
+assignees: ''
+
+---
+
+## Is your feature request related to a problem? Please describe.
+
+A clear and concise description of what the problem is. Ex. I'm always using this feature but am missing [...]
+
+## Describe the solution you'd like
+
+A clear and concise description of what you want to happen.
+
+## Describe alternatives you've considered
+
+A clear and concise description of any alternative solutions or features you've considered.
+
+## Additional context
+
+Add any other context or screenshots about the feature request here.


### PR DESCRIPTION
# PR Description

This PR adds two issue-templates and one issue configuration:

* A template for bug reports that ask for details
* A template for feature requests

These templates should help us (maintainers) and users to add all relevant information.
Additionally, it guides users and lets them know what is needed to fulfill such a request.

On top of this, we provide a link to the issue tracker of https://github.com/go-jira/jira
Every now and then, we get issues of the CLI tool go-jira.
(hey @coryb, have a look :) )

The templates are inspired by the Icinga2 project (https://github.com/Icinga/icinga2/tree/master/.github/ISSUE_TEMPLATE). Thanks goes to them!

# Checklist

* [X] Tests added
  * [X] Good Path
  * [x] Error Path
* [x] Commits follow conventions described here:
  * [x] [https://conventionalcommits.org/en/v1.0.0-beta.4/#summary](https://conventionalcommits.org/en/v1.0.0-beta.4/#summary)
  * [x] [https://chris.beams.io/posts/git-commit/#seven-rules](https://chris.beams.io/posts/git-commit/#seven-rules)
* [X] Commits are squashed such that
  * [X] There is 1 commit per isolated change
* [X] I've not made extraneous commits/changes that are unrelated to my change.

Notes:
* Tests not needed