### PR TITLE
chore: Added go v1.14 to TravisCI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,13 +8,10 @@ go:
   - "1.11.x"
   - "1.12.x"
   - "1.13.x"
+  - "1.14.x"
 
 before_install:
   - go get -t ./...
-
-matrix:
-  allow_failures:
-    - go: 1.13.x
 
 script:
   - GOMAXPROCS=4 GORACE="halt_on_error=1" go test -race -v ./...


### PR DESCRIPTION
# PR Description

go v1.14 was released, but we don't test for it right now.

Additionally, the allowed failure for go v1.13 is removed, because this library should support this version (and it is not marked as not supported).

# Checklist

* [X] Tests added
  * [X] Good Path
  * [X] Error Path
* [X] Commits follow conventions described here:
  * [x] [https://conventionalcommits.org/en/v1.0.0-beta.4/#summary](https://conventionalcommits.org/en/v1.0.0-beta.4/#summary)
  * [X] [https://chris.beams.io/posts/git-commit/#seven-rules](https://chris.beams.io/posts/git-commit/#seven-rules)
* [X] Commits are squashed such that
  * [X] There is 1 commit per isolated change
* [X] I've not made extraneous commits/changes that are unrelated to my change.
