### PR TITLE
Add request body logger

### DIFF
--- a/error_logger.go
+++ b/error_logger.go
@@ -1,0 +1,16 @@
+package jira
+
+import (
+	"io"
+	"log"
+	"os"
+)
+
+func BodyLog(body io.ReadCloser){
+	if body!=nil && os.Getenv("DEBUG_REQUEST")=="YES"{
+		data, _ := io.ReadAll(body)
+		body.Close()
+		log.Println(string(data))
+		data=nil
+	}
+}

--- a/issue.go
+++ b/issue.go
@@ -810,7 +810,6 @@ func (s *IssueService) CreateWithContext(ctx context.Context, issue *Issue) (*Is
 	defer resp.Body.Close()
 	data, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
-
 		return nil, resp, fmt.Errorf("could not read the returned data")
 	}
 	err = json.Unmarshal(data, responseIssue)

--- a/issue.go
+++ b/issue.go
@@ -802,6 +802,7 @@ func (s *IssueService) CreateWithContext(ctx context.Context, issue *Issue) (*Is
 	resp, err := s.client.Do(req, nil)
 	if err != nil {
 		// incase of error return the resp for further inspection
+		BodyLog(resp.Body)
 		return nil, resp, err
 	}
 
@@ -809,6 +810,7 @@ func (s *IssueService) CreateWithContext(ctx context.Context, issue *Issue) (*Is
 	defer resp.Body.Close()
 	data, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
+
 		return nil, resp, fmt.Errorf("could not read the returned data")
 	}
 	err = json.Unmarshal(data, responseIssue)


### PR DESCRIPTION
Hi,

Jira return additional information in body response. Let's add logger for error response body. 
To activate, you need to add the environment variable 
```
export DEBUG_REQUEST = YES
```
BRGD
Alex