### PR TITLE
Resolve nogo tautological linting error

### DIFF
--- a/filter.go
+++ b/filter.go
@@ -130,13 +130,11 @@ func (fs *FilterService) GetListWithContext(ctx context.Context) ([]*Filter, *Re
 		return nil, nil, err
 	}
 
-	if options != nil {
-		q, err := query.Values(options)
-		if err != nil {
-			return nil, nil, err
-		}
-		req.URL.RawQuery = q.Encode()
+	q, err := query.Values(options)
+	if err != nil {
+		return nil, nil, err
 	}
+	req.URL.RawQuery = q.Encode()
 
 	filters := []*Filter{}
 	resp, err := fs.client.Do(req, &filters)


### PR DESCRIPTION
# Description

[nogo](https://github.com/bazelbuild/rules_go/blob/master/go/nogo.rst)'s static analysis finds an issue with a line in `GetListWithContext`, specifically this line:

https://github.com/andygrunwald/go-jira/blob/1abf9e57d22e6fd138bf9aaa9c030a201f784f3f/filter.go#L133

The error is

```
tautological condition: non-nil != nil
```

The issue seems to be that `options` is initialized to a non-nil value (`&GetQueryOptions{}`), then immediately checked against `nil` despite the absence of any modifications that could make it `nil`.

This change just fixes this error by removing the `nil` check; if you'd prefer to keep it, feel free to just close the PR!

# Checklist

* [ ] Unit or Integration tests added
  * [ ] Good Path
  * [ ] Error Path
* [x] Commits follow conventions described here:
  * [x] [Conventional Commits 1.0.0](https://conventionalcommits.org/en/v1.0.0-beta.4/#summary)
  * [x] [The seven rules of a great Git commit message](https://chris.beams.io/posts/git-commit/#seven-rules)
* [x] Commits are squashed such that
  * [x] There is 1 commit per isolated change
* [x] I've not made extraneous commits/changes that are unrelated to my change.
