### PR TITLE
Fix example - use account id

### DIFF
--- a/examples/create/main.go
+++ b/examples/create/main.go
@@ -38,10 +38,10 @@ func main() {
 	i := jira.Issue{
 		Fields: &jira.IssueFields{
 			Assignee: &jira.User{
-				Name: "myuser",
+				AccountID: "myatlassianid",
 			},
 			Reporter: &jira.User{
-				Name: "youruser",
+				AccountID: "myatlassianid",
 			},
 			Description: "Test Issue",
 			Type: jira.IssueType{


### PR DESCRIPTION
# Description

- It seems that only `AccountID` is supported for users in issue creation
- Closes #308


Information that is useful here:

- Fix an issue with the examples identified in #308 
- This only updates the example, no change was made in the actual library