### PR TITLE
Make basic auth deprecation more clear in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,9 +92,11 @@ an `http.Client`.  That client can then be passed into the `NewClient` function 
 
 For convenience, capability for basic and cookie-based authentication is included in the main library.
 
-#### Basic auth example
+#### Token (Jira on Atlassian Cloud)
 
-A more thorough, [runnable example](examples/basicauth/main.go) is provided in the examples directory. **It's worth noting that using passwords in basic auth is now deprecated and will be removed.** Jira gives you the ability to [create tokens now.](https://confluence.atlassian.com/cloud/api-tokens-938839638.html)
+Token-based authentication uses the basic authentication scheme, with a user-generated API token in place of a user's password. You can generate a token for your user [here](https://id.atlassian.com/manage-profile/security/api-tokens). Additional information about Atlassian Cloud API tokens can be found [here](https://confluence.atlassian.com/cloud/api-tokens-938839638.html).
+
+A more thorough, [runnable example](examples/basicauth/main.go) is provided in the examples directory.
 
 ```go
 func main() {
@@ -111,10 +113,11 @@ func main() {
 }
 ```
 
-#### Authenticate with session cookie [DEPRECATED]
+#### Basic (self-hosted Jira)
 
-Jira [deprecated this authentication method.](https://developer.atlassian.com/cloud/jira/platform/deprecation-notice-basic-auth-and-cookie-based-auth/)  It's not longer available for use.
+Password-based API authentication works for self-hosted Jira **only**, and has been [deprecated for users of Atlassian Cloud](https://developer.atlassian.com/cloud/jira/platform/deprecation-notice-basic-auth-and-cookie-based-auth/).
 
+The above token authentication example may be used, substituting a user's password for a generated token.
 
 #### Authenticate with OAuth
 


### PR DESCRIPTION
Atlassian has deprecated password-based basic authentication for users
of Atlassian Cloud, but it remains useable for users with a self-hosted
Jira. Update the README to make this more clear.

closes #317

# Description

Please describe _what does this Pull Request fix or add?_.

Information that is useful here:
* **The What**: What is your change doing?
* **The Why**: Why is your change useful/needed? What is your use case? (this helps us to understand the real world better)
* **Type of change**: Things like Bugfix, New feature, Code quality improvements, Dependency upgrade, Documentation, ...
* **Breaking change**: Yes or no? Backward compatible?
* **Related to an issue**: Does this fix or close an issue? Or is related in any kind?
* **Jira Version + Type**: Which Jira version and type (on-premise / cloud) you have used?

## Example:

Let us know how users can use or test this functionality.

```go
// Example code

```

# Checklist

* [ ] Unit or Integration tests added
  * [ ] Good Path
  * [ ] Error Path
* [ ] Commits follow conventions described here:
  * [ ] [Conventional Commits 1.0.0](https://conventionalcommits.org/en/v1.0.0-beta.4/#summary)
  * [ ] [The seven rules of a great Git commit message](https://chris.beams.io/posts/git-commit/#seven-rules)
* [ ] Commits are squashed such that
  * [ ] There is 1 commit per isolated change
* [ ] I've not made extraneous commits/changes that are unrelated to my change.
