### PR TITLE
Added property "StartedAfter" to GetWorklogsQueryOptions struct accor…

### DIFF
--- a/issue.go
+++ b/issue.go
@@ -533,9 +533,10 @@ type GetQueryOptions struct {
 
 // GetWorklogsQueryOptions specifies the optional parameters for the Get Worklogs method
 type GetWorklogsQueryOptions struct {
-	StartAt    int64  `url:"startAt,omitempty"`
-	MaxResults int32  `url:"maxResults,omitempty"`
-	Expand     string `url:"expand,omitempty"`
+	StartAt    	int64  `url:"startAt,omitempty"`
+	MaxResults 	int32  `url:"maxResults,omitempty"`
+	StartedAfter    int64  `url:"startedAfter,omitempty"`
+	Expand     	string `url:"expand,omitempty"`
 }
 
 type AddWorklogQueryOptions struct {

--- a/issue.go
+++ b/issue.go
@@ -533,10 +533,10 @@ type GetQueryOptions struct {
 
 // GetWorklogsQueryOptions specifies the optional parameters for the Get Worklogs method
 type GetWorklogsQueryOptions struct {
-	StartAt    	int64  `url:"startAt,omitempty"`
-	MaxResults 	int32  `url:"maxResults,omitempty"`
-	StartedAfter    int64  `url:"startedAfter,omitempty"`
-	Expand     	string `url:"expand,omitempty"`
+	StartAt      int64  `url:"startAt,omitempty"`
+	MaxResults   int32  `url:"maxResults,omitempty"`
+	StartedAfter int64  `url:"startedAfter,omitempty"`
+	Expand       string `url:"expand,omitempty"`
 }
 
 type AddWorklogQueryOptions struct {


### PR DESCRIPTION
# Description

Imprevement: Added property "StartedAfter" to GetWorklogsQueryOptions struct according to official API documentation. It allows to filter WorkLog list by indicating the starting date.

The property is documented here (Jira API official documentation) https://developer.atlassian.com/cloud/jira/platform/rest/v3/api-group-issue-worklogs/
however there is a known bug so at this moent this parameter is ignored https://jira.atlassian.com/browse/JRACLOUD-73630?error=login_required&error_description=Login+required&state=e6bbdd57-72bf-4334-98ec-248e519e7337
Hopefully it will be fixed in the future.  Adding the parameter is not affecting the query.


## Example:

```go
	jiraClient, _ := jira.NewClient(tp.Client(), cfg.Jira.Host)
	dateStart := int64(time.Now().Unix())
	var op * jira.GetWorklogsQueryOptions = &jira.GetWorklogsQueryOptions{Expand: "properties", StartedAfter: dateStart}
	issue, _, err := jiraClient.Issue.GetWorklogs(issueid, jira.WithQueryOptions(op))
```

# Checklist

* [x] Unit tests passed localy
* [ ] Unit or Integration tests added
  * [ ] Good Path
  * [ ] Error Path
* [ ] Commits follow conventions described here:
  * [ ] [Conventional Commits 1.0.0](https://conventionalcommits.org/en/v1.0.0-beta.4/#summary)
  * [ ] [The seven rules of a great Git commit message](https://chris.beams.io/posts/git-commit/#seven-rules)
* [ ] Commits are squashed such that
  * [ ] There is 1 commit per isolated change
* [ ] I've not made extraneous commits/changes that are unrelated to my change.
