### PR TITLE
feat: add customer and request endpoints for service desk api

### DIFF
--- a/customer.go
+++ b/customer.go
@@ -1,0 +1,77 @@
+package jira
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+)
+
+// CustomerService handles ServiceDesk customers for the Jira instance / API.
+type CustomerService struct {
+	client *Client
+}
+
+// Customer represents a ServiceDesk customer.
+type Customer struct {
+	AccountID    string    `json:"accountId,omitempty" structs:"accountId,omitempty"`
+	Name         string    `json:"name,omitempty" structs:"name,omitempty"`
+	Key          string    `json:"key,omitempty" structs:"key,omitempty"`
+	EmailAddress string    `json:"emailAddress,omitempty" structs:"emailAddress,omitempty"`
+	DisplayName  string    `json:"displayName,omitempty" structs:"displayName,omitempty"`
+	Active       *bool     `json:"active,omitempty" structs:"active,omitempty"`
+	TimeZone     string    `json:"timeZone,omitempty" structs:"timeZone,omitempty"`
+	Links        *SelfLink `json:"_links,omitempty" structs:"_links,omitempty"`
+}
+
+// CustomerListOptions is the query options for listing customers.
+type CustomerListOptions struct {
+	Query string `url:"query,omitempty"`
+	Start int    `url:"start,omitempty"`
+	Limit int    `url:"limit,omitempty"`
+}
+
+// CustomerList is a page of customers.
+type CustomerList struct {
+	Values  []Customer `json:"values,omitempty" structs:"values,omitempty"`
+	Start   int        `json:"start,omitempty" structs:"start,omitempty"`
+	Limit   int        `json:"limit,omitempty" structs:"limit,omitempty"`
+	IsLast  bool       `json:"isLastPage,omitempty" structs:"isLastPage,omitempty"`
+	Expands []string   `json:"_expands,omitempty" structs:"_expands,omitempty"`
+}
+
+// CreateWithContext creates a ServiceDesk customer.
+//
+// https://developer.atlassian.com/cloud/jira/service-desk/rest/api-group-customer/#api-rest-servicedeskapi-customer-post
+func (c *CustomerService) CreateWithContext(ctx context.Context, email, displayName string) (*Customer, *Response, error) {
+	apiEndpoint := "rest/servicedeskapi/customer"
+
+	payload := struct {
+		Email       string `json:"email"`
+		DisplayName string `json:"displayName"`
+	}{
+		Email:       email,
+		DisplayName: displayName,
+	}
+
+	req, err := c.client.NewRequestWithContext(ctx, "POST", apiEndpoint, payload)
+	if err != nil {
+		return nil, nil, err
+	}
+	resp, err := c.client.Do(req, nil)
+	if err != nil {
+		return nil, resp, NewJiraError(resp, err)
+	}
+	defer resp.Body.Close()
+
+	responseCustomer := new(Customer)
+	if err := json.NewDecoder(resp.Body).Decode(responseCustomer); err != nil {
+		return nil, resp, fmt.Errorf("could not unmarshall the data into struct")
+	}
+
+	return responseCustomer, resp, nil
+}
+
+// Create wraps CreateWithContext using the background context.
+func (c *CustomerService) Create(email, displayName string) (*Customer, *Response, error) {
+	return c.CreateWithContext(context.Background(), email, displayName)
+}

--- a/customer_test.go
+++ b/customer_test.go
@@ -1,0 +1,56 @@
+package jira
+
+import (
+	"fmt"
+	"net/http"
+	"testing"
+)
+
+func TestCustomerService_Create(t *testing.T) {
+	setup()
+	defer teardown()
+
+	const (
+		wantDisplayName  = "Fred F. User"
+		wantEmailAddress = "fred@example.com"
+	)
+
+	testMux.HandleFunc("/rest/servicedeskapi/customer", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "POST")
+		testRequestURL(t, r, "/rest/servicedeskapi/customer")
+
+		w.WriteHeader(http.StatusOK)
+		fmt.Fprintf(w, `{
+		  "accountId": "qm:a713c8ea-1075-4e30-9d96-891a7d181739:5ad6d3581db05e2a66fa80b",
+		  "name": "qm:a713c8ea-1075-4e30-9d96-891a7d181739:5ad6d3581db05e2a66fa80b",
+		  "key": "qm:a713c8ea-1075-4e30-9d96-891a7d181739:5ad6d3581db05e2a66fa80b",
+		  "emailAddress": "%s",
+		  "displayName": "%s",
+		  "active": true,
+		  "timeZone": "Australia/Sydney",
+		  "_links": {
+			"jiraRest": "https://your-domain.atlassian.net/rest/api/2/user?username=qm:a713c8ea-1075-4e30-9d96-891a7d181739:5ad6d3581db05e2a66fa80b",
+			"avatarUrls": {
+			  "48x48": "https://avatar-cdn.atlassian.com/image",
+			  "24x24": "https://avatar-cdn.atlassian.com/image",
+			  "16x16": "https://avatar-cdn.atlassian.com/image",
+			  "32x32": "https://avatar-cdn.atlassian.com/image"
+			},
+			"self": "https://your-domain.atlassian.net/rest/api/2/user?username=qm:a713c8ea-1075-4e30-9d96-891a7d181739:5ad6d3581db05e2a66fa80b"
+		  }
+		}`, wantEmailAddress, wantDisplayName)
+	})
+
+	gotCustomer, _, err := testClient.Customer.Create(wantEmailAddress, wantDisplayName)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if want, got := wantDisplayName, gotCustomer.DisplayName; want != got {
+		t.Fatalf("want display name: %q, got %q", want, got)
+	}
+
+	if want, got := wantEmailAddress, gotCustomer.EmailAddress; want != got {
+		t.Fatalf("want email address: %q, got %q", want, got)
+	}
+}

--- a/jira.go
+++ b/jira.go
@@ -58,6 +58,8 @@ type Client struct {
 	IssueLinkType    *IssueLinkTypeService
 	Organization     *OrganizationService
 	ServiceDesk      *ServiceDeskService
+	Customer         *CustomerService
+	Request          *RequestService
 }
 
 // NewClient returns a new Jira API client.
@@ -106,6 +108,8 @@ func NewClient(httpClient httpClient, baseURL string) (*Client, error) {
 	c.IssueLinkType = &IssueLinkTypeService{client: c}
 	c.Organization = &OrganizationService{client: c}
 	c.ServiceDesk = &ServiceDeskService{client: c}
+	c.Customer = &CustomerService{client: c}
+	c.Request = &RequestService{client: c}
 
 	return c, nil
 }

