### PR TITLE
handle resource leaks

### DIFF
--- a/authentication.go
+++ b/authentication.go
@@ -142,6 +142,7 @@ func (s *AuthenticationService) LogoutWithContext(ctx context.Context) error {
 	if err != nil {
 		return fmt.Errorf("error sending the logout request: %s", err)
 	}
+	defer resp.Body.Close()
 	if resp.StatusCode != 204 {
 		return fmt.Errorf("the logout was unsuccessful with status %d", resp.StatusCode)
 	}
@@ -182,11 +183,10 @@ func (s *AuthenticationService) GetCurrentUserWithContext(ctx context.Context) (
 	if err != nil {
 		return nil, fmt.Errorf("error sending request to get user info : %s", err)
 	}
+	defer resp.Body.Close()
 	if resp.StatusCode != 200 {
 		return nil, fmt.Errorf("getting user info failed with status : %d", resp.StatusCode)
 	}
-
-	defer resp.Body.Close()
 	ret := new(Session)
 	data, err := ioutil.ReadAll(resp.Body)
 	if err != nil {

--- a/board.go
+++ b/board.go
@@ -213,6 +213,7 @@ func (s *BoardService) CreateBoard(board *Board) (*Board, *Response, error) {
 // DeleteBoardWithContext will delete an agile board.
 //
 // Jira API docs: https://docs.atlassian.com/jira-software/REST/cloud/#agile/1.0/board-deleteBoard
+// Caller must close resp.Body
 func (s *BoardService) DeleteBoardWithContext(ctx context.Context, boardID int) (*Board, *Response, error) {
 	apiEndpoint := fmt.Sprintf("rest/agile/1.0/board/%v", boardID)
 	req, err := s.client.NewRequestWithContext(ctx, "DELETE", apiEndpoint, nil)
@@ -228,6 +229,7 @@ func (s *BoardService) DeleteBoardWithContext(ctx context.Context, boardID int) 
 }
 
 // DeleteBoard wraps DeleteBoardWithContext using the background context.
+// Caller must close resp.Body
 func (s *BoardService) DeleteBoard(boardID int) (*Board, *Response, error) {
 	return s.DeleteBoardWithContext(context.Background(), boardID)
 }

--- a/examples/do/main.go
+++ b/examples/do/main.go
@@ -11,10 +11,11 @@ func main() {
 	req, _ := jiraClient.NewRequest("GET", "/rest/api/2/project", nil)
 
 	projects := new([]jira.Project)
-	_, err := jiraClient.Do(req, projects)
+	res, err := jiraClient.Do(req, projects)
 	if err != nil {
 		panic(err)
 	}
+	defer res.Body.Close()
 
 	for _, project := range *projects {
 		fmt.Printf("%s: %s\n", project.Key, project.Name)

--- a/group.go
+++ b/group.go
@@ -155,6 +155,7 @@ func (s *GroupService) Add(groupname string, username string) (*Group, *Response
 // RemoveWithContext removes user from group
 //
 // Jira API docs: https://docs.atlassian.com/jira/REST/cloud/#api/2/group-removeUserFromGroup
+// Caller must close resp.Body
 func (s *GroupService) RemoveWithContext(ctx context.Context, groupname string, username string) (*Response, error) {
 	apiEndpoint := fmt.Sprintf("/rest/api/2/group/user?groupname=%s&username=%s", groupname, username)
 	req, err := s.client.NewRequestWithContext(ctx, "DELETE", apiEndpoint, nil)
@@ -172,6 +173,7 @@ func (s *GroupService) RemoveWithContext(ctx context.Context, groupname string, 
 }
 
 // Remove wraps RemoveWithContext using the background context.
+// Caller must close resp.Body
 func (s *GroupService) Remove(groupname string, username string) (*Response, error) {
 	return s.RemoveWithContext(context.Background(), groupname, username)
 }

--- a/issue.go
+++ b/issue.go
@@ -632,7 +632,7 @@ func (s *IssueService) Get(issueID string, options *GetQueryOptions) (*Issue, *R
 // DownloadAttachmentWithContext returns a Response of an attachment for a given attachmentID.
 // The attachment is in the Response.Body of the response.
 // This is an io.ReadCloser.
-// The caller should close the resp.Body.
+// Caller must close resp.Body.
 func (s *IssueService) DownloadAttachmentWithContext(ctx context.Context, attachmentID string) (*Response, error) {
 	apiEndpoint := fmt.Sprintf("secure/attachment/%s/", attachmentID)
 	req, err := s.client.NewRequestWithContext(ctx, "GET", apiEndpoint, nil)
@@ -650,6 +650,7 @@ func (s *IssueService) DownloadAttachmentWithContext(ctx context.Context, attach
 }
 
 // DownloadAttachment wraps DownloadAttachmentWithContext using the background context.
+// Caller must close resp.Body
 func (s *IssueService) DownloadAttachment(attachmentID string) (*Response, error) {
 	return s.DownloadAttachmentWithContext(context.Background(), attachmentID)
 }
@@ -698,6 +699,7 @@ func (s *IssueService) PostAttachment(issueID string, r io.Reader, attachmentNam
 }
 
 // DeleteAttachmentWithContext deletes an attachment of a given attachmentID
+// Caller must close resp.Body
 func (s *IssueService) DeleteAttachmentWithContext(ctx context.Context, attachmentID string) (*Response, error) {
 	apiEndpoint := fmt.Sprintf("rest/api/2/attachment/%s", attachmentID)
 
@@ -716,11 +718,13 @@ func (s *IssueService) DeleteAttachmentWithContext(ctx context.Context, attachme
 }
 
 // DeleteAttachment wraps DeleteAttachmentWithContext using the background context.
+// Caller must close resp.Body
 func (s *IssueService) DeleteAttachment(attachmentID string) (*Response, error) {
 	return s.DeleteAttachmentWithContext(context.Background(), attachmentID)
 }
 
 // DeleteLinkWithContext deletes a link of a given linkID
+// Caller must close resp.Body
 func (s *IssueService) DeleteLinkWithContext(ctx context.Context, linkID string) (*Response, error) {
 	apiEndpoint := fmt.Sprintf("rest/api/2/issueLink/%s", linkID)
 
@@ -739,6 +743,7 @@ func (s *IssueService) DeleteLinkWithContext(ctx context.Context, linkID string)
 }
 
 // DeleteLink wraps DeleteLinkWithContext using the background context.
+// Caller must close resp.Body
 func (s *IssueService) DeleteLink(linkID string) (*Response, error) {
 	return s.DeleteLinkWithContext(context.Background(), linkID)
 }
@@ -827,6 +832,7 @@ func (s *IssueService) Create(issue *Issue) (*Issue, *Response, error) {
 // while also specifying query params. The issue is found by key.
 //
 // Jira API docs: https://docs.atlassian.com/jira/REST/cloud/#api/2/issue-editIssue
+// Caller must close resp.Body
 func (s *IssueService) UpdateWithOptionsWithContext(ctx context.Context, issue *Issue, opts *UpdateQueryOptions) (*Issue, *Response, error) {
 	apiEndpoint := fmt.Sprintf("rest/api/2/issue/%v", issue.Key)
 	url, err := addOptions(apiEndpoint, opts)
@@ -850,6 +856,7 @@ func (s *IssueService) UpdateWithOptionsWithContext(ctx context.Context, issue *
 }
 
 // UpdateWithOptions wraps UpdateWithOptionsWithContext using the background context.
+// Caller must close resp.Body
 func (s *IssueService) UpdateWithOptions(issue *Issue, opts *UpdateQueryOptions) (*Issue, *Response, error) {
 	return s.UpdateWithOptionsWithContext(context.Background(), issue, opts)
 }
@@ -869,6 +876,7 @@ func (s *IssueService) Update(issue *Issue) (*Issue, *Response, error) {
 // UpdateIssueWithContext updates an issue from a JSON representation. The issue is found by key.
 //
 // https://docs.atlassian.com/jira/REST/7.4.0/#api/2/issue-editIssue
+// Caller must close resp.Body
 func (s *IssueService) UpdateIssueWithContext(ctx context.Context, jiraID string, data map[string]interface{}) (*Response, error) {
 	apiEndpoint := fmt.Sprintf("rest/api/2/issue/%v", jiraID)
 	req, err := s.client.NewRequestWithContext(ctx, "PUT", apiEndpoint, data)
@@ -886,6 +894,7 @@ func (s *IssueService) UpdateIssueWithContext(ctx context.Context, jiraID string
 }
 
 // UpdateIssue wraps UpdateIssueWithContext using the background context.
+// Caller must close resp.Body
 func (s *IssueService) UpdateIssue(jiraID string, data map[string]interface{}) (*Response, error) {
 	return s.UpdateIssueWithContext(context.Background(), jiraID, data)
 }
@@ -959,6 +968,7 @@ func (s *IssueService) DeleteCommentWithContext(ctx context.Context, issueID, co
 		jerr := NewJiraError(resp, err)
 		return jerr
 	}
+	defer resp.Body.Close()
 
 	return nil
 }
@@ -1035,6 +1045,7 @@ func (s *IssueService) UpdateWorklogRecord(issueID, worklogID string, record *Wo
 // AddLinkWithContext adds a link between two issues.
 //
 // Jira API docs: https://docs.atlassian.com/jira/REST/latest/#api/2/issueLink
+// Caller must close resp.Body
 func (s *IssueService) AddLinkWithContext(ctx context.Context, issueLink *IssueLink) (*Response, error) {
 	apiEndpoint := "rest/api/2/issueLink"
 	req, err := s.client.NewRequestWithContext(ctx, "POST", apiEndpoint, issueLink)
@@ -1051,6 +1062,7 @@ func (s *IssueService) AddLinkWithContext(ctx context.Context, issueLink *IssueL
 }
 
 // AddLink wraps AddLinkWithContext using the background context.
+// Caller must close resp.Body
 func (s *IssueService) AddLink(issueLink *IssueLink) (*Response, error) {
 	return s.AddLinkWithContext(context.Background(), issueLink)
 }
@@ -1242,6 +1254,7 @@ func (s *IssueService) DoTransition(ticketID, transitionID string) (*Response, e
 // When performing the transition you can update or set other issue fields.
 //
 // Jira API docs: https://docs.atlassian.com/jira/REST/latest/#api/2/issue-doTransition
+// Caller must close resp.Body
 func (s *IssueService) DoTransitionWithPayloadWithContext(ctx context.Context, ticketID, payload interface{}) (*Response, error) {
 	apiEndpoint := fmt.Sprintf("rest/api/2/issue/%s/transitions", ticketID)
 
@@ -1259,6 +1272,7 @@ func (s *IssueService) DoTransitionWithPayloadWithContext(ctx context.Context, t
 }
 
 // DoTransitionWithPayload wraps DoTransitionWithPayloadWithContext using the background context.
+// Caller must close resp.Body
 func (s *IssueService) DoTransitionWithPayload(ticketID, payload interface{}) (*Response, error) {
 	return s.DoTransitionWithPayloadWithContext(context.Background(), ticketID, payload)
 }
@@ -1343,6 +1357,7 @@ func InitIssueWithMetaAndFields(metaProject *MetaProject, metaIssuetype *MetaIss
 }
 
 // DeleteWithContext will delete a specified issue.
+// Caller must close resp.Body
 func (s *IssueService) DeleteWithContext(ctx context.Context, issueID string) (*Response, error) {
 	apiEndpoint := fmt.Sprintf("rest/api/2/issue/%s", issueID)
 
@@ -1361,6 +1376,7 @@ func (s *IssueService) DeleteWithContext(ctx context.Context, issueID string) (*
 }
 
 // Delete wraps DeleteWithContext using the background context.
+// Caller must close resp.Body
 func (s *IssueService) Delete(issueID string) (*Response, error) {
 	return s.DeleteWithContext(context.Background(), issueID)
 }
@@ -1405,6 +1421,7 @@ func (s *IssueService) GetWatchers(issueID string) (*[]User, *Response, error) {
 // AddWatcherWithContext adds watcher to the given issue
 //
 // Jira API docs: https://docs.atlassian.com/software/jira/docs/api/REST/latest/#api/2/issue-addWatcher
+// Caller must close resp.Body
 func (s *IssueService) AddWatcherWithContext(ctx context.Context, issueID string, userName string) (*Response, error) {
 	apiEndPoint := fmt.Sprintf("rest/api/2/issue/%s/watchers", issueID)
 
@@ -1422,6 +1439,7 @@ func (s *IssueService) AddWatcherWithContext(ctx context.Context, issueID string
 }
 
 // AddWatcher wraps AddWatcherWithContext using the background context.
+// Caller must close resp.Body
 func (s *IssueService) AddWatcher(issueID string, userName string) (*Response, error) {
 	return s.AddWatcherWithContext(context.Background(), issueID, userName)
 }
@@ -1429,6 +1447,7 @@ func (s *IssueService) AddWatcher(issueID string, userName string) (*Response, e
 // RemoveWatcherWithContext removes given user from given issue
 //
 // Jira API docs: https://docs.atlassian.com/software/jira/docs/api/REST/latest/#api/2/issue-removeWatcher
+// Caller must close resp.Body
 func (s *IssueService) RemoveWatcherWithContext(ctx context.Context, issueID string, userName string) (*Response, error) {
 	apiEndPoint := fmt.Sprintf("rest/api/2/issue/%s/watchers", issueID)
 
@@ -1446,6 +1465,7 @@ func (s *IssueService) RemoveWatcherWithContext(ctx context.Context, issueID str
 }
 
 // RemoveWatcher wraps RemoveWatcherWithContext using the background context.
+// Caller must close resp.Body
 func (s *IssueService) RemoveWatcher(issueID string, userName string) (*Response, error) {
 	return s.RemoveWatcherWithContext(context.Background(), issueID, userName)
 }
@@ -1453,6 +1473,7 @@ func (s *IssueService) RemoveWatcher(issueID string, userName string) (*Response
 // UpdateAssigneeWithContext updates the user assigned to work on the given issue
 //
 // Jira API docs: https://docs.atlassian.com/software/jira/docs/api/REST/7.10.2/#api/2/issue-assign
+// Caller must close resp.Body
 func (s *IssueService) UpdateAssigneeWithContext(ctx context.Context, issueID string, assignee *User) (*Response, error) {
 	apiEndPoint := fmt.Sprintf("rest/api/2/issue/%s/assignee", issueID)
 
@@ -1470,6 +1491,7 @@ func (s *IssueService) UpdateAssigneeWithContext(ctx context.Context, issueID st
 }
 
 // UpdateAssignee wraps UpdateAssigneeWithContext using the background context.
+// Caller must close resp.Body
 func (s *IssueService) UpdateAssignee(issueID string, assignee *User) (*Response, error) {
 	return s.UpdateAssigneeWithContext(context.Background(), issueID, assignee)
 }
@@ -1503,6 +1525,7 @@ func (s *IssueService) GetRemoteLinksWithContext(ctx context.Context, id string)
 }
 
 // GetRemoteLinks wraps GetRemoteLinksWithContext using the background context.
+// Caller must close resp.Body
 func (s *IssueService) GetRemoteLinks(id string) (*[]RemoteLink, *Response, error) {
 	return s.GetRemoteLinksWithContext(context.Background(), id)
 }

--- a/issuelinktype.go
+++ b/issuelinktype.go
@@ -98,6 +98,7 @@ func (s *IssueLinkTypeService) Create(linkType *IssueLinkType) (*IssueLinkType, 
 // UpdateWithContext updates an issue link type.  The issue is found by key.
 //
 // Jira API docs: https://developer.atlassian.com/cloud/jira/platform/rest/v2/#api-rest-api-2-issueLinkType-issueLinkTypeId-put
+// Caller must close resp.Body
 func (s *IssueLinkTypeService) UpdateWithContext(ctx context.Context, linkType *IssueLinkType) (*IssueLinkType, *Response, error) {
 	apiEndpoint := fmt.Sprintf("rest/api/2/issueLinkType/%s", linkType.ID)
 	req, err := s.client.NewRequestWithContext(ctx, "PUT", apiEndpoint, linkType)
@@ -113,6 +114,7 @@ func (s *IssueLinkTypeService) UpdateWithContext(ctx context.Context, linkType *
 }
 
 // Update wraps UpdateWithContext using the background context.
+// Caller must close resp.Body
 func (s *IssueLinkTypeService) Update(linkType *IssueLinkType) (*IssueLinkType, *Response, error) {
 	return s.UpdateWithContext(context.Background(), linkType)
 }
@@ -120,6 +122,7 @@ func (s *IssueLinkTypeService) Update(linkType *IssueLinkType) (*IssueLinkType, 
 // DeleteWithContext deletes an issue link type based on provided ID.
 //
 // Jira API docs: https://developer.atlassian.com/cloud/jira/platform/rest/v2/#api-rest-api-2-issueLinkType-issueLinkTypeId-delete
+// Caller must close resp.Body
 func (s *IssueLinkTypeService) DeleteWithContext(ctx context.Context, ID string) (*Response, error) {
 	apiEndpoint := fmt.Sprintf("rest/api/2/issueLinkType/%s", ID)
 	req, err := s.client.NewRequestWithContext(ctx, "DELETE", apiEndpoint, nil)
@@ -132,6 +135,7 @@ func (s *IssueLinkTypeService) DeleteWithContext(ctx context.Context, ID string)
 }
 
 // Delete wraps DeleteWithContext using the background context.
+// Caller must close resp.Body
 func (s *IssueLinkTypeService) Delete(ID string) (*Response, error) {
 	return s.DeleteWithContext(context.Background(), ID)
 }

--- a/jira.go
+++ b/jira.go
@@ -444,6 +444,7 @@ func (t *CookieAuthTransport) setSessionObject() error {
 	if err != nil {
 		return err
 	}
+	defer resp.Body.Close()
 
 	t.SessionObject = resp.Cookies()
 	return nil

--- a/organization.go
+++ b/organization.go
@@ -161,6 +161,7 @@ func (s *OrganizationService) GetOrganization(organizationID int) (*Organization
 // For example, associations with service desks.
 //
 // Jira API docs: https://developer.atlassian.com/cloud/jira/service-desk/rest/api-group-organization/#api-rest-servicedeskapi-organization-organizationid-delete
+// Caller must close resp.Body
 func (s *OrganizationService) DeleteOrganizationWithContext(ctx context.Context, organizationID int) (*Response, error) {
 	apiEndPoint := fmt.Sprintf("rest/servicedeskapi/organization/%d", organizationID)
 
@@ -180,6 +181,7 @@ func (s *OrganizationService) DeleteOrganizationWithContext(ctx context.Context,
 }
 
 // DeleteOrganization wraps DeleteOrganizationWithContext using the background context.
+// Caller must close resp.Body
 func (s *OrganizationService) DeleteOrganization(organizationID int) (*Response, error) {
 	return s.DeleteOrganizationWithContext(context.Background(), organizationID)
 }
@@ -250,6 +252,7 @@ func (s *OrganizationService) GetProperty(organizationID int, propertyKey string
 // resource to store custom data against an organization.
 //
 // https://developer.atlassian.com/cloud/jira/service-desk/rest/api-group-organization/#api-rest-servicedeskapi-organization-organizationid-property-propertykey-put
+// Caller must close resp.Body
 func (s *OrganizationService) SetPropertyWithContext(ctx context.Context, organizationID int, propertyKey string) (*Response, error) {
 	apiEndPoint := fmt.Sprintf("rest/servicedeskapi/organization/%d/property/%s", organizationID, propertyKey)
 
@@ -270,6 +273,7 @@ func (s *OrganizationService) SetPropertyWithContext(ctx context.Context, organi
 }
 
 // SetProperty wraps SetPropertyWithContext using the background context.
+// Caller must close resp.Body
 func (s *OrganizationService) SetProperty(organizationID int, propertyKey string) (*Response, error) {
 	return s.SetPropertyWithContext(context.Background(), organizationID, propertyKey)
 }
@@ -277,6 +281,7 @@ func (s *OrganizationService) SetProperty(organizationID int, propertyKey string
 // DeletePropertyWithContext removes a property from an organization.
 //
 // https://developer.atlassian.com/cloud/jira/service-desk/rest/api-group-organization/#api-rest-servicedeskapi-organization-organizationid-property-propertykey-delete
+// Caller must close resp.Body
 func (s *OrganizationService) DeletePropertyWithContext(ctx context.Context, organizationID int, propertyKey string) (*Response, error) {
 	apiEndPoint := fmt.Sprintf("rest/servicedeskapi/organization/%d/property/%s", organizationID, propertyKey)
 
@@ -297,6 +302,7 @@ func (s *OrganizationService) DeletePropertyWithContext(ctx context.Context, org
 }
 
 // DeleteProperty wraps DeletePropertyWithContext using the background context.
+// Caller must close resp.Body
 func (s *OrganizationService) DeleteProperty(organizationID int, propertyKey string) (*Response, error) {
 	return s.DeletePropertyWithContext(context.Background(), organizationID, propertyKey)
 }
@@ -336,6 +342,7 @@ func (s *OrganizationService) GetUsers(organizationID int, start int, limit int)
 // AddUsersWithContext adds users to an organization.
 //
 // https://developer.atlassian.com/cloud/jira/service-desk/rest/api-group-organization/#api-rest-servicedeskapi-organization-organizationid-user-post
+// Caller must close resp.Body
 func (s *OrganizationService) AddUsersWithContext(ctx context.Context, organizationID int, users OrganizationUsersDTO) (*Response, error) {
 	apiEndPoint := fmt.Sprintf("rest/servicedeskapi/organization/%d/user", organizationID)
 
@@ -355,6 +362,7 @@ func (s *OrganizationService) AddUsersWithContext(ctx context.Context, organizat
 }
 
 // AddUsers wraps AddUsersWithContext using the background context.
+// Caller must close resp.Body
 func (s *OrganizationService) AddUsers(organizationID int, users OrganizationUsersDTO) (*Response, error) {
 	return s.AddUsersWithContext(context.Background(), organizationID, users)
 }
@@ -362,6 +370,7 @@ func (s *OrganizationService) AddUsers(organizationID int, users OrganizationUse
 // RemoveUsersWithContext removes users from an organization.
 //
 // https://developer.atlassian.com/cloud/jira/service-desk/rest/api-group-organization/#api-rest-servicedeskapi-organization-organizationid-user-delete
+// Caller must close resp.Body
 func (s *OrganizationService) RemoveUsersWithContext(ctx context.Context, organizationID int, users OrganizationUsersDTO) (*Response, error) {
 	apiEndPoint := fmt.Sprintf("rest/servicedeskapi/organization/%d/user", organizationID)
 
@@ -382,6 +391,7 @@ func (s *OrganizationService) RemoveUsersWithContext(ctx context.Context, organi
 }
 
 // RemoveUsers wraps RemoveUsersWithContext using the background context.
+// Caller must close resp.Body
 func (s *OrganizationService) RemoveUsers(organizationID int, users OrganizationUsersDTO) (*Response, error) {
 	return s.RemoveUsersWithContext(context.Background(), organizationID, users)
 }

--- a/servicedesk.go
+++ b/servicedesk.go
@@ -53,6 +53,7 @@ func (s *ServiceDeskService) GetOrganizations(serviceDeskID int, start int, limi
 // and the resource returns a 204 success code.
 //
 // https://developer.atlassian.com/cloud/jira/service-desk/rest/api-group-organization/#api-rest-servicedeskapi-servicedesk-servicedeskid-organization-post
+// Caller must close resp.Body
 func (s *ServiceDeskService) AddOrganizationWithContext(ctx context.Context, serviceDeskID int, organizationID int) (*Response, error) {
 	apiEndPoint := fmt.Sprintf("rest/servicedeskapi/servicedesk/%d/organization", serviceDeskID)
 
@@ -76,6 +77,7 @@ func (s *ServiceDeskService) AddOrganizationWithContext(ctx context.Context, ser
 }
 
 // AddOrganization wraps AddOrganizationWithContext using the background context.
+// Caller must close resp.Body
 func (s *ServiceDeskService) AddOrganization(serviceDeskID int, organizationID int) (*Response, error) {
 	return s.AddOrganizationWithContext(context.Background(), serviceDeskID, organizationID)
 }
@@ -86,6 +88,7 @@ func (s *ServiceDeskService) AddOrganization(serviceDeskID int, organizationID i
 // no change is made and the resource returns a 204 success code.
 //
 // https://developer.atlassian.com/cloud/jira/service-desk/rest/api-group-organization/#api-rest-servicedeskapi-servicedesk-servicedeskid-organization-delete
+// Caller must close resp.Body
 func (s *ServiceDeskService) RemoveOrganizationWithContext(ctx context.Context, serviceDeskID int, organizationID int) (*Response, error) {
 	apiEndPoint := fmt.Sprintf("rest/servicedeskapi/servicedesk/%d/organization", serviceDeskID)
 
@@ -109,6 +112,7 @@ func (s *ServiceDeskService) RemoveOrganizationWithContext(ctx context.Context, 
 }
 
 // RemoveOrganization wraps RemoveOrganizationWithContext using the background context.
+// Caller must close resp.Body
 func (s *ServiceDeskService) RemoveOrganization(serviceDeskID int, organizationID int) (*Response, error) {
 	return s.RemoveOrganizationWithContext(context.Background(), serviceDeskID, organizationID)
 }

--- a/sprint.go
+++ b/sprint.go
@@ -28,6 +28,7 @@ type IssuesInSprintResult struct {
 // The maximum number of issues that can be moved in one operation is 50.
 //
 // Jira API docs: https://docs.atlassian.com/jira-software/REST/cloud/#agile/1.0/sprint-moveIssuesToSprint
+// Caller must close resp.Body
 func (s *SprintService) MoveIssuesToSprintWithContext(ctx context.Context, sprintID int, issueIDs []string) (*Response, error) {
 	apiEndpoint := fmt.Sprintf("rest/agile/1.0/sprint/%d/issue", sprintID)
 
@@ -47,6 +48,7 @@ func (s *SprintService) MoveIssuesToSprintWithContext(ctx context.Context, sprin
 }
 
 // MoveIssuesToSprint wraps MoveIssuesToSprintWithContext using the background context.
+// Caller must close resp.Body
 func (s *SprintService) MoveIssuesToSprint(sprintID int, issueIDs []string) (*Response, error) {
 	return s.MoveIssuesToSprintWithContext(context.Background(), sprintID, issueIDs)
 }

--- a/user.go
+++ b/user.go
@@ -132,6 +132,7 @@ func (s *UserService) Create(user *User) (*User, *Response, error) {
 // Returns http.StatusNoContent on success.
 //
 // Jira API docs: https://developer.atlassian.com/cloud/jira/platform/rest/v2/#api-rest-api-2-user-delete
+// Caller must close resp.Body
 func (s *UserService) DeleteWithContext(ctx context.Context, accountId string) (*Response, error) {
 	apiEndpoint := fmt.Sprintf("/rest/api/2/user?accountId=%s", accountId)
 	req, err := s.client.NewRequestWithContext(ctx, "DELETE", apiEndpoint, nil)
@@ -147,6 +148,7 @@ func (s *UserService) DeleteWithContext(ctx context.Context, accountId string) (
 }
 
 // Delete wraps DeleteWithContext using the background context.
+// Caller must close resp.Body
 func (s *UserService) Delete(accountId string) (*Response, error) {
 	return s.DeleteWithContext(context.Background(), accountId)
 }

--- a/version.go
+++ b/version.go
@@ -89,6 +89,7 @@ func (s *VersionService) Create(version *Version) (*Version, *Response, error) {
 // UpdateWithContext updates a version from a JSON representation.
 //
 // Jira API docs: https://developer.atlassian.com/cloud/jira/platform/rest/#api-api-2-version-id-put
+// Caller must close resp.Body
 func (s *VersionService) UpdateWithContext(ctx context.Context, version *Version) (*Version, *Response, error) {
 	apiEndpoint := fmt.Sprintf("rest/api/2/version/%v", version.ID)
 	req, err := s.client.NewRequestWithContext(ctx, "PUT", apiEndpoint, version)
@@ -108,6 +109,7 @@ func (s *VersionService) UpdateWithContext(ctx context.Context, version *Version
 }
 
 // Update wraps UpdateWithContext using the background context.
+// Caller must close resp.Body
 func (s *VersionService) Update(version *Version) (*Version, *Response, error) {
 	return s.UpdateWithContext(context.Background(), version)
 }


### PR DESCRIPTION
# Description

This MR cleans up resource leaks of response bodies.

There are a few categories of changes:
- closing resp.Body when the response is not returned and the interface{} provided to client.Do() is nil
- instructing the caller to close resp.Body when a response is returned and the interface{} provided to client.Do() is nil