### PR TITLE
Add Items and Custom to FieldSchema

### DIFF
--- a/field.go
+++ b/field.go
@@ -24,8 +24,8 @@ type Field struct {
 // FieldSchema represents a schema of a Jira field.
 type FieldSchema struct {
 	Type   string `json:"type,omitempty" structs:"type,omitempty"`
-	Items  string `json:"items,omitempty", structs:"items,omitempty"`
-	Custom string `json:"custom,omitempty", structs:"items,omitempty"`
+	Items  string `json:"items,omitempty" structs:"items,omitempty"`
+	Custom string `json:"custom,omitempty" structs:"items,omitempty"`
 	System string `json:"system,omitempty" structs:"system,omitempty"`
 }
 

--- a/field.go
+++ b/field.go
@@ -21,8 +21,11 @@ type Field struct {
 	Schema      FieldSchema `json:"schema,omitempty" structs:"schema,omitempty"`
 }
 
+// FieldSchema represents a schema of a Jira field.
 type FieldSchema struct {
 	Type   string `json:"type,omitempty" structs:"type,omitempty"`
+	Items  string `json:"items,omitempty", structs:"items,omitempty"`
+	Custom string `json:"custom,omitempty", structs:"items,omitempty"`
 	System string `json:"system,omitempty" structs:"system,omitempty"`
 }
 

--- a/field.go
+++ b/field.go
@@ -22,11 +22,13 @@ type Field struct {
 }
 
 // FieldSchema represents a schema of a Jira field.
+// Documentation: https://developer.atlassian.com/cloud/jira/platform/rest/v2/api-group-issue-fields/#api-rest-api-2-field-get
 type FieldSchema struct {
 	Type   string `json:"type,omitempty" structs:"type,omitempty"`
 	Items  string `json:"items,omitempty" structs:"items,omitempty"`
-	Custom string `json:"custom,omitempty" structs:"items,omitempty"`
+	Custom string `json:"custom,omitempty" structs:"custom,omitempty"`
 	System string `json:"system,omitempty" structs:"system,omitempty"`
+	CustomID int64 `json:"customId,omitempty" structs:"customId,omitempty"`
 }
 
 // GetListWithContext gets all fields from Jira

--- a/field.go
+++ b/field.go
@@ -24,11 +24,11 @@ type Field struct {
 // FieldSchema represents a schema of a Jira field.
 // Documentation: https://developer.atlassian.com/cloud/jira/platform/rest/v2/api-group-issue-fields/#api-rest-api-2-field-get
 type FieldSchema struct {
-	Type   string `json:"type,omitempty" structs:"type,omitempty"`
-	Items  string `json:"items,omitempty" structs:"items,omitempty"`
-	Custom string `json:"custom,omitempty" structs:"custom,omitempty"`
-	System string `json:"system,omitempty" structs:"system,omitempty"`
-	CustomID int64 `json:"customId,omitempty" structs:"customId,omitempty"`
+	Type     string `json:"type,omitempty" structs:"type,omitempty"`
+	Items    string `json:"items,omitempty" structs:"items,omitempty"`
+	Custom   string `json:"custom,omitempty" structs:"custom,omitempty"`
+	System   string `json:"system,omitempty" structs:"system,omitempty"`
+	CustomID int64  `json:"customId,omitempty" structs:"customId,omitempty"`
 }
 
 // GetListWithContext gets all fields from Jira


### PR DESCRIPTION
# Description

Please describe _what does this Pull Request fix or add?_.
Adding `Items` and `Custom` to `FieldSchema` so they can be used to determine the data type of a Jira field.

Information that is useful here:
* **The What**: Adding `Items` and `Custom` to `FieldSchema`
* **The Why**: For example, the `Type` can be `array` and the `Items` can be `string` or some other type. It is useful to have that information if the user wants to get more information about the data type 
* **Type of change**: New feature
* **Breaking change**: No
* **Related to an issue**: Does this fix or close an issue? Or is related in any kind?
* **Jira Version + Type**: Cloud

## Example:

Let us know how users can use or test this functionality.

```go
// Example code

```

# Checklist

* [ ] Unit or Integration tests added
  * [ ] Good Path
  * [ ] Error Path
* [ ] Commits follow conventions described here:
  * [ ] [Conventional Commits 1.0.0](https://conventionalcommits.org/en/v1.0.0-beta.4/#summary)
  * [ ] [The seven rules of a great Git commit message](https://chris.beams.io/posts/git-commit/#seven-rules)
* [ ] Commits are squashed such that
  * [ ] There is 1 commit per isolated change
* [ ] I've not made extraneous commits/changes that are unrelated to my change.
