### PR TITLE
update jwt-go to v4

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/andygrunwald/go-jira
 go 1.12
 
 require (
-	github.com/dgrijalva/jwt-go v3.2.0+incompatible
+	github.com/dgrijalva/jwt-go/v4 v4.0.0-preview1
 	github.com/fatih/structs v1.1.0
 	github.com/google/go-cmp v0.5.6
 	github.com/google/go-querystring v0.0.0-20170111101155-53e6ce116135

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,5 @@
-github.com/dgrijalva/jwt-go v3.2.0+incompatible h1:7qlOGliEKZXTDg6OTjfoBKDXWrumCAMpl/TFQ4/5kLM=
-github.com/dgrijalva/jwt-go v3.2.0+incompatible/go.mod h1:E3ru+11k8xSBh+hMPgOLZmtrrCbhqsmaPHjLKYnJCaQ=
+github.com/dgrijalva/jwt-go/v4 v4.0.0-preview1 h1:CaO/zOnF8VvUfEbhRatPcwKVWamvbYd8tQGRWacE9kU=
+github.com/dgrijalva/jwt-go/v4 v4.0.0-preview1/go.mod h1:+hnT3ywWDTAFrW5aE+u2Sa/wT555ZqwoCS+pk3p6ry4=
 github.com/fatih/structs v1.1.0 h1:Q7juDM0QtcnhCpeyLGQKyg4TOIghuNXrkL32pHAUMxo=
 github.com/fatih/structs v1.1.0/go.mod h1:9NiDSp5zOcgEDl+j00MP/WkGVPOlPRLejGD8Ga6PJ7M=
 github.com/google/go-cmp v0.5.6 h1:BKbKCqvP6I+rmFHt06ZmyQtvB8xAkWdhFyr0ZUNZcxQ=

--- a/jira.go
+++ b/jira.go
@@ -15,7 +15,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/dgrijalva/jwt-go"
+	jwt "github.com/dgrijalva/jwt-go/v4"
 	"github.com/google/go-querystring/query"
 	"github.com/pkg/errors"
 )


### PR DESCRIPTION
# Description

Updating the jwt-go library. Current version is vulnerable: https://www.whitesourcesoftware.com/vulnerability-database/CVE-2020-26160  -- this is a preview version but works the same way. 

Information that is useful here:
* **The What**: Updating a library which is vulnerable.
* **The Why**: Security
* **Type of change**: Dependency update
* **Breaking change**: No
* **Related to an issue**: #343 
* **Jira Version + Type**: Cloud
