### PR TITLE
chore(test): Remove unit testing log output for success cases

### DIFF
--- a/issue_test.go
+++ b/issue_test.go
@@ -583,13 +583,10 @@ func TestIssueService_DeleteAttachment(t *testing.T) {
 		if resp.StatusCode == 404 {
 			t.Error("Attachment not found")
 		}
-	} else {
-		t.Log("Attachment deleted")
 	}
+
 	if err != nil {
 		t.Errorf("Error given: %s", err)
-	} else {
-		t.Log("No error")
 	}
 }
 


### PR DESCRIPTION
# Description

During running the unit tests we see output like

=== RUN   TestIssueService_DeleteAttachment
    TestIssueService_DeleteAttachment: issue_test.go:587: Attachment deleted
    TestIssueService_DeleteAttachment: issue_test.go:592: No error

This log can be removed because this mostly confirms the success case.
The opposite case is throwing a testing error, which is visible as well.
Hence, there is no need to log these messages during testing

# Checklist

* [ ] Unit or Integration tests added
  * [ ] Good Path
  * [ ] Error Path
* [X] Commits follow conventions described here:
  * [X] [Conventional Commits 1.0.0](https://conventionalcommits.org/en/v1.0.0-beta.4/#summary)
  * [X] [The seven rules of a great Git commit message](https://chris.beams.io/posts/git-commit/#seven-rules)
* [X] Commits are squashed such that
  * [X] There is 1 commit per isolated change
* [X] I've not made extraneous commits/changes that are unrelated to my change.
