### PR TITLE
feat: added support for personal-access-tokens

### DIFF
--- a/authentication_test.go
+++ b/authentication_test.go
@@ -133,7 +133,7 @@ func TestAuthenticationService_Authenticated_WithBasicAuthButNoUsername(t *testi
 	}
 }
 
-func TestAithenticationService_GetUserInfo_AccessForbidden_Fail(t *testing.T) {
+func TestAuthenticationService_GetUserInfo_AccessForbidden_Fail(t *testing.T) {
 	setup()
 	defer teardown()
 	testMux.HandleFunc("/rest/auth/1/session", func(w http.ResponseWriter, r *http.Request) {

--- a/jira.go
+++ b/jira.go
@@ -382,6 +382,40 @@ func (t *BasicAuthTransport) transport() http.RoundTripper {
 	return http.DefaultTransport
 }
 
+// PATAuthTransport is an http.RoundTripper that authenticates all requests
+// using the Personal Access Token specified.
+type PATAuthTransport struct {
+	Token string
+
+	// Transport is the underlying HTTP transport to use when making requests.
+	// It will default to http.DefaultTransport if nil.
+	Transport http.RoundTripper
+}
+
+// RoundTrip implements the RoundTripper interface.  We just add the
+// basic auth and return the RoundTripper for this transport type.
+func (t *PATAuthTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	req2 := cloneRequest(req) // per RoundTripper contract
+	req2.Header.Set("Authorization", "Bearer "+t.Token)
+	return t.transport().RoundTrip(req2)
+}
+
+// Client returns an *http.Client that makes requests that are authenticated
+// using HTTP Basic Authentication.  This is a nice little bit of sugar
+// so we can just get the client instead of creating the client in the calling code.
+// If it's necessary to send more information on client init, the calling code can
+// always skip this and set the transport itself.
+func (t *PATAuthTransport) Client() *http.Client {
+	return &http.Client{Transport: t}
+}
+
+func (t *PATAuthTransport) transport() http.RoundTripper {
+	if t.Transport != nil {
+		return t.Transport
+	}
+	return http.DefaultTransport
+}
+
 // CookieAuthTransport is an http.RoundTripper that authenticates all requests
 // using Jira's cookie-based authentication.
 //

--- a/jira.go
+++ b/jira.go
@@ -384,7 +384,9 @@ func (t *BasicAuthTransport) transport() http.RoundTripper {
 
 // PATAuthTransport is an http.RoundTripper that authenticates all requests
 // using the Personal Access Token specified.
+// See here for more info: https://confluence.atlassian.com/enterprise/using-personal-access-tokens-1026032365.html
 type PATAuthTransport struct {
+	// Token is the key that was provided by Jira when creating the Personal Access Token.
 	Token string
 
 	// Transport is the underlying HTTP transport to use when making requests.

--- a/jira_test.go
+++ b/jira_test.go
@@ -631,3 +631,26 @@ func TestJWTAuthTransport_HeaderContainsJWT(t *testing.T) {
 	jwtClient, _ := NewClient(jwtTransport.Client(), testServer.URL)
 	jwtClient.Issue.Get("TEST-1", nil)
 }
+
+func TestPATAuthTransport_HeaderContainsAuth(t *testing.T) {
+	setup()
+	defer teardown()
+
+	token := "shhh, it's a token"
+
+	patTransport := &PATAuthTransport{
+		Token: token,
+	}
+
+	testMux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		val := r.Header.Get("Authorization")
+		expected := "Bearer " + token
+		if val != expected {
+			t.Errorf("request does not contain bearer token in the Authorization header.")
+		}
+	})
+
+	client, _ := NewClient(patTransport.Client(), testServer.URL)
+	client.User.GetSelf()
+
+}


### PR DESCRIPTION
- added a new PATAuthTransport type that has a 'Token' attribute to hold your unique PAT
- setting the Authorization header with the bearer token in the RoundTrip function.
- added test to prove to the token gets passed via the header
- bonus: fixed typo in existing test name

Resolves #421  

# Description

This PR adds support for authentication using Personal Access Tokens on Jira Data Center.

Information that is useful here:
* **The What**: It adds a new PATAuthTransport type which can be used to create a client that uses PATs to authenticate.
* **The Why**: Using PATs make it easier to run jobs on Jira automatically, without having to maintain usernames/passwords to get access to the on-premise Jira.
* **Type of change**: New feature
* **Breaking change**: No
* **Related to an issue**: This PR fixes issue 421
* **Jira Version + Type**: Jira DataCenter v8.20.1 

## Example:



```go

// Create transport using the PersonalAccessToken specified in the password.
tp := client.PATAuthTransport {
		Token: password,
		Transport: &http.Transport{
			TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
		},
	}

// Open the connection to Jira
jiraClient, err := jira.NewClient(tp.Client(), url)

```

# Checklist

* [ x] Unit or Integration tests added
  * [x ] Good Path
  * [x] Error Path
* [ x] Commits follow conventions described here:
  * [x ] [Conventional Commits 1.0.0](https://conventionalcommits.org/en/v1.0.0-beta.4/#summary)
  * [ x] [The seven rules of a great Git commit message](https://chris.beams.io/posts/git-commit/#seven-rules)
* [ x] Commits are squashed such that
  * [x ] There is 1 commit per isolated change
* [ x] I've not made extraneous commits/changes that are unrelated to my change.
