### PR TITLE
Allow user-facing API to set password for user creation

### DIFF
--- a/user.go
+++ b/user.go
@@ -21,7 +21,7 @@ type User struct {
 	AccountType     string     `json:"accountType,omitempty" structs:"accountType,omitempty"`
 	Name            string     `json:"name,omitempty" structs:"name,omitempty"`
 	Key             string     `json:"key,omitempty" structs:"key,omitempty"`
-	Password        string     `json:"-"`
+	Password        string     `json:"password"`
 	EmailAddress    string     `json:"emailAddress,omitempty" structs:"emailAddress,omitempty"`
 	AvatarUrls      AvatarUrls `json:"avatarUrls,omitempty" structs:"avatarUrls,omitempty"`
 	DisplayName     string     `json:"displayName,omitempty" structs:"displayName,omitempty"`


### PR DESCRIPTION

# Description

Previously, a bug existed that would not allow the API user to set the new user's password.


Information that is useful here:
* **The What**: Adding JSON password field
* **The Why**: This will allow the user to set the password field for the user creation
* **Type of change**: This is a bugfix
* **Breaking change**: Should be non-breaking
* **Jira Version + Type**:  JIRA 8.13.0: on-prem

## Example:

Let us know how users can use or test this functionality.

```go
// Example code
client.User.Create(&jira.User{
		EmailAddress: "user@example.com",
		DisplayName:  "example-user",
		Name:         "example-user",
		Password:     "this-is-a-bad-password-example",
}) // this will actually create the user with the given password
```

# Checklist

* [ ] Unit or Integration tests added
  * [ ] Good Path
  * [ ] Error Path
* [ ] Commits follow conventions described here:
  * [ ] [Conventional Commits 1.0.0](https://conventionalcommits.org/en/v1.0.0-beta.4/#summary)
  * [ ] [The seven rules of a great Git commit message](https://chris.beams.io/posts/git-commit/#seven-rules)
* [ ] Commits are squashed such that
  * [ ] There is 1 commit per isolated change
* [X] I've not made extraneous commits/changes that are unrelated to my change.
