### PR TITLE
fix(issue): IssueService.Search() with a not empty JQL triggers 400 bad request

### DIFF
--- a/examples/jql/main.go
+++ b/examples/jql/main.go
@@ -1,0 +1,42 @@
+package main
+
+import (
+	"fmt"
+
+	jira "github.com/andygrunwald/go-jira"
+)
+
+func main() {
+	jiraClient, _ := jira.NewClient(nil, "https://issues.apache.org/jira/")
+
+	// Running JQL query
+
+	jql := "project = Mesos and type = Bug and Status NOT IN (Resolved)"
+	fmt.Printf("Usecase: Running a JQL query '%s'\n", jql)
+	issues, resp, err := jiraClient.Issue.Search(jql, nil)
+	if err != nil {
+		panic(err)
+	}
+	outputResponse(issues, resp)
+
+	fmt.Println("")
+	fmt.Println("")
+
+	// Running an empty JQL query to get all tickets
+	jql = ""
+	fmt.Printf("Usecase: Running an empty JQL query to get all tickets\n")
+	issues, resp, err = jiraClient.Issue.Search(jql, nil)
+	if err != nil {
+		panic(err)
+	}
+	outputResponse(issues, resp)
+}
+
+func outputResponse(issues []jira.Issue, resp *jira.Response) {
+	fmt.Printf("Call to %s\n", resp.Request.URL)
+	fmt.Printf("Response Code: %d\n", resp.StatusCode)
+	fmt.Println("==================================")
+	for _, i := range issues {
+		fmt.Printf("%s (%s/%s): %+v\n", i.Key, i.Fields.Type.Name, i.Fields.Priority.Name, i.Fields.Summary)
+	}
+}

--- a/issue.go
+++ b/issue.go
@@ -963,7 +963,7 @@ func (s *IssueService) Search(jql string, options *SearchOptions) ([]Issue, *Res
 	}
 	uv := url.Values{}
 	if jql != "" {
-		uv.Add("jql", url.QueryEscape(jql))
+		uv.Add("jql", jql)
 	}
 
 	if options != nil {

--- a/issue_test.go
+++ b/issue_test.go
@@ -598,13 +598,13 @@ func TestIssueService_Search(t *testing.T) {
 	defer teardown()
 	testMux.HandleFunc("/rest/api/2/search", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
-		testRequestURL(t, r, "/rest/api/2/search?expand=foo&jql=something&maxResults=40&startAt=1")
+		testRequestURL(t, r, "/rest/api/2/search?expand=foo&jql=type+%3D+Bug+and+Status+NOT+IN+%28Resolved%29&maxResults=40&startAt=1")
 		w.WriteHeader(http.StatusOK)
 		fmt.Fprint(w, `{"expand": "schema,names","startAt": 1,"maxResults": 40,"total": 6,"issues": [{"expand": "html","id": "10230","self": "http://kelpie9:8081/rest/api/2/issue/BULK-62","key": "BULK-62","fields": {"summary": "testing","timetracking": null,"issuetype": {"self": "http://kelpie9:8081/rest/api/2/issuetype/5","id": "5","description": "The sub-task of the issue","iconUrl": "http://kelpie9:8081/images/icons/issue_subtask.gif","name": "Sub-task","subtask": true},"customfield_10071": null}},{"expand": "html","id": "10004","self": "http://kelpie9:8081/rest/api/2/issue/BULK-47","key": "BULK-47","fields": {"summary": "Cheese v1 2.0 issue","timetracking": null,"issuetype": {"self": "http://kelpie9:8081/rest/api/2/issuetype/3","id": "3","description": "A task that needs to be done.","iconUrl": "http://kelpie9:8081/images/icons/task.gif","name": "Task","subtask": false}}}]}`)
 	})
 
 	opt := &SearchOptions{StartAt: 1, MaxResults: 40, Expand: "foo"}
-	_, resp, err := testClient.Issue.Search("something", opt)
+	_, resp, err := testClient.Issue.Search("type = Bug and Status NOT IN (Resolved)", opt)
 
 	if resp == nil {
 		t.Errorf("Response given: %+v", resp)


### PR DESCRIPTION
## Description

The JQL search term is escaped twice.

closes issue #291

The unit test did not fire a proper JQL query (with whitespace, etc.). Hence this was not caught.
Additionally, I added a new example.

# Checklist

* [X] Unit or Integration tests added
  * [X] Good Path
  * [X] Error Path
* [X] Commits follow conventions described here:
  * [X] [Conventional Commits 1.0.0](https://conventionalcommits.org/en/v1.0.0-beta.4/#summary)
  * [X] [The seven rules of a great Git commit message](https://chris.beams.io/posts/git-commit/#seven-rules)
* [X] Commits are squashed such that
  * [X] There is 1 commit per isolated change
* [X] I've not made extraneous commits/changes that are unrelated to my change.
