### PR TITLE
feat(project): Add cronjob to check for stale issues

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,19 @@
+name: "Close stale issues"
+on:
+  schedule:
+  - cron: "0 4 * * *"
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/stale@v1.1.0
+      with:
+        repo-token: ${{ secrets.GITHUB_TOKEN }}
+        stale-issue-message: >
+          This issue has been automatically marked as stale because it has not had
+          recent activity in the last 60 days. It will be closed in 7 days if no further activity occurs.
+          Thank you for your contributions.
+        days-before-stale: 60
+        days-before-close: 7
+        stale-issue-label: stale


### PR DESCRIPTION
# Description

GitHub actions is a workflow engine.
The stale workflow helps us to keep the issue tracker up to date.
Issues that don't have activity since 60 days will be marked as
stale and closed eventually.

# Checklist

* [ ] Unit or Integration tests added
  * [ ] Good Path
  * [ ] Error Path
* [X] Commits follow conventions described here:
  * [X] [Conventional Commits 1.0.0](https://conventionalcommits.org/en/v1.0.0-beta.4/#summary)
  * [X] [The seven rules of a great Git commit message](https://chris.beams.io/posts/git-commit/#seven-rules)
* [X] Commits are squashed such that
  * [X] There is 1 commit per isolated change
* [X] I've not made extraneous commits/changes that are unrelated to my change.
