### PR TITLE
Missing alias for import in example in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ package main
 
 import (
 	"fmt"
-	"github.com/andygrunwald/go-jira"
+	jira "github.com/andygrunwald/go-jira"
 )
 
 func main() {


### PR DESCRIPTION
Tried to run this example but it wouldn't run without specifying the alias.