### PR TITLE
fix!: update Add/Remove due to 'username' argument being deprecated

### DIFF
--- a/group_test.go
+++ b/group_test.go
@@ -87,7 +87,7 @@ func TestGroupService_Add(t *testing.T) {
 		fmt.Fprint(w, `{"name":"default","self":"http://www.example.com/jira/rest/api/2/group?groupname=default","users":{"size":1,"items":[],"max-results":50,"start-index":0,"end-index":0},"expand":"users"}`)
 	})
 
-	if group, _, err := testClient.Group.Add("default", "theodore"); err != nil {
+	if group, _, err := testClient.Group.Add("default", "000000000000000000000000"); err != nil {
 		t.Errorf("Error given: %s", err)
 	} else if group == nil {
 		t.Error("Expected group. Group is nil")
@@ -105,7 +105,7 @@ func TestGroupService_Remove(t *testing.T) {
 		fmt.Fprint(w, `{"name":"default","self":"http://www.example.com/jira/rest/api/2/group?groupname=default","users":{"size":1,"items":[],"max-results":50,"start-index":0,"end-index":0},"expand":"users"}`)
 	})
 
-	if _, err := testClient.Group.Remove("default", "theodore"); err != nil {
+	if _, err := testClient.Group.Remove("default", "000000000000000000000000"); err != nil {
 		t.Errorf("Error given: %s", err)
 	}
 }


### PR DESCRIPTION
BREAKING CHANGE: Replace 'username' argument with 'accountID'
Refer to: https://developer.atlassian.com/cloud/jira/platform/deprecation-notice-user-privacy-api-migration-guide/

Modify `Group` struct fields to reflect different fields returned by the API and documented JIRA API URLs to match the [JIRA docs](https://developer.atlassian.com/cloud/jira/platform/rest/v2/api-group-groups/#api-rest-api-2-group-user-post)


# Description

Please describe _what does this Pull Request fix or add?_


* **The What**: Update documented JIRA API URLs and modify Group struct & Add/Remove to match the JIRA docs
* **The Why**: The Add/Remove methods will fail upon being called now as they try to add or remove a user from group using their username, which is now deprecated. This update allows us to use these methods with the latest JIRA API.
* **Type of change**: Bugfix
* **Breaking change**: Yes, users will have to use accountid instead of username as argument to the abovementioned methods. 
* **Related to an issue**: NA
* **Jira Version + Type**: Jira Cloud

## Example:

Let us know how users can use or test this functionality.

```go
// Add
group, resp, err := testClient.Group.Add("default", "000000000000000000000000");

// Remove
resp, err := testClient.Group.Remove("default", "000000000000000000000000"); 
```

# Checklist

* [x] Unit or Integration tests added
  * [x] Good Path
  * [ ] Error Path
* [x] Commits follow conventions described here:
  * [x] [Conventional Commits 1.0.0](https://conventionalcommits.org/en/v1.0.0-beta.4/#summary)
  * [ ] [The seven rules of a great Git commit message](https://chris.beams.io/posts/git-commit/#seven-rules)
* [ ] Commits are squashed such that
  * [ ] There is 1 commit per isolated change
* [x] I've not made extraneous commits/changes that are unrelated to my change.