--- a/request.go
+++ b/request.go
@@ -1,0 +1,136 @@
+package jira
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+)
+
+// RequestService handles ServiceDesk customer requests for the Jira instance / API.
+type RequestService struct {
+	client *Client
+}
+
+// Request represents a ServiceDesk customer request.
+type Request struct {
+	IssueID       string              `json:"issueId,omitempty" structs:"issueId,omitempty"`
+	IssueKey      string              `json:"issueKey,omitempty" structs:"issueKey,omitempty"`
+	TypeID        string              `json:"requestTypeId,omitempty" structs:"requestTypeId,omitempty"`
+	ServiceDeskID string              `json:"serviceDeskId,omitempty" structs:"serviceDeskId,omitempty"`
+	Reporter      *Customer           `json:"reporter,omitempty" structs:"reporter,omitempty"`
+	FieldValues   []RequestFieldValue `json:"requestFieldValues,omitempty" structs:"requestFieldValues,omitempty"`
+	Status        *RequestStatus      `json:"currentStatus,omitempty" structs:"currentStatus,omitempty"`
+	Links         *SelfLink           `json:"_links,omitempty" structs:"_links,omitempty"`
+	Expands       []string            `json:"_expands,omitempty" structs:"_expands,omitempty"`
+}
+
+// RequestFieldValue is a request field.
+type RequestFieldValue struct {
+	FieldID string `json:"fieldId,omitempty" structs:"fieldId,omitempty"`
+	Label   string `json:"label,omitempty" structs:"label,omitempty"`
+	Value   string `json:"value,omitempty" structs:"value,omitempty"`
+}
+
+// RequestDate is the date format used in requests.
+type RequestDate struct {
+	ISO8601  string `json:"iso8601,omitempty" structs:"iso8601,omitempty"`
+	Jira     string `json:"jira,omitempty" structs:"jira,omitempty"`
+	Friendly string `json:"friendly,omitempty" structs:"friendly,omitempty"`
+	Epoch    int64  `json:"epoch,omitempty" structs:"epoch,omitempty"`
+}
+
+// RequestStatus is the status for a request.
+type RequestStatus struct {
+	Status   string
+	Category string
+	Date     RequestDate
+}
+
+// RequestComment is a comment for a request.
+type RequestComment struct {
+	ID      string       `json:"id,omitempty" structs:"id,omitempty"`
+	Body    string       `json:"body,omitempty" structs:"body,omitempty"`
+	Public  bool         `json:"public" structs:"public"`
+	Author  *Customer    `json:"author,omitempty" structs:"author,omitempty"`
+	Created *RequestDate `json:"created,omitempty" structs:"created,omitempty"`
+	Links   *SelfLink    `json:"_links,omitempty" structs:"_links,omitempty"`
+	Expands []string     `json:"_expands,omitempty" structs:"_expands,omitempty"`
+}
+
+// CreateWithContext creates a new request.
+//
+// https://developer.atlassian.com/cloud/jira/service-desk/rest/api-group-request/#api-rest-servicedeskapi-request-post
+func (r *RequestService) CreateWithContext(ctx context.Context, requester string, participants []string, request *Request) (*Request, *Response, error) {
+	apiEndpoint := "rest/servicedeskapi/request"
+
+	payload := struct {
+		*Request
+		FieldValues  map[string]string `json:"requestFieldValues,omitempty"`
+		Requester    string            `json:"raiseOnBehalfOf,omitempty"`
+		Participants []string          `json:"requestParticipants,omitempty"`
+	}{
+		Request:      request,
+		FieldValues:  make(map[string]string),
+		Requester:    requester,
+		Participants: participants,
+	}
+
+	for _, field := range request.FieldValues {
+		payload.FieldValues[field.FieldID] = field.Value
+	}
+
+	req, err := r.client.NewRequestWithContext(ctx, "POST", apiEndpoint, payload)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	resp, err := r.client.Do(req, nil)
+	if err != nil {
+		return nil, resp, NewJiraError(resp, err)
+	}
+
+	defer resp.Body.Close()
+
+	responseRequest := new(Request)
+	if err := json.NewDecoder(resp.Body).Decode(responseRequest); err != nil {
+		return nil, resp, fmt.Errorf("could not unmarshall the data into struct")
+	}
+
+	return responseRequest, resp, nil
+}
+
+// Create wraps CreateWithContext using the background context.
+func (r *RequestService) Create(requester string, participants []string, request *Request) (*Request, *Response, error) {
+	return r.CreateWithContext(context.Background(), requester, participants, request)
+}
+
+// CreateCommentWithContext creates a comment on a request.
+//
+// https://developer.atlassian.com/cloud/jira/service-desk/rest/api-group-request/#api-rest-servicedeskapi-request-issueidorkey-comment-post
+func (r *RequestService) CreateCommentWithContext(ctx context.Context, issueIDOrKey string, comment *RequestComment) (*RequestComment, *Response, error) {
+	apiEndpoint := fmt.Sprintf("rest/servicedeskapi/request/%v/comment", issueIDOrKey)
+
+	req, err := r.client.NewRequestWithContext(ctx, "POST", apiEndpoint, comment)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	resp, err := r.client.Do(req, nil)
+	if err != nil {
+		return nil, resp, NewJiraError(resp, err)
+	}
+
+	defer resp.Body.Close()
+
+	responseComment := new(RequestComment)
+	if err := json.NewDecoder(resp.Body).Decode(responseComment); err != nil {
+		return nil, resp, fmt.Errorf("could not unmarshall the data into struct")
+	}
+
+	return responseComment, resp, nil
+}
+
+// CreateComment wraps CreateCommentWithContext using the background context.
+func (r *RequestService) CreateComment(issueIDOrKey string, comment *RequestComment) (*RequestComment, *Response, error) {
+	return r.CreateCommentWithContext(context.Background(), issueIDOrKey, comment)
+}

--- a/request.go
+++ b/request.go
@@ -2,7 +2,6 @@ package jira
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 )
 
@@ -84,16 +83,10 @@ func (r *RequestService) CreateWithContext(ctx context.Context, requester string
 		return nil, nil, err
 	}
 
-	resp, err := r.client.Do(req, nil)
+	responseRequest := new(Request)
+	resp, err := r.client.Do(req, responseRequest)
 	if err != nil {
 		return nil, resp, NewJiraError(resp, err)
-	}
-
-	defer resp.Body.Close()
-
-	responseRequest := new(Request)
-	if err := json.NewDecoder(resp.Body).Decode(responseRequest); err != nil {
-		return nil, resp, fmt.Errorf("could not unmarshall the data into struct")
 	}
 
 	return responseRequest, resp, nil
@@ -115,16 +108,10 @@ func (r *RequestService) CreateCommentWithContext(ctx context.Context, issueIDOr
 		return nil, nil, err
 	}
 
-	resp, err := r.client.Do(req, nil)
+	responseComment := new(RequestComment)
+	resp, err := r.client.Do(req, responseComment)
 	if err != nil {
 		return nil, resp, NewJiraError(resp, err)
-	}
-
-	defer resp.Body.Close()
-
-	responseComment := new(RequestComment)
-	if err := json.NewDecoder(resp.Body).Decode(responseComment); err != nil {
-		return nil, resp, fmt.Errorf("could not unmarshall the data into struct")
 	}
 
 	return responseComment, resp, nil

