### PR TITLE
Add ComponentService.Get methods

### DIFF
--- a/component.go
+++ b/component.go
@@ -1,6 +1,9 @@
 package jira
 
-import "context"
+import (
+	"context"
+	"fmt"
+)
 
 // ComponentService handles components for the Jira instance / API.//
 // Jira API docs: https://docs.atlassian.com/software/jira/docs/api/REST/7.10.1/#api/2/component
@@ -41,4 +44,27 @@ func (s *ComponentService) CreateWithContext(ctx context.Context, options *Creat
 // Create wraps CreateWithContext using the background context.
 func (s *ComponentService) Create(options *CreateComponentOptions) (*ProjectComponent, *Response, error) {
 	return s.CreateWithContext(context.Background(), options)
+}
+
+// GetWithContext returns a full representation of the JIRA component for the given component ID.
+// Jira API docs: https://developer.atlassian.com/cloud/jira/platform/rest/v3/api-group-project-components/
+func (s *ComponentService) GetWithContext(ctx context.Context, componentID string) (*ProjectComponent, *Response, error) {
+	apiEndpoint := fmt.Sprintf("rest/api/2/component/%s", componentID)
+	req, err := s.client.NewRequestWithContext(ctx, "GET", apiEndpoint, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	component := new(ProjectComponent)
+	resp, err := s.client.Do(req, component)
+	if err != nil {
+		return nil, resp, NewJiraError(resp, err)
+	}
+
+	return component, resp, nil
+}
+
+// Get wraps GetWithContext using the background context.
+func (s *ComponentService) Get(componentID string) (*ProjectComponent, *Response, error) {
+	return s.GetWithContext(context.Background(), componentID)
 }

--- a/mocks/component.json
+++ b/mocks/component.json
@@ -1,0 +1,50 @@
+{
+  "self": "https://issues.apache.org/jira/rest/api/2/component/42102",
+  "id": "42102",
+  "name": "Some Component",
+  "lead": {
+    "self": "https://issues.apache.org/jira/rest/api/2/user?username=firstname.lastname@apache.org",
+    "key": "firstname.lastname",
+    "name": "firstname.lastname@apache.org",
+    "avatarUrls": {
+      "48x48": "https://issues.apache.org/jira/secure/useravatar?ownerId=firstname.lastname&avatarId=31851",
+      "24x24": "https://issues.apache.org/jira/secure/useravatar?size=small&ownerId=firstname.lastname&avatarId=31851",
+      "16x16": "https://issues.apache.org/jira/secure/useravatar?size=xsmall&ownerId=firstname.lastname&avatarId=31851",
+      "32x32": "https://issues.apache.org/jira/secure/useravatar?size=medium&ownerId=firstname.lastname&avatarId=31851"
+    },
+    "displayName": "Firstname Lastname",
+    "active": true
+  },
+  "assigneeType": "COMPONENT_LEAD",
+  "assignee": {
+    "self": "https://issues.apache.org/jira/rest/api/2/user?username=firstname.lastname@apache.org",
+    "key": "firstname.lastname",
+    "name": "firstname.lastname@apache.org",
+    "avatarUrls": {
+      "48x48": "https://issues.apache.org/jira/secure/useravatar?ownerId=firstname.lastname&avatarId=31851",
+      "24x24": "https://issues.apache.org/jira/secure/useravatar?size=small&ownerId=firstname.lastname&avatarId=31851",
+      "16x16": "https://issues.apache.org/jira/secure/useravatar?size=xsmall&ownerId=firstname.lastname&avatarId=31851",
+      "32x32": "https://issues.apache.org/jira/secure/useravatar?size=medium&ownerId=firstname.lastname&avatarId=31851"
+    },
+    "displayName": "Firstname Lastname",
+    "active": true
+  },
+  "realAssigneeType": "COMPONENT_LEAD",
+  "realAssignee": {
+    "self": "https://issues.apache.org/jira/rest/api/2/user?username=firstname.lastname@apache.org",
+    "key": "firstname.lastname",
+    "name": "firstname.lastname@apache.org",
+    "avatarUrls": {
+      "48x48": "https://issues.apache.org/jira/secure/useravatar?ownerId=firstname.lastname&avatarId=31851",
+      "24x24": "https://issues.apache.org/jira/secure/useravatar?size=small&ownerId=firstname.lastname&avatarId=31851",
+      "16x16": "https://issues.apache.org/jira/secure/useravatar?size=xsmall&ownerId=firstname.lastname&avatarId=31851",
+      "32x32": "https://issues.apache.org/jira/secure/useravatar?size=medium&ownerId=firstname.lastname&avatarId=31851"
+    },
+    "displayName": "Firstname Lastname",
+    "active": true
+  },
+  "isAssigneeTypeValid": true,
+  "project": "ABC",
+  "projectId": 12345,
+  "archived": false
+}


### PR DESCRIPTION
# Description

Hi!

**What**: Added a `Get` and `GetWithContext` method for `ComponentService`
**Why**: to be able to use `go-jira` to get Project Components (functionality that currently exists in the REST API but not in the library)
**Type of change**: New feature + tests
Also added tests/mock data that effectively mirrors the way we've tested `Get`/`GetWithContext` in `ProjectService`.
**Issue**: This might relate to #361 
**JIRA version + type**: Should work with all JIRA REST API v2, I specifically confirmed with on-prem + 8.17.1 (though I think this feature has been available for much longer)

## Example:

Let us know how users can use or test this functionality.

```go
component, res, err := jiraClient.Component.Get("12345") // 12345 being a component ID, which you can find by going to a list of components, inspecting element, and looking for a data-component-id

```

# Checklist

* [x] Unit or Integration tests added
  * [x] Good Path
  * [x] Error Path
* [x] Commits follow conventions described here:
  * [x] [Conventional Commits 1.0.0](https://conventionalcommits.org/en/v1.0.0-beta.4/#summary)
  * [x] [The seven rules of a great Git commit message](https://chris.beams.io/posts/git-commit/#seven-rules)
* [x] Commits are squashed such that
  * [x] There is 1 commit per isolated change
* [x] I've not made extraneous commits/changes that are unrelated to my change.
