### PR TITLE
Allow import/export of session

### DIFF
--- a/authentication.go
+++ b/authentication.go
@@ -45,7 +45,19 @@ type Session struct {
 		LastFailedLoginTime string `json:"lastFailedLoginTime"`
 		PreviousLoginTime   string `json:"previousLoginTime"`
 	} `json:"loginInfo"`
-	Cookies []*http.Cookie
+	Cookies []*http.Cookie `json:"cookies"`
+}
+
+// ExportSession exports the current session so it can be reused later
+func (s *AuthenticationService) ExportSession() []byte {
+	session, _ := json.Marshal(s.client.session)
+	return session
+}
+
+// ImportSession imports a session
+func (s *AuthenticationService) ImportSession(session []byte) {
+	_ = json.Unmarshal(session, &s.client.session)
+	s.authType = authTypeSession
 }
 
 // AcquireSessionCookieWithContext creates a new session for a user in Jira.


### PR DESCRIPTION
# Description

This adds two functions `ImportSession` and `ExportSession`.  These functions allow you to cache authentication cookies so you don't have to reauthenticate as often.  This is especially useful for CLI apps that don't include a long running process to hold the session.  The session is exported as a json byte array, so it is very easy to store in just about any caching mechanism.  I'll demonstrate Redis below.

## Example:
```go
session, err := redisClient.Get("jiraSession").Bytes()
if err != nil {
    _, err = jiraClient.Authentication.AcquireSessionCookie(jiraUsername, jiraPassword)
    if err != nil {
        return nil, err
    }

    session = jiraClient.Authentication.ExportSession()
    _ = redisClient.Set("jiraSession", session, time.Hour).Err()
} else {
    jiraClient.Authentication.ImportSession(session)
}
```

# Checklist

* [ ] Unit or Integration tests added
  * [ ] Good Path
  * [ ] Error Path
* [ ] Commits follow conventions described here:
  * [ ] [Conventional Commits 1.0.0](https://conventionalcommits.org/en/v1.0.0-beta.4/#summary)
  * [ ] [The seven rules of a great Git commit message](https://chris.beams.io/posts/git-commit/#seven-rules)
* [ ] Commits are squashed such that
  * [ ] There is 1 commit per isolated change
* [ ] I've not made extraneous commits/changes that are unrelated to my change.