--- a/request_test.go
+++ b/request_test.go
@@ -1,0 +1,199 @@
+package jira
+
+import (
+	"encoding/json"
+	"net/http"
+	"reflect"
+	"testing"
+)
+
+func TestRequestService_Create(t *testing.T) {
+	setup()
+	defer teardown()
+
+	var (
+		wantRequester = "qm:a713c8ea-1075-4e30-9d96-891a7d181739:5ad6d3581db05e2a66fa80b"
+		gotRequester  string
+
+		wantParticipants = []string{
+			"qm:a713c8ea-1075-4e30-9d96-891a7d181739:5ad6d3581db05e2a66fa80b",
+		}
+		gotParticipants []string
+	)
+
+	testMux.HandleFunc("/rest/servicedeskapi/request", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "POST")
+		testRequestURL(t, r, "/rest/servicedeskapi/request")
+
+		var payload struct {
+			Requester    string   `json:"raiseOnBehalfOf,omitempty"`
+			Participants []string `json:"requestParticipants,omitempty"`
+		}
+
+		if err := json.NewDecoder(r.Body).Decode(&payload); err != nil {
+			t.Fatal(err)
+		}
+
+		gotRequester = payload.Requester
+		gotParticipants = payload.Participants
+
+		w.Write([]byte(`{
+		  "_expands": [
+			"participant",
+			"status",
+			"sla",
+			"requestType",
+			"serviceDesk",
+			"attachment",
+			"action",
+			"comment"
+		  ],
+		  "issueId": "107001",
+		  "issueKey": "HELPDESK-1",
+		  "requestTypeId": "25",
+		  "serviceDeskId": "10",
+		  "createdDate": {
+			"iso8601": "2015-10-08T14:42:00+0700",
+			"jira": "2015-10-08T14:42:00.000+0700",
+			"friendly": "Monday 14:42 PM",
+			"epochMillis": 1444290120000
+		  },
+		  "reporter": {
+			"accountId": "qm:a713c8ea-1075-4e30-9d96-891a7d181739:5ad6d3581db05e2a66fa80b",
+			"name": "qm:a713c8ea-1075-4e30-9d96-891a7d181739:5ad6d3581db05e2a66fa80b",
+			"key": "qm:a713c8ea-1075-4e30-9d96-891a7d181739:5ad6d3581db05e2a66fa80b",
+			"emailAddress": "fred@example.com",
+			"displayName": "Fred F. User",
+			"active": true,
+			"timeZone": "Australia/Sydney",
+			"_links": {
+			  "jiraRest": "https://your-domain.atlassian.net/rest/api/2/user?username=qm:a713c8ea-1075-4e30-9d96-891a7d181739:5ad6d3581db05e2a66fa80b",
+			  "avatarUrls": {
+				"48x48": "https://avatar-cdn.atlassian.com/9bc3b5bcb0db050c6d7660b28a5b86c9?s=48&d=https%3A%2F%2Fsecure.gravatar.com%2Favatar%2F9bc3b5bcb0db050c6d7660b28a5b86c9%3Fd%3Dmm%26s%3D48%26noRedirect%3Dtrue",
+				"24x24": "https://avatar-cdn.atlassian.com/9bc3b5bcb0db050c6d7660b28a5b86c9?s=24&d=https%3A%2F%2Fsecure.gravatar.com%2Favatar%2F9bc3b5bcb0db050c6d7660b28a5b86c9%3Fd%3Dmm%26s%3D24%26noRedirect%3Dtrue",
+				"16x16": "https://avatar-cdn.atlassian.com/9bc3b5bcb0db050c6d7660b28a5b86c9?s=16&d=https%3A%2F%2Fsecure.gravatar.com%2Favatar%2F9bc3b5bcb0db050c6d7660b28a5b86c9%3Fd%3Dmm%26s%3D16%26noRedirect%3Dtrue",
+				"32x32": "https://avatar-cdn.atlassian.com/9bc3b5bcb0db050c6d7660b28a5b86c9?s=32&d=https%3A%2F%2Fsecure.gravatar.com%2Favatar%2F9bc3b5bcb0db050c6d7660b28a5b86c9%3Fd%3Dmm%26s%3D32%26noRedirect%3Dtrue"
+			  },
+			  "self": "https://your-domain.atlassian.net/rest/api/2/user?username=qm:a713c8ea-1075-4e30-9d96-891a7d181739:5ad6d3581db05e2a66fa80b"
+			}
+		  },
+		  "requestFieldValues": [
+			{
+			  "fieldId": "summary",
+			  "label": "What do you need?",
+			  "value": "Request JSD help via REST"
+			},
+			{
+			  "fieldId": "description",
+			  "label": "Why do you need this?",
+			  "value": "I need a new *mouse* for my Mac",
+			  "renderedValue": {
+				"html": "<p>I need a new <b>mouse</b> for my Mac</p>"
+			  }
+			}
+		  ],
+		  "currentStatus": {
+			"status": "Waiting for Support",
+			"statusCategory": "NEW",
+			"statusDate": {
+			  "iso8601": "2015-10-08T14:01:00+0700",
+			  "jira": "2015-10-08T14:01:00.000+0700",
+			  "friendly": "Today 14:01 PM",
+			  "epochMillis": 1444287660000
+			}
+		  },
+		  "_links": {
+			"jiraRest": "https://your-domain.atlassian.net/rest/api/2/issue/107001",
+			"web": "https://your-domain.atlassian.net/servicedesk/customer/portal/10/HELPDESK-1",
+			"self": "https://your-domain.atlassian.net/rest/servicedeskapi/request/107001",
+			"agent": "https://your-domain.atlassian.net/browse/HELPDESK-1"
+		  }
+		}`))
+	})
+
+	request := &Request{
+		ServiceDeskID: "10",
+		TypeID:        "25",
+		FieldValues: []RequestFieldValue{
+			{
+				FieldID: "summary",
+				Value:   "Request JSD help via REST",
+			},
+			{
+				FieldID: "description",
+				Value:   "I need a new *mouse* for my Mac",
+			},
+		},
+	}
+
+	_, _, err := testClient.Request.Create(wantRequester, wantParticipants, request)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if wantRequester != gotRequester {
+		t.Fatalf("want requester: %q, got %q", wantRequester, gotRequester)
+	}
+
+	if !reflect.DeepEqual(wantParticipants, gotParticipants) {
+		t.Fatalf("want participants: %v, got %v", wantParticipants, gotParticipants)
+	}
+}
+
+func TestRequestService_CreateComment(t *testing.T) {
+	setup()
+	defer teardown()
+
+	testMux.HandleFunc("/rest/servicedeskapi/request/HELPDESK-1/comment", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "POST")
+		testRequestURL(t, r, "/rest/servicedeskapi/request/HELPDESK-1/comment")
+
+		w.Write([]byte(`{
+		  "_expands": [
+			"attachment",
+			"renderedBody"
+		  ],
+		  "id": "1000",
+		  "body": "Hello there",
+		  "public": true,
+		  "author": {
+			"accountId": "qm:a713c8ea-1075-4e30-9d96-891a7d181739:5ad6d3581db05e2a66fa80b",
+			"name": "qm:a713c8ea-1075-4e30-9d96-891a7d181739:5ad6d3581db05e2a66fa80b",
+			"key": "qm:a713c8ea-1075-4e30-9d96-891a7d181739:5ad6d3581db05e2a66fa80b",
+			"emailAddress": "fred@example.com",
+			"displayName": "Fred F. User",
+			"active": true,
+			"timeZone": "Australia/Sydney",
+			"_links": {
+			  "jiraRest": "https://your-domain.atlassian.net/rest/api/2/user?username=qm:a713c8ea-1075-4e30-9d96-891a7d181739:5ad6d3581db05e2a66fa80b",
+			  "avatarUrls": {
+				"48x48": "https://avatar-cdn.atlassian.com/9bc3b5bcb0db050c6d7660b28a5b86c9?s=48&d=https%3A%2F%2Fsecure.gravatar.com%2Favatar%2F9bc3b5bcb0db050c6d7660b28a5b86c9%3Fd%3Dmm%26s%3D48%26noRedirect%3Dtrue",
+				"24x24": "https://avatar-cdn.atlassian.com/9bc3b5bcb0db050c6d7660b28a5b86c9?s=24&d=https%3A%2F%2Fsecure.gravatar.com%2Favatar%2F9bc3b5bcb0db050c6d7660b28a5b86c9%3Fd%3Dmm%26s%3D24%26noRedirect%3Dtrue",
+				"16x16": "https://avatar-cdn.atlassian.com/9bc3b5bcb0db050c6d7660b28a5b86c9?s=16&d=https%3A%2F%2Fsecure.gravatar.com%2Favatar%2F9bc3b5bcb0db050c6d7660b28a5b86c9%3Fd%3Dmm%26s%3D16%26noRedirect%3Dtrue",
+				"32x32": "https://avatar-cdn.atlassian.com/9bc3b5bcb0db050c6d7660b28a5b86c9?s=32&d=https%3A%2F%2Fsecure.gravatar.com%2Favatar%2F9bc3b5bcb0db050c6d7660b28a5b86c9%3Fd%3Dmm%26s%3D32%26noRedirect%3Dtrue"
+			  },
+			  "self": "https://your-domain.atlassian.net/rest/api/2/user?username=qm:a713c8ea-1075-4e30-9d96-891a7d181739:5ad6d3581db05e2a66fa80b"
+			}
+		  },
+		  "created": {
+			"iso8601": "2015-10-09T10:22:00+0700",
+			"jira": "2015-10-09T10:22:00.000+0700",
+			"friendly": "Today 10:22 AM",
+			"epochMillis": 1444360920000
+		  },
+		  "_links": {
+			"self": "https://your-domain.atlassian.net/rest/servicedeskapi/request/2000/comment/1000"
+		  }
+		}`))
+	})
+
+	comment := &RequestComment{
+		Body:   "Hello there",
+		Public: true,
+	}
+
+	_, _, err := testClient.Request.CreateComment("HELPDESK-1", comment)
+	if err != nil {
+		t.Fatal(err)
+	}
+}

