### PR TITLE
Fixed examples/create response output

### DIFF
--- a/examples/create/main.go
+++ b/examples/create/main.go
@@ -59,5 +59,5 @@ func main() {
 		panic(err)
 	}
 
-	fmt.Printf("%s: %+v\n", issue.Key, issue.Fields.Summary)
+	fmt.Printf("%s: %+v\n", issue.Key, issue.Self)
 }


### PR DESCRIPTION
# Description

Corrected example "create".  It was throwing errors when trying to display "issue.Fields.Summary" because "Fields" is not part of POST response.  This change displays issue.Self instead.

Information that is useful here:
* **The What**: Switching output fields of "create" example to avoid errors.
* **The Why**: It was provoking errors, "issue.Fields.Summary" was not present in the HTTP response.
* **Type of change**: Bugfix
* **Breaking change**: No
* **Related to an issue**: Related with https://github.com/andygrunwald/go-jira/issues/350#issuecomment-778109070
* **Jira Version + Type**: Cloud

## Example:

Simply try examples/create

```bash
go run examples/create/main.go

```
