### PR TITLE
feat: Add Names support on Issue struct

### DIFF
--- a/issue.go
+++ b/issue.go
@@ -47,6 +47,7 @@ type Issue struct {
 	RenderedFields *IssueRenderedFields `json:"renderedFields,omitempty" structs:"renderedFields,omitempty"`
 	Changelog      *Changelog           `json:"changelog,omitempty" structs:"changelog,omitempty"`
 	Transitions    []Transition         `json:"transitions,omitempty" structs:"transitions,omitempty"`
+	Names          map[string]string    `json:"names,omitempty" structs:"names,omitempty"`
 }
 
 // ChangelogItems reflects one single changelog item of a history item

--- a/sprint_test.go
+++ b/sprint_test.go
@@ -89,6 +89,23 @@ func TestSprintService_GetIssue(t *testing.T) {
 	if len(issue.Fields.Comments.Comments) != 1 {
 		t.Errorf("Expected one comment, %v found", len(issue.Fields.Comments.Comments))
 	}
+	if len(issue.Names) != 10 {
+		t.Errorf("Expected 10 names, %v found", len(issue.Names))
+	}
+	if !reflect.DeepEqual(issue.Names, map[string]string{
+		"watcher":      "watcher",
+		"attachment":   "attachment",
+		"sub-tasks":    "sub-tasks",
+		"description":  "description",
+		"project":      "project",
+		"comment":      "comment",
+		"issuelinks":   "issuelinks",
+		"worklog":      "worklog",
+		"updated":      "updated",
+		"timetracking": "timetracking",
+	}) {
+		t.Error("Expected names for the returned issue")
+	}
 	if err != nil {
 		t.Errorf("Error given: %s", err)
 	}


### PR DESCRIPTION
# PR Description
Adds support for the `expand=names` field on the `Issue` struct. Ex:
```json
{
   "id": "1234",
   "names": {
       "customfield_56789": "Sprint",
       "reporter": "Reporter"
    }
}
```
From [JIRA API: Issues -> Get Issue](https://developer.atlassian.com/cloud/jira/platform/rest/v3/?utm_source=%2Fcloud%2Fjira%2Fplatform%2Frest%2F&utm_medium=302#api-rest-api-3-issue-issueIdOrKey-get):
>Use expand to include additional information about the issues in the response. This parameter accepts a comma-separated list. Expand options include:
> * names Returns the display name of each field.

# Checklist

* [x] Tests added
  * [x] Good Path
  * [ ] Error Path
* [x] Commits follow conventions described here:
  * [x] [https://conventionalcommits.org/en/v1.0.0-beta.4/#summary](https://conventionalcommits.org/en/v1.0.0-beta.4/#summary)
  * [x] [https://chris.beams.io/posts/git-commit/#seven-rules](https://chris.beams.io/posts/git-commit/#seven-rules)
* [x] Commits are squashed such that
  * [x] There is 1 commit per isolated change
* [x] I've not made extraneous commits/changes that are unrelated to my change.