--- a/servicedesk.go
+++ b/servicedesk.go
@@ -121,7 +121,7 @@ func (s *ServiceDeskService) RemoveOrganization(serviceDeskID interface{}, organ
 // AddCustomersWithContext adds customers to the given service desk.
 //
 // https://developer.atlassian.com/cloud/jira/service-desk/rest/api-group-servicedesk/#api-rest-servicedeskapi-servicedesk-servicedeskid-customer-post
-func (s *ServiceDeskService) AddCustomersWithContext(ctx context.Context, serviceDeskID int, acountIDs ...string) (*Response, error) {
+func (s *ServiceDeskService) AddCustomersWithContext(ctx context.Context, serviceDeskID interface{}, acountIDs ...string) (*Response, error) {
 	apiEndpoint := fmt.Sprintf("rest/servicedeskapi/servicedesk/%v/customer", serviceDeskID)
 
 	payload := struct {
@@ -146,14 +146,14 @@ func (s *ServiceDeskService) AddCustomersWithContext(ctx context.Context, servic
 }
 
 // AddCustomers wraps AddCustomersWithContext using the background context.
-func (s *ServiceDeskService) AddCustomers(serviceDeskID int, acountIDs ...string) (*Response, error) {
+func (s *ServiceDeskService) AddCustomers(serviceDeskID interface{}, acountIDs ...string) (*Response, error) {
 	return s.AddCustomersWithContext(context.Background(), serviceDeskID, acountIDs...)
 }
 
 // RemoveCustomersWithContext removes customers to the given service desk.
 //
 // https://developer.atlassian.com/cloud/jira/service-desk/rest/api-group-servicedesk/#api-rest-servicedeskapi-servicedesk-servicedeskid-customer-delete
-func (s *ServiceDeskService) RemoveCustomersWithContext(ctx context.Context, serviceDeskID int, acountIDs ...string) (*Response, error) {
+func (s *ServiceDeskService) RemoveCustomersWithContext(ctx context.Context, serviceDeskID interface{}, acountIDs ...string) (*Response, error) {
 	apiEndpoint := fmt.Sprintf("rest/servicedeskapi/servicedesk/%v/customer", serviceDeskID)
 
 	payload := struct {
@@ -178,14 +178,14 @@ func (s *ServiceDeskService) RemoveCustomersWithContext(ctx context.Context, ser
 }
 
 // RemoveCustomers wraps RemoveCustomersWithContext using the background context.
-func (s *ServiceDeskService) RemoveCustomers(serviceDeskID int, acountIDs ...string) (*Response, error) {
+func (s *ServiceDeskService) RemoveCustomers(serviceDeskID interface{}, acountIDs ...string) (*Response, error) {
 	return s.RemoveCustomersWithContext(context.Background(), serviceDeskID, acountIDs...)
 }
 
 // ListCustomersWithContext lists customers for a ServiceDesk.
 //
 // https://developer.atlassian.com/cloud/jira/service-desk/rest/api-group-servicedesk/#api-rest-servicedeskapi-servicedesk-servicedeskid-customer-get
-func (s *ServiceDeskService) ListCustomersWithContext(ctx context.Context, serviceDeskID int, options *CustomerListOptions) (*CustomerList, *Response, error) {
+func (s *ServiceDeskService) ListCustomersWithContext(ctx context.Context, serviceDeskID interface{}, options *CustomerListOptions) (*CustomerList, *Response, error) {
 	apiEndpoint := fmt.Sprintf("rest/servicedeskapi/servicedesk/%v/customer", serviceDeskID)
 	req, err := s.client.NewRequestWithContext(ctx, "GET", apiEndpoint, nil)
 	if err != nil {
@@ -218,6 +218,6 @@ func (s *ServiceDeskService) ListCustomersWithContext(ctx context.Context, servi
 }
 
 // ListCustomers wraps ListCustomersWithContext using the background context.
-func (s *ServiceDeskService) ListCustomers(serviceDeskID int, options *CustomerListOptions) (*CustomerList, *Response, error) {
+func (s *ServiceDeskService) ListCustomers(serviceDeskID interface{}, options *CustomerListOptions) (*CustomerList, *Response, error) {
 	return s.ListCustomersWithContext(context.Background(), serviceDeskID, options)
 }

--- a/servicedesk.go
+++ b/servicedesk.go
@@ -2,7 +2,12 @@ package jira
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
+	"io"
+	"io/ioutil"
+
+	"github.com/google/go-querystring/query"
 )
 
 // ServiceDeskService handles ServiceDesk for the Jira instance / API.
@@ -111,4 +116,108 @@ func (s *ServiceDeskService) RemoveOrganizationWithContext(ctx context.Context, 
 // RemoveOrganization wraps RemoveOrganizationWithContext using the background context.
 func (s *ServiceDeskService) RemoveOrganization(serviceDeskID interface{}, organizationID int) (*Response, error) {
 	return s.RemoveOrganizationWithContext(context.Background(), serviceDeskID, organizationID)
+}
+
+// AddCustomersWithContext adds customers to the given service desk.
+//
+// https://developer.atlassian.com/cloud/jira/service-desk/rest/api-group-servicedesk/#api-rest-servicedeskapi-servicedesk-servicedeskid-customer-post
+func (s *ServiceDeskService) AddCustomersWithContext(ctx context.Context, serviceDeskID int, acountIDs ...string) (*Response, error) {
+	apiEndpoint := fmt.Sprintf("rest/servicedeskapi/servicedesk/%v/customer", serviceDeskID)
+
+	payload := struct {
+		AccountIDs []string `json:"accountIds"`
+	}{
+		AccountIDs: acountIDs,
+	}
+	req, err := s.client.NewRequestWithContext(ctx, "POST", apiEndpoint, payload)
+	if err != nil {
+		return nil, err
+	}
+
+	resp, err := s.client.Do(req, nil)
+	if err != nil {
+		return resp, NewJiraError(resp, err)
+	}
+
+	defer resp.Body.Close()
+	_, _ = io.Copy(ioutil.Discard, resp.Body)
+
+	return resp, nil
+}
+
+// AddCustomers wraps AddCustomersWithContext using the background context.
+func (s *ServiceDeskService) AddCustomers(serviceDeskID int, acountIDs ...string) (*Response, error) {
+	return s.AddCustomersWithContext(context.Background(), serviceDeskID, acountIDs...)
+}
+
+// RemoveCustomersWithContext removes customers to the given service desk.
+//
+// https://developer.atlassian.com/cloud/jira/service-desk/rest/api-group-servicedesk/#api-rest-servicedeskapi-servicedesk-servicedeskid-customer-delete
+func (s *ServiceDeskService) RemoveCustomersWithContext(ctx context.Context, serviceDeskID int, acountIDs ...string) (*Response, error) {
+	apiEndpoint := fmt.Sprintf("rest/servicedeskapi/servicedesk/%v/customer", serviceDeskID)
+
+	payload := struct {
+		AccountIDs []string `json:"accountIDs"`
+	}{
+		AccountIDs: acountIDs,
+	}
+	req, err := s.client.NewRequestWithContext(ctx, "DELETE", apiEndpoint, payload)
+	if err != nil {
+		return nil, err
+	}
+
+	resp, err := s.client.Do(req, nil)
+	if err != nil {
+		return resp, NewJiraError(resp, err)
+	}
+
+	defer resp.Body.Close()
+	_, _ = io.Copy(ioutil.Discard, resp.Body)
+
+	return resp, nil
+}
+
+// RemoveCustomers wraps RemoveCustomersWithContext using the background context.
+func (s *ServiceDeskService) RemoveCustomers(serviceDeskID int, acountIDs ...string) (*Response, error) {
+	return s.RemoveCustomersWithContext(context.Background(), serviceDeskID, acountIDs...)
+}
+
+// ListCustomersWithContext lists customers for a ServiceDesk.
+//
+// https://developer.atlassian.com/cloud/jira/service-desk/rest/api-group-servicedesk/#api-rest-servicedeskapi-servicedesk-servicedeskid-customer-get
+func (s *ServiceDeskService) ListCustomersWithContext(ctx context.Context, serviceDeskID int, options *CustomerListOptions) (*CustomerList, *Response, error) {
+	apiEndpoint := fmt.Sprintf("rest/servicedeskapi/servicedesk/%v/customer", serviceDeskID)
+	req, err := s.client.NewRequestWithContext(ctx, "GET", apiEndpoint, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	// this is an experiemntal endpoint
+	req.Header.Set("X-ExperimentalApi", "opt-in")
+
+	if options != nil {
+		q, err := query.Values(options)
+		if err != nil {
+			return nil, nil, err
+		}
+		req.URL.RawQuery = q.Encode()
+	}
+
+	resp, err := s.client.Do(req, nil)
+	if err != nil {
+		return nil, resp, NewJiraError(resp, err)
+	}
+	defer resp.Body.Close()
+
+	customerList := new(CustomerList)
+	if err := json.NewDecoder(resp.Body).Decode(customerList); err != nil {
+		return nil, resp, fmt.Errorf("could not unmarshall the data into struct")
+	}
+
+	return customerList, resp, nil
+}
+
+// ListCustomers wraps ListCustomersWithContext using the background context.
+func (s *ServiceDeskService) ListCustomers(serviceDeskID int, options *CustomerListOptions) (*CustomerList, *Response, error) {
+	return s.ListCustomersWithContext(context.Background(), serviceDeskID, options)
 }

--- a/servicedesk_test.go
+++ b/servicedesk_test.go
@@ -1,8 +1,12 @@
 package jira
 
 import (
+	"encoding/json"
 	"fmt"
 	"net/http"
+	"reflect"
+	"sort"
+	"strconv"
 	"testing"
 )
 
@@ -189,5 +193,181 @@ func TestServiceDeskServiceStringServiceDeskID_RemoveOrganizations(t *testing.T)
 
 	if err != nil {
 		t.Errorf("Error given: %s", err)
+	}
+}
+
+func TestServiceDeskService_AddCustomers(t *testing.T) {
+	setup()
+	defer teardown()
+
+	var (
+		wantAccountIDs = []string{
+			"qm:a713c8ea-1075-4e30-9d96-891a7d181739:5ad6d3a01db05e2a66fa80bd",
+			"qm:a713c8ea-1075-4e30-9d96-891a7d181739:5ad6d3581db05e2a66fa80b",
+		}
+		gotAccountIDs []string
+	)
+
+	testMux.HandleFunc("/rest/servicedeskapi/servicedesk/10000/customer", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "POST")
+		testRequestURL(t, r, "/rest/servicedeskapi/servicedesk/10000/customer")
+
+		var payload struct {
+			AccountIDs []string `json:"accountIds"`
+		}
+
+		if err := json.NewDecoder(r.Body).Decode(&payload); err != nil {
+			t.Fatal(err)
+		}
+
+		gotAccountIDs = append(gotAccountIDs, payload.AccountIDs...)
+
+		w.WriteHeader(http.StatusNoContent)
+	})
+
+	_, err := testClient.ServiceDesk.AddCustomers(10000, wantAccountIDs...)
+
+	if err != nil {
+		t.Errorf("Error given: %s", err)
+	}
+
+	if want, got := len(wantAccountIDs), len(gotAccountIDs); want != got {
+		t.Fatalf("want account id length: %d, got %d", want, got)
+	}
+
+	sort.Strings(wantAccountIDs)
+	sort.Strings(gotAccountIDs)
+
+	if !reflect.DeepEqual(wantAccountIDs, gotAccountIDs) {
+		t.Fatalf("want account ids: %v, got %v", wantAccountIDs, gotAccountIDs)
+	}
+}
+
+func TestServiceDeskService_RemoveCustomers(t *testing.T) {
+	setup()
+	defer teardown()
+
+	var (
+		wantAccountIDs = []string{
+			"qm:a713c8ea-1075-4e30-9d96-891a7d181739:5ad6d3a01db05e2a66fa80bd",
+			"qm:a713c8ea-1075-4e30-9d96-891a7d181739:5ad6d3581db05e2a66fa80b",
+		}
+		gotAccountIDs []string
+	)
+
+	testMux.HandleFunc("/rest/servicedeskapi/servicedesk/10000/customer", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "DELETE")
+		testRequestURL(t, r, "/rest/servicedeskapi/servicedesk/10000/customer")
+
+		var payload struct {
+			AccountIDs []string `json:"accountIds"`
+		}
+
+		if err := json.NewDecoder(r.Body).Decode(&payload); err != nil {
+			t.Fatal(err)
+		}
+
+		gotAccountIDs = append(gotAccountIDs, payload.AccountIDs...)
+
+		w.WriteHeader(http.StatusNoContent)
+	})
+
+	_, err := testClient.ServiceDesk.RemoveCustomers(10000, wantAccountIDs...)
+
+	if err != nil {
+		t.Errorf("Error given: %s", err)
+	}
+
+	if want, got := len(wantAccountIDs), len(gotAccountIDs); want != got {
+		t.Fatalf("want account id length: %d, got %d", want, got)
+	}
+
+	sort.Strings(wantAccountIDs)
+	sort.Strings(gotAccountIDs)
+
+	if !reflect.DeepEqual(wantAccountIDs, gotAccountIDs) {
+		t.Fatalf("want account ids: %v, got %v", wantAccountIDs, gotAccountIDs)
+	}
+}
+
+func TestServiceDeskService_ListCustomers(t *testing.T) {
+	setup()
+	defer teardown()
+
+	var (
+		email       = "fred@example.com"
+		wantOptions = &CustomerListOptions{
+			Query: email,
+			Start: 1,
+			Limit: 10,
+		}
+
+		gotOptions = new(CustomerListOptions)
+	)
+
+	testMux.HandleFunc("/rest/servicedeskapi/servicedesk/10000/customer", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "GET")
+		testRequestURL(t, r, "/rest/servicedeskapi/servicedesk/10000/customer")
+
+		qs := r.URL.Query()
+		gotOptions.Query = qs.Get("query")
+		if start := qs.Get("start"); start != "" {
+			gotOptions.Start, _ = strconv.Atoi(start)
+		}
+		if limit := qs.Get("limit"); limit != "" {
+			gotOptions.Limit, _ = strconv.Atoi(limit)
+		}
+
+		w.Write([]byte(`{
+		  "_expands": [],
+		  "size": 1,
+		  "start": 1,
+		  "limit": 1,
+		  "isLastPage": false,
+		  "_links": {
+			"base": "https://your-domain.atlassian.net/rest/servicedeskapi",
+			"context": "context",
+			"next": "https://your-domain.atlassian.net/rest/servicedeskapi/servicedesk/1/customer?start=2&limit=1",
+			"prev": "https://your-domain.atlassian.net/rest/servicedeskapi/servicedesk/1/customer?start=0&limit=1"
+		  },
+		  "values": [
+			{
+			  "accountId": "qm:a713c8ea-1075-4e30-9d96-891a7d181739:5ad6d3581db05e2a66fa80b",
+			  "name": "qm:a713c8ea-1075-4e30-9d96-891a7d181739:5ad6d3581db05e2a66fa80b",
+			  "key": "qm:a713c8ea-1075-4e30-9d96-891a7d181739:5ad6d3581db05e2a66fa80b",
+			  "emailAddress": "fred@example.com",
+			  "displayName": "Fred F. User",
+			  "active": true,
+			  "timeZone": "Australia/Sydney",
+			  "_links": {
+				"jiraRest": "https://your-domain.atlassian.net/rest/api/2/user?username=qm:a713c8ea-1075-4e30-9d96-891a7d181739:5ad6d3581db05e2a66fa80b",
+				"avatarUrls": {
+				  "48x48": "https://avatar-cdn.atlassian.com/9bc3b5bcb0db050c6d7660b28a5b86c9?s=48&d=https%3A%2F%2Fsecure.gravatar.com%2Favatar%2F9bc3b5bcb0db050c6d7660b28a5b86c9%3Fd%3Dmm%26s%3D48%26noRedirect%3Dtrue",
+				  "24x24": "https://avatar-cdn.atlassian.com/9bc3b5bcb0db050c6d7660b28a5b86c9?s=24&d=https%3A%2F%2Fsecure.gravatar.com%2Favatar%2F9bc3b5bcb0db050c6d7660b28a5b86c9%3Fd%3Dmm%26s%3D24%26noRedirect%3Dtrue",
+				  "16x16": "https://avatar-cdn.atlassian.com/9bc3b5bcb0db050c6d7660b28a5b86c9?s=16&d=https%3A%2F%2Fsecure.gravatar.com%2Favatar%2F9bc3b5bcb0db050c6d7660b28a5b86c9%3Fd%3Dmm%26s%3D16%26noRedirect%3Dtrue",
+				  "32x32": "https://avatar-cdn.atlassian.com/9bc3b5bcb0db050c6d7660b28a5b86c9?s=32&d=https%3A%2F%2Fsecure.gravatar.com%2Favatar%2F9bc3b5bcb0db050c6d7660b28a5b86c9%3Fd%3Dmm%26s%3D32%26noRedirect%3Dtrue"
+				},
+				"self": "https://your-domain.atlassian.net/rest/api/2/user?username=qm:a713c8ea-1075-4e30-9d96-891a7d181739:5ad6d3581db05e2a66fa80b"
+			  }
+			}
+		  ]
+		}`))
+	})
+
+	customerList, _, err := testClient.ServiceDesk.ListCustomers(10000, wantOptions)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if !reflect.DeepEqual(wantOptions, gotOptions) {
+		t.Fatalf("want options: %#v, got %#v", wantOptions, gotOptions)
+	}
+
+	if want, got := 1, len(customerList.Values); want != got {
+		t.Fatalf("want customer count: %d, got %d", want, got)
+	}
+
+	if want, got := email, customerList.Values[0].EmailAddress; want != got {
+		t.Fatalf("want customer email: %q, got %q", want, got)
 	}
 }

--- a/servicedesk_test.go
+++ b/servicedesk_test.go
@@ -197,177 +197,234 @@ func TestServiceDeskServiceStringServiceDeskID_RemoveOrganizations(t *testing.T)
 }
 
 func TestServiceDeskService_AddCustomers(t *testing.T) {
-	setup()
-	defer teardown()
-
-	var (
-		wantAccountIDs = []string{
-			"qm:a713c8ea-1075-4e30-9d96-891a7d181739:5ad6d3a01db05e2a66fa80bd",
-			"qm:a713c8ea-1075-4e30-9d96-891a7d181739:5ad6d3581db05e2a66fa80b",
-		}
-		gotAccountIDs []string
-	)
-
-	testMux.HandleFunc("/rest/servicedeskapi/servicedesk/10000/customer", func(w http.ResponseWriter, r *http.Request) {
-		testMethod(t, r, "POST")
-		testRequestURL(t, r, "/rest/servicedeskapi/servicedesk/10000/customer")
-
-		var payload struct {
-			AccountIDs []string `json:"accountIds"`
-		}
-
-		if err := json.NewDecoder(r.Body).Decode(&payload); err != nil {
-			t.Fatal(err)
-		}
-
-		gotAccountIDs = append(gotAccountIDs, payload.AccountIDs...)
-
-		w.WriteHeader(http.StatusNoContent)
-	})
-
-	_, err := testClient.ServiceDesk.AddCustomers(10000, wantAccountIDs...)
-
-	if err != nil {
-		t.Errorf("Error given: %s", err)
+	tests := []struct {
+		name          string
+		serviceDeskID interface{}
+	}{
+		{
+			name:          "string service desk id",
+			serviceDeskID: "10000",
+		},
+		{
+			name:          "int service desk id",
+			serviceDeskID: 10000,
+		},
 	}
 
-	if want, got := len(wantAccountIDs), len(gotAccountIDs); want != got {
-		t.Fatalf("want account id length: %d, got %d", want, got)
-	}
+	for _, test := range tests {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			setup()
+			defer teardown()
 
-	sort.Strings(wantAccountIDs)
-	sort.Strings(gotAccountIDs)
+			var (
+				wantAccountIDs = []string{
+					"qm:a713c8ea-1075-4e30-9d96-891a7d181739:5ad6d3a01db05e2a66fa80bd",
+					"qm:a713c8ea-1075-4e30-9d96-891a7d181739:5ad6d3581db05e2a66fa80b",
+				}
+				gotAccountIDs []string
+			)
 
-	if !reflect.DeepEqual(wantAccountIDs, gotAccountIDs) {
-		t.Fatalf("want account ids: %v, got %v", wantAccountIDs, gotAccountIDs)
+			testMux.HandleFunc(fmt.Sprintf("/rest/servicedeskapi/servicedesk/%v/customer", test.serviceDeskID), func(w http.ResponseWriter, r *http.Request) {
+				testMethod(t, r, "POST")
+				testRequestURL(t, r, fmt.Sprintf("/rest/servicedeskapi/servicedesk/%v/customer", test.serviceDeskID))
+
+				var payload struct {
+					AccountIDs []string `json:"accountIds"`
+				}
+
+				if err := json.NewDecoder(r.Body).Decode(&payload); err != nil {
+					t.Fatal(err)
+				}
+
+				gotAccountIDs = append(gotAccountIDs, payload.AccountIDs...)
+
+				w.WriteHeader(http.StatusNoContent)
+			})
+
+			_, err := testClient.ServiceDesk.AddCustomers(test.serviceDeskID, wantAccountIDs...)
+
+			if err != nil {
+				t.Errorf("Error given: %s", err)
+			}
+
+			if want, got := len(wantAccountIDs), len(gotAccountIDs); want != got {
+				t.Fatalf("want account id length: %d, got %d", want, got)
+			}
+
+			sort.Strings(wantAccountIDs)
+			sort.Strings(gotAccountIDs)
+
+			if !reflect.DeepEqual(wantAccountIDs, gotAccountIDs) {
+				t.Fatalf("want account ids: %v, got %v", wantAccountIDs, gotAccountIDs)
+			}
+		})
 	}
 }
 
 func TestServiceDeskService_RemoveCustomers(t *testing.T) {
-	setup()
-	defer teardown()
-
-	var (
-		wantAccountIDs = []string{
-			"qm:a713c8ea-1075-4e30-9d96-891a7d181739:5ad6d3a01db05e2a66fa80bd",
-			"qm:a713c8ea-1075-4e30-9d96-891a7d181739:5ad6d3581db05e2a66fa80b",
-		}
-		gotAccountIDs []string
-	)
-
-	testMux.HandleFunc("/rest/servicedeskapi/servicedesk/10000/customer", func(w http.ResponseWriter, r *http.Request) {
-		testMethod(t, r, "DELETE")
-		testRequestURL(t, r, "/rest/servicedeskapi/servicedesk/10000/customer")
-
-		var payload struct {
-			AccountIDs []string `json:"accountIds"`
-		}
-
-		if err := json.NewDecoder(r.Body).Decode(&payload); err != nil {
-			t.Fatal(err)
-		}
-
-		gotAccountIDs = append(gotAccountIDs, payload.AccountIDs...)
-
-		w.WriteHeader(http.StatusNoContent)
-	})
-
-	_, err := testClient.ServiceDesk.RemoveCustomers(10000, wantAccountIDs...)
-
-	if err != nil {
-		t.Errorf("Error given: %s", err)
+	tests := []struct {
+		name          string
+		serviceDeskID interface{}
+	}{
+		{
+			name:          "string service desk id",
+			serviceDeskID: "10000",
+		},
+		{
+			name:          "int service desk id",
+			serviceDeskID: 10000,
+		},
 	}
 
-	if want, got := len(wantAccountIDs), len(gotAccountIDs); want != got {
-		t.Fatalf("want account id length: %d, got %d", want, got)
-	}
+	for _, test := range tests {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			setup()
+			defer teardown()
 
-	sort.Strings(wantAccountIDs)
-	sort.Strings(gotAccountIDs)
+			var (
+				wantAccountIDs = []string{
+					"qm:a713c8ea-1075-4e30-9d96-891a7d181739:5ad6d3a01db05e2a66fa80bd",
+					"qm:a713c8ea-1075-4e30-9d96-891a7d181739:5ad6d3581db05e2a66fa80b",
+				}
+				gotAccountIDs []string
+			)
 
-	if !reflect.DeepEqual(wantAccountIDs, gotAccountIDs) {
-		t.Fatalf("want account ids: %v, got %v", wantAccountIDs, gotAccountIDs)
+			testMux.HandleFunc(fmt.Sprintf("/rest/servicedeskapi/servicedesk/%v/customer", test.serviceDeskID), func(w http.ResponseWriter, r *http.Request) {
+				testMethod(t, r, "DELETE")
+				testRequestURL(t, r, fmt.Sprintf("/rest/servicedeskapi/servicedesk/%v/customer", test.serviceDeskID))
+
+				var payload struct {
+					AccountIDs []string `json:"accountIds"`
+				}
+
+				if err := json.NewDecoder(r.Body).Decode(&payload); err != nil {
+					t.Fatal(err)
+				}
+
+				gotAccountIDs = append(gotAccountIDs, payload.AccountIDs...)
+
+				w.WriteHeader(http.StatusNoContent)
+			})
+
+			_, err := testClient.ServiceDesk.RemoveCustomers(test.serviceDeskID, wantAccountIDs...)
+
+			if err != nil {
+				t.Errorf("Error given: %s", err)
+			}
+
+			if want, got := len(wantAccountIDs), len(gotAccountIDs); want != got {
+				t.Fatalf("want account id length: %d, got %d", want, got)
+			}
+
+			sort.Strings(wantAccountIDs)
+			sort.Strings(gotAccountIDs)
+
+			if !reflect.DeepEqual(wantAccountIDs, gotAccountIDs) {
+				t.Fatalf("want account ids: %v, got %v", wantAccountIDs, gotAccountIDs)
+			}
+		})
 	}
 }
 
 func TestServiceDeskService_ListCustomers(t *testing.T) {
-	setup()
-	defer teardown()
+	tests := []struct {
+		name          string
+		serviceDeskID interface{}
+	}{
+		{
+			name:          "string service desk id",
+			serviceDeskID: "10000",
+		},
+		{
+			name:          "int service desk id",
+			serviceDeskID: 10000,
+		},
+	}
 
-	var (
-		email       = "fred@example.com"
-		wantOptions = &CustomerListOptions{
-			Query: email,
-			Start: 1,
-			Limit: 10,
-		}
+	for _, test := range tests {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			setup()
+			defer teardown()
 
-		gotOptions = new(CustomerListOptions)
-	)
+			var (
+				email       = "fred@example.com"
+				wantOptions = &CustomerListOptions{
+					Query: email,
+					Start: 1,
+					Limit: 10,
+				}
 
-	testMux.HandleFunc("/rest/servicedeskapi/servicedesk/10000/customer", func(w http.ResponseWriter, r *http.Request) {
-		testMethod(t, r, "GET")
-		testRequestURL(t, r, "/rest/servicedeskapi/servicedesk/10000/customer")
+				gotOptions = new(CustomerListOptions)
+			)
 
-		qs := r.URL.Query()
-		gotOptions.Query = qs.Get("query")
-		if start := qs.Get("start"); start != "" {
-			gotOptions.Start, _ = strconv.Atoi(start)
-		}
-		if limit := qs.Get("limit"); limit != "" {
-			gotOptions.Limit, _ = strconv.Atoi(limit)
-		}
+			testMux.HandleFunc(fmt.Sprintf("/rest/servicedeskapi/servicedesk/%v/customer", test.serviceDeskID), func(w http.ResponseWriter, r *http.Request) {
+				testMethod(t, r, "GET")
+				testRequestURL(t, r, fmt.Sprintf("/rest/servicedeskapi/servicedesk/%v/customer", test.serviceDeskID))
 
-		w.Write([]byte(`{
-		  "_expands": [],
-		  "size": 1,
-		  "start": 1,
-		  "limit": 1,
-		  "isLastPage": false,
-		  "_links": {
-			"base": "https://your-domain.atlassian.net/rest/servicedeskapi",
-			"context": "context",
-			"next": "https://your-domain.atlassian.net/rest/servicedeskapi/servicedesk/1/customer?start=2&limit=1",
-			"prev": "https://your-domain.atlassian.net/rest/servicedeskapi/servicedesk/1/customer?start=0&limit=1"
-		  },
-		  "values": [
-			{
-			  "accountId": "qm:a713c8ea-1075-4e30-9d96-891a7d181739:5ad6d3581db05e2a66fa80b",
-			  "name": "qm:a713c8ea-1075-4e30-9d96-891a7d181739:5ad6d3581db05e2a66fa80b",
-			  "key": "qm:a713c8ea-1075-4e30-9d96-891a7d181739:5ad6d3581db05e2a66fa80b",
-			  "emailAddress": "fred@example.com",
-			  "displayName": "Fred F. User",
-			  "active": true,
-			  "timeZone": "Australia/Sydney",
-			  "_links": {
-				"jiraRest": "https://your-domain.atlassian.net/rest/api/2/user?username=qm:a713c8ea-1075-4e30-9d96-891a7d181739:5ad6d3581db05e2a66fa80b",
-				"avatarUrls": {
-				  "48x48": "https://avatar-cdn.atlassian.com/9bc3b5bcb0db050c6d7660b28a5b86c9?s=48&d=https%3A%2F%2Fsecure.gravatar.com%2Favatar%2F9bc3b5bcb0db050c6d7660b28a5b86c9%3Fd%3Dmm%26s%3D48%26noRedirect%3Dtrue",
-				  "24x24": "https://avatar-cdn.atlassian.com/9bc3b5bcb0db050c6d7660b28a5b86c9?s=24&d=https%3A%2F%2Fsecure.gravatar.com%2Favatar%2F9bc3b5bcb0db050c6d7660b28a5b86c9%3Fd%3Dmm%26s%3D24%26noRedirect%3Dtrue",
-				  "16x16": "https://avatar-cdn.atlassian.com/9bc3b5bcb0db050c6d7660b28a5b86c9?s=16&d=https%3A%2F%2Fsecure.gravatar.com%2Favatar%2F9bc3b5bcb0db050c6d7660b28a5b86c9%3Fd%3Dmm%26s%3D16%26noRedirect%3Dtrue",
-				  "32x32": "https://avatar-cdn.atlassian.com/9bc3b5bcb0db050c6d7660b28a5b86c9?s=32&d=https%3A%2F%2Fsecure.gravatar.com%2Favatar%2F9bc3b5bcb0db050c6d7660b28a5b86c9%3Fd%3Dmm%26s%3D32%26noRedirect%3Dtrue"
-				},
-				"self": "https://your-domain.atlassian.net/rest/api/2/user?username=qm:a713c8ea-1075-4e30-9d96-891a7d181739:5ad6d3581db05e2a66fa80b"
-			  }
+				qs := r.URL.Query()
+				gotOptions.Query = qs.Get("query")
+				if start := qs.Get("start"); start != "" {
+					gotOptions.Start, _ = strconv.Atoi(start)
+				}
+				if limit := qs.Get("limit"); limit != "" {
+					gotOptions.Limit, _ = strconv.Atoi(limit)
+				}
+
+				w.Write([]byte(`{
+				  "_expands": [],
+				  "size": 1,
+				  "start": 1,
+				  "limit": 1,
+				  "isLastPage": false,
+				  "_links": {
+					"base": "https://your-domain.atlassian.net/rest/servicedeskapi",
+					"context": "context",
+					"next": "https://your-domain.atlassian.net/rest/servicedeskapi/servicedesk/1/customer?start=2&limit=1",
+					"prev": "https://your-domain.atlassian.net/rest/servicedeskapi/servicedesk/1/customer?start=0&limit=1"
+				  },
+				  "values": [
+					{
+					  "accountId": "qm:a713c8ea-1075-4e30-9d96-891a7d181739:5ad6d3581db05e2a66fa80b",
+					  "name": "qm:a713c8ea-1075-4e30-9d96-891a7d181739:5ad6d3581db05e2a66fa80b",
+					  "key": "qm:a713c8ea-1075-4e30-9d96-891a7d181739:5ad6d3581db05e2a66fa80b",
+					  "emailAddress": "fred@example.com",
+					  "displayName": "Fred F. User",
+					  "active": true,
+					  "timeZone": "Australia/Sydney",
+					  "_links": {
+						"jiraRest": "https://your-domain.atlassian.net/rest/api/2/user?username=qm:a713c8ea-1075-4e30-9d96-891a7d181739:5ad6d3581db05e2a66fa80b",
+						"avatarUrls": {
+						  "48x48": "https://avatar-cdn.atlassian.com/9bc3b5bcb0db050c6d7660b28a5b86c9?s=48&d=https%3A%2F%2Fsecure.gravatar.com%2Favatar%2F9bc3b5bcb0db050c6d7660b28a5b86c9%3Fd%3Dmm%26s%3D48%26noRedirect%3Dtrue",
+						  "24x24": "https://avatar-cdn.atlassian.com/9bc3b5bcb0db050c6d7660b28a5b86c9?s=24&d=https%3A%2F%2Fsecure.gravatar.com%2Favatar%2F9bc3b5bcb0db050c6d7660b28a5b86c9%3Fd%3Dmm%26s%3D24%26noRedirect%3Dtrue",
+						  "16x16": "https://avatar-cdn.atlassian.com/9bc3b5bcb0db050c6d7660b28a5b86c9?s=16&d=https%3A%2F%2Fsecure.gravatar.com%2Favatar%2F9bc3b5bcb0db050c6d7660b28a5b86c9%3Fd%3Dmm%26s%3D16%26noRedirect%3Dtrue",
+						  "32x32": "https://avatar-cdn.atlassian.com/9bc3b5bcb0db050c6d7660b28a5b86c9?s=32&d=https%3A%2F%2Fsecure.gravatar.com%2Favatar%2F9bc3b5bcb0db050c6d7660b28a5b86c9%3Fd%3Dmm%26s%3D32%26noRedirect%3Dtrue"
+						},
+						"self": "https://your-domain.atlassian.net/rest/api/2/user?username=qm:a713c8ea-1075-4e30-9d96-891a7d181739:5ad6d3581db05e2a66fa80b"
+					  }
+					}
+				  ]
+				}`))
+			})
+
+			customerList, _, err := testClient.ServiceDesk.ListCustomers(test.serviceDeskID, wantOptions)
+			if err != nil {
+				t.Fatal(err)
 			}
-		  ]
-		}`))
-	})
 
-	customerList, _, err := testClient.ServiceDesk.ListCustomers(10000, wantOptions)
-	if err != nil {
-		t.Fatal(err)
-	}
+			if !reflect.DeepEqual(wantOptions, gotOptions) {
+				t.Fatalf("want options: %#v, got %#v", wantOptions, gotOptions)
+			}
 
-	if !reflect.DeepEqual(wantOptions, gotOptions) {
-		t.Fatalf("want options: %#v, got %#v", wantOptions, gotOptions)
-	}
+			if want, got := 1, len(customerList.Values); want != got {
+				t.Fatalf("want customer count: %d, got %d", want, got)
+			}
 
-	if want, got := 1, len(customerList.Values); want != got {
-		t.Fatalf("want customer count: %d, got %d", want, got)
-	}
-
-	if want, got := email, customerList.Values[0].EmailAddress; want != got {
-		t.Fatalf("want customer email: %q, got %q", want, got)
+			if want, got := email, customerList.Values[0].EmailAddress; want != got {
+				t.Fatalf("want customer email: %q, got %q", want, got)
+			}
+		})
 	}
 }


### PR DESCRIPTION
Information that is useful here:
* **The What**: This adds endpoints for customers and requests in the service desk api.
* **The Why**: Because these endpoints are missing (and I need them in my project).
* **Type of change**: New feature.
* **Breaking change**: This change should be backwards compatible.
* **Related to an issue**: Not that I'm aware of.
* **Jira Version + Type**: Cloud

## Example:

Tests exist for all new endpoints, which is probably the best source of sample code.

# Checklist

* [x] Unit or Integration tests added
  * [x] Good Path
  * [ ] Error Path
* [x] Commits follow conventions described here:
  * [x] [Conventional Commits 1.0.0](https://conventionalcommits.org/en/v1.0.0-beta.4/#summary)
  * [ ] [The seven rules of a great Git commit message](https://chris.beams.io/posts/git-commit/#seven-rules)
* [x] Commits are squashed such that
  * [x] There is 1 commit per isolated change
* [x] I've not made extraneous commits/changes that are unrelated to my change.
