### PR TITLE
add missing min/max to BoardConfigurationColumn

### DIFF
--- a/board.go
+++ b/board.go
@@ -117,6 +117,8 @@ type BoardConfigurationColumnConfig struct {
 type BoardConfigurationColumn struct {
 	Name   string                           `json:"name"`
 	Status []BoardConfigurationColumnStatus `json:"statuses"`
+	Min    int                              `json:"min"`
+	Max    int                              `json:"max"`
 }
 
 // BoardConfigurationColumnStatus represents a status in the column configuration

--- a/board.go
+++ b/board.go
@@ -117,8 +117,8 @@ type BoardConfigurationColumnConfig struct {
 type BoardConfigurationColumn struct {
 	Name   string                           `json:"name"`
 	Status []BoardConfigurationColumnStatus `json:"statuses"`
-	Min    int                              `json:"min"`
-	Max    int                              `json:"max"`
+	Min    int                              `json:"min,omitempty"`
+	Max    int                              `json:"max,omitempty"`
 }
 
 // BoardConfigurationColumnStatus represents a status in the column configuration

--- a/board_test.go
+++ b/board_test.go
@@ -248,4 +248,11 @@ func TestBoardService_GetBoardConfigoration(t *testing.T) {
 		t.Errorf("Expected 6 columns. go %d", len(boardConfiguration.ColumnConfig.Columns))
 	}
 
+	backlogColumn := boardConfiguration.ColumnConfig.Columns[0]
+	if backlogColumn.Min != 5 {
+		t.Errorf("Expected a min of 5 issues in backlog. Got %d", backlogColumn.Min)
+	}
+	if backlogColumn.Max != 30 {
+		t.Errorf("Expected a max of 30 issues in backlog. Got %d", backlogColumn.Max)
+	}
 }

--- a/board_test.go
+++ b/board_test.go
@@ -255,4 +255,12 @@ func TestBoardService_GetBoardConfigoration(t *testing.T) {
 	if backlogColumn.Max != 30 {
 		t.Errorf("Expected a max of 30 issues in backlog. Got %d", backlogColumn.Max)
 	}
+
+	inProgressColumn := boardConfiguration.ColumnConfig.Columns[2]
+	if inProgressColumn.Min != 0 {
+		t.Errorf("Expected a min of 0 issues in progress. Got %d", inProgressColumn.Min)
+	}
+	if inProgressColumn.Max != 0 {
+		t.Errorf("Expected a max of 0 issues in progress. Got %d", inProgressColumn.Max)
+	}
 }

--- a/mocks/board_configuration.json
+++ b/mocks/board_configuration.json
@@ -26,7 +26,9 @@
             "id": "10005",
             "self": "https://test.jira.org/rest/api/2/status/10005"
           }
-        ]
+        ],
+        "min": 5,
+        "max": 30
       },
       {
         "name": "Selected for development",


### PR DESCRIPTION
# Description

Please describe _what does this Pull Request fix or add?_.

Information that is useful here:
* **The What**: What is your change doing?
Fixing missing fields in BoardConfigurationColumn struct. 

* **The Why**: Why is your change useful/needed? What is your use case? (this helps us to understand the real world better)
So we can identify what is the min/max of a column and to complete the API implementation 👍 
Doc URL: https://developer.atlassian.com/cloud/jira/software/rest/api-group-board/#api-agile-1-0-board-boardid-configuration-get

Doc pic:
![image](https://user-images.githubusercontent.com/7342697/147704283-006ea12e-649a-4cd6-ae54-054136c34352.png)

* **Type of change**: Things like Bugfix, New feature, Code quality improvements, Dependency upgrade, Documentation, ...
I think it's a new feature, but its also a bug fix, so I labeled the commit as a feature.

* **Breaking change**: Yes or no? Backward compatible?
Backwards compatible

* **Related to an issue**: Does this fix or close an issue? Or is related in any kind?
Did not find any issue

* **Jira Version + Type**: Which Jira version and type (on-premise / cloud) you have used?
Unfortunately I'm not sure.

## Example:

Let us know how users can use or test this functionality.

```go
// Example code
id := 26
boardConf, _, err := jira.Board.GetBoardConfiguration(id)
if err != nil { 
    panic(err)
}
// assuming your board has columns...
log.Println(boardConf.ColumnConfig.Columns[0].Min)
log.Println(boardConf.ColumnConfig.Columns[0].Max)
```

# Checklist

* [X] Unit or Integration tests added
  * [X] Good Path
  * [ ] Error Path
* [X] Commits follow conventions described here:
  * [X] [Conventional Commits 1.0.0](https://conventionalcommits.org/en/v1.0.0-beta.4/#summary)
  * [X] [The seven rules of a great Git commit message](https://chris.beams.io/posts/git-commit/#seven-rules)
* [X] Commits are squashed such that
  * [X] There is 1 commit per isolated change
* [X] I've not made extraneous commits/changes that are unrelated to my change.
