### PR TITLE
#69 #373 example/create changed to use accountID intead of username

### DIFF
--- a/examples/create/main.go
+++ b/examples/create/main.go
@@ -38,7 +38,7 @@ func main() {
 	i := jira.Issue{
 		Fields: &jira.IssueFields{
 			Assignee: &jira.User{
-				Name: "myuser",
+				AccountID: "my-user-account-id",
 			},
 			Reporter: &jira.User{
 				AccountID: "your-user-account-id",

--- a/examples/create/main.go
+++ b/examples/create/main.go
@@ -41,7 +41,7 @@ func main() {
 				Name: "myuser",
 			},
 			Reporter: &jira.User{
-				Name: "youruser",
+				AccountID: "your-user-account-id",
 			},
 			Description: "Test Issue",
 			Type: jira.IssueType{

--- a/go.sum
+++ b/go.sum
@@ -18,7 +18,9 @@ golang.org/x/net v0.0.0-20190404232315-eb5bcb51f2a3/go.mod h1:t9HGtf8HONx5eT2rtn
 golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190412213103-97732733099d h1:+R4KGOnez64A81RvjARKc4UT5/tI9ujCIVX+P5KiHuI=
 golang.org/x/sys v0.0.0-20190412213103-97732733099d/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20201119102817-f84b799fce68 h1:nxC68pudNYkKU6jWhgrqdreuFiOQWj1Fs7T3VrH4Pjw=
 golang.org/x/sys v0.0.0-20201119102817-f84b799fce68/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/term v0.0.0-20210220032956-6a3ed077a48d h1:SZxvLBoTP5yHO3Frd4z4vrF+DBX9vMVanchswa69toE=
 golang.org/x/term v0.0.0-20210220032956-6a3ed077a48d/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543 h1:E7g+9GITq07hpfrRu66IVDexMakfv52eLZ2CXBWiKr4=


### PR DESCRIPTION
Changed creation example to refer reporter by accountID instead of username since it is deprecated in Jira cloud.
Working by accountID is compatible with both Jira Cloud and Jira Server versions.

# Description

Please describe _what does this Pull Request fix or add?_.

Information that is useful here:
* **The What**: examples/create   Changed username field by accountID
* **The Why**: Jira Cloud API is rejecting usernames  from 2018 due to GDPR compliance 
* **Type of change**: Minor fix in an example
* **Breaking change**: Non breaking
* **Related to an issue**: #69 and #373
* **Jira Version + Type**: Jira Cloud

## Example:

Just try examples/create  using go run

