### PR TITLE
fix: Added support for update section in DoTransitionWithPayload struct

### DIFF
--- a/issue.go
+++ b/issue.go
@@ -317,8 +317,24 @@ type TransitionField struct {
 
 // CreateTransitionPayload is used for creating new issue transitions
 type CreateTransitionPayload struct {
+	Update     TransitionPayloadUpdate `json:"update" structs:"update"`
 	Transition TransitionPayload       `json:"transition" structs:"transition"`
 	Fields     TransitionPayloadFields `json:"fields" structs:"fields"`
+}
+
+// TransitionPayloadUpdate represents the updates of Transition calls like DoTransition
+type TransitionPayloadUpdate struct {
+	Comment []TransitionPayloadComment
+}
+
+// TransitionPayloadComment represents comment in Transition payload
+type TransitionPayloadComment struct {
+	Add TransitionPayloadCommentBody `json:"add" structs:"add"`
+}
+
+// TransitionPayloadCommentBody represents body of comment in payload
+type TransitionPayloadCommentBody struct {
+	Body string `json:"body"`
 }
 
 // TransitionPayload represents the request payload of Transition calls like DoTransition

--- a/issue.go
+++ b/issue.go
@@ -317,24 +317,24 @@ type TransitionField struct {
 
 // CreateTransitionPayload is used for creating new issue transitions
 type CreateTransitionPayload struct {
-	Update     TransitionPayloadUpdate `json:"update" structs:"update"`
+	Update     TransitionPayloadUpdate `json:"update,omitempty" structs:"update,omitempty"`
 	Transition TransitionPayload       `json:"transition" structs:"transition"`
 	Fields     TransitionPayloadFields `json:"fields" structs:"fields"`
 }
 
 // TransitionPayloadUpdate represents the updates of Transition calls like DoTransition
 type TransitionPayloadUpdate struct {
-	Comment []TransitionPayloadComment `json:"comment" structs:"comment"`
+	Comment []TransitionPayloadComment `json:"comment,omitempty" structs:"comment,omitempty"`
 }
 
 // TransitionPayloadComment represents comment in Transition payload
 type TransitionPayloadComment struct {
-	Add TransitionPayloadCommentBody `json:"add" structs:"add"`
+	Add TransitionPayloadCommentBody `json:"add,omitempty" structs:"add,omitempty"`
 }
 
 // TransitionPayloadCommentBody represents body of comment in payload
 type TransitionPayloadCommentBody struct {
-	Body string `json:"body"`
+	Body string `json:"body,omitempty"`
 }
 
 // TransitionPayload represents the request payload of Transition calls like DoTransition

--- a/issue.go
+++ b/issue.go
@@ -324,7 +324,7 @@ type CreateTransitionPayload struct {
 
 // TransitionPayloadUpdate represents the updates of Transition calls like DoTransition
 type TransitionPayloadUpdate struct {
-	Comment []TransitionPayloadComment
+	Comment []TransitionPayloadComment `json:"comment" structs:"comment"`
 }
 
 // TransitionPayloadComment represents comment in Transition payload


### PR DESCRIPTION
# Description

In this commit I've added Update field to CreateTransitionPayload, with this featrue it is now possible to perform transition with posting a comment

It is backward compatible

Related issue: 
https://github.com/andygrunwald/go-jira/issues/248 -- author of issue decided to use self-made struct I've added in this PR 

Jira API docs: [link](https://docs.atlassian.com/software/jira/docs/api/REST/6.2.7/#d2e1312)

Tested on Jira v8.5.9 (on-premise)

## Example:

```go
var comment = "Closed due to age"

i := CreateTransitionPayload{
		Updates: TransitionPayloadUpdate{
			Comment: []TransitionPayloadComment{
				{
					Add: TransitionPayloadCommentBody{Body: comment},
				},
			},
		},
		Transition: jira.TransitionPayload{
			ID: "171",
		},
		Fields: jira.TransitionPayloadFields{
			Resolution: &jira.Resolution{
				ID: "10101",
			},
		},
	}
	resp, _ := jiraClient.Issue.DoTransitionWithPayload(task.ID, issue)
```

# Checklist

* [x] Unit or Integration tests added
  * [x] Good Path
  * [x] Error Path
* [x] Commits follow conventions described here:
  * [x] [Conventional Commits 1.0.0](https://conventionalcommits.org/en/v1.0.0-beta.4/#summary)
  * [x] [The seven rules of a great Git commit message](https://chris.beams.io/posts/git-commit/#seven-rules)
* [ ] Commits are squashed such that
  * [ ] There is 1 commit per isolated change
* [x] I've not made extraneous commits/changes that are unrelated to my change.
