### PR TITLE
Add options to GetIssuesForSprint

### DIFF
--- a/sprint.go
+++ b/sprint.go
@@ -23,6 +23,11 @@ type IssuesInSprintResult struct {
 	Issues []Issue `json:"issues"`
 }
 
+type GetIssuesForSprintOptions struct {
+	SearchOptions
+	Jql string `url:"jql,omitempty"`
+}
+
 // MoveIssuesToSprintWithContext moves issues to a sprint, for a given sprint Id.
 // Issues can only be moved to open or active sprints.
 // The maximum number of issues that can be moved in one operation is 50.
@@ -56,10 +61,15 @@ func (s *SprintService) MoveIssuesToSprint(sprintID int, issueIDs []string) (*Re
 // By default, the returned issues are ordered by rank.
 //
 // Jira API Docs: https://docs.atlassian.com/jira-software/REST/cloud/#agile/1.0/sprint-getIssuesForSprint
-func (s *SprintService) GetIssuesForSprintWithContext(ctx context.Context, sprintID int) ([]Issue, *Response, error) {
+func (s *SprintService) GetIssuesForSprintWithContext(ctx context.Context, sprintID int, options *GetIssuesForSprintOptions) ([]Issue, *Response, error) {
 	apiEndpoint := fmt.Sprintf("rest/agile/1.0/sprint/%d/issue", sprintID)
 
-	req, err := s.client.NewRequestWithContext(ctx, "GET", apiEndpoint, nil)
+	url, err := addOptions(apiEndpoint, options)
+	if err != nil {
+		return nil, nil, fmt.Errorf("add options: %w", err)
+	}
+
+	req, err := s.client.NewRequestWithContext(ctx, "GET", url, nil)
 
 	if err != nil {
 		return nil, nil, err
@@ -75,8 +85,8 @@ func (s *SprintService) GetIssuesForSprintWithContext(ctx context.Context, sprin
 }
 
 // GetIssuesForSprint wraps GetIssuesForSprintWithContext using the background context.
-func (s *SprintService) GetIssuesForSprint(sprintID int) ([]Issue, *Response, error) {
-	return s.GetIssuesForSprintWithContext(context.Background(), sprintID)
+func (s *SprintService) GetIssuesForSprint(sprintID int, options *GetIssuesForSprintOptions) ([]Issue, *Response, error) {
+	return s.GetIssuesForSprintWithContext(context.Background(), sprintID, options)
 }
 
 // GetIssueWithContext returns a full representation of the issue for the given issue key.

--- a/sprint_test.go
+++ b/sprint_test.go
@@ -54,7 +54,41 @@ func TestSprintService_GetIssuesForSprint(t *testing.T) {
 		fmt.Fprint(w, string(raw))
 	})
 
-	issues, _, err := testClient.Sprint.GetIssuesForSprint(123)
+	issues, _, err := testClient.Sprint.GetIssuesForSprint(123, nil)
+	if err != nil {
+		t.Errorf("Error given: %v", err)
+	}
+	if issues == nil {
+		t.Error("Expected issues in sprint list. Issues list is nil")
+	}
+	if len(issues) != 1 {
+		t.Errorf("Expect there to be 1 issue in the sprint, found %v", len(issues))
+	}
+
+}
+
+func TestSprintService_GetIssuesForSprint_WithFilter(t *testing.T) {
+	setup()
+	defer teardown()
+	testAPIEdpoint := "/rest/agile/1.0/sprint/123/issue"
+
+	raw, err := ioutil.ReadFile("./mocks/issues_in_sprint.json")
+	if err != nil {
+		t.Error(err.Error())
+	}
+	testMux.HandleFunc(testAPIEdpoint, func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "GET")
+		testRequestURL(t, r, testAPIEdpoint)
+		testRequestParams(t, r, map[string]string{"jql": "assignee=foo", "expand": "bar"})
+		fmt.Fprint(w, string(raw))
+	})
+
+	issues, _, err := testClient.Sprint.GetIssuesForSprint(123, &GetIssuesForSprintOptions{
+		SearchOptions: SearchOptions{
+			Expand: "bar",
+		},
+		Jql: "assignee=foo",
+	})
 	if err != nil {
 		t.Errorf("Error given: %v", err)
 	}


### PR DESCRIPTION
# Description
Adding query options to `GetIssuesForSprint` and `GetIssueWithContext`

Information that is useful here:
* **The What**: Adding missing query options to `GetIssuesForSprint` and `GetIssueWithContext`
* **The Why**: To be able to use Jira provided filtering by API
* **Type of change**: Missing API query
* **Breaking change**: Yes. Whoever currently uses `GetIssuesForSprint` and will update to this version, will need to pass `nil` (or real query if he wish)
* **Related to an issue**: closes #352 
* **Jira Version + Type**: Jira cloud

## Example:

Let us know how users can use or test this functionality.

```go
issues, _, err := j.client.Sprint.GetIssuesForSprint(sprint.ID, &jira.GetIssuesForSprintOptions{
	Jql: fmt.Sprintf(`assignee="%s"`, j.assignee),
})
```

# Checklist

* [X] Unit or Integration tests added
  * [X] Good Path
  * [X] Error Path
* [X] Commits follow conventions described here:
  * [X] [Conventional Commits 1.0.0](https://conventionalcommits.org/en/v1.0.0-beta.4/#summary)
  * [X] [The seven rules of a great Git commit message](https://chris.beams.io/posts/git-commit/#seven-rules)
* [X] Commits are squashed such that
  * [X] There is 1 commit per isolated change
* [X] I've not made extraneous commits/changes that are unrelated to my change.
