### PR TITLE
feat: Extend Makefile for more source code quality targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,2 +1,25 @@
-test:
-	go test -v ./...
+.DEFAULT_GOAL := help
+
+.PHONY: help
+help: ## Outputs the help.
+	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'
+
+.PHONY: test
+test: ## Runs all unit, integration and example tests.
+	go test -race -v ./...
+
+.PHONY: vet
+vet: ## Runs go vet (to detect suspicious constructs).
+	go vet ./...
+
+.PHONY: fmt
+fmt: ## Runs go fmt (to check for go coding guidelines).
+	gofmt -d -s .
+
+.PHONY: staticcheck
+staticcheck: ## Runs static analysis to prevend bugs, foster code simplicity, performance and editor integration.
+	go get -u honnef.co/go/tools/cmd/staticcheck
+	staticcheck ./...
+
+.PHONY: all
+all: test vet fmt staticcheck ## Runs all source code quality targets (like test, vet, fmt, staticcheck)


### PR DESCRIPTION
# PR Description

The Makefile contains now additional commands to support
during development and aim for a higher source code quality:

- go vet
- go fmt
- same unit tests run command like travis
- static analysis
- and a target to run all together

The basic idea is (once it is merged):
- to include the same make commands in our CI / PR checks
- to add this to the contribution guidelines / docs

# Checklist

* [x] Tests added
  * [x] Good Path
  * [x] Error Path
* [x] Commits follow conventions described here:
  * [x] [https://conventionalcommits.org/en/v1.0.0-beta.4/#summary](https://conventionalcommits.org/en/v1.0.0-beta.4/#summary)
  * [x] [https://chris.beams.io/posts/git-commit/#seven-rules](https://chris.beams.io/posts/git-commit/#seven-rules)
* [x] Commits are squashed such that
  * [x] There is 1 commit per isolated change
* [x] I've not made extraneous commits/changes that are unrelated to my change.
