### PR TITLE
feat: add GetIssuesForSprintWithOptions

### DIFF
--- a/mocks/issues_in_sprint_with_changelog.json
+++ b/mocks/issues_in_sprint_with_changelog.json
@@ -1,0 +1,161 @@
+{
+  "expand": "schema,names",
+  "startAt": 0,
+  "maxResults": 50,
+  "total": 10,
+  "issues": [
+    {
+      "expand": "operations,versionedRepresentations,editmeta,changelog,renderedFields",
+      "id": "12338",
+      "self": "https://example.atlassian.net/rest/agile/1.0/issue/12338",
+      "key": "AR-86",
+      "fields": {
+        "issuetype": {
+          "self": "https://example.atlassian.net/rest/api/2/issuetype/3",
+          "id": "3",
+          "description": "A task that needs to be done.",
+          "iconUrl": "https://example.atlassian.net/secure/viewavatar?size=xsmall&avatarId=10418&avatarType=issuetype",
+          "name": "Task",
+          "subtask": false,
+          "avatarId": 10418
+        },
+        "timespent": null,
+        "project": {
+          "self": "https://example.atlassian.net/rest/api/2/project/10302",
+          "id": "10302",
+          "key": "AR",
+          "name": "Team Argon",
+          "avatarUrls": {
+            "48x48": "https://example.atlassian.net/secure/projectavatar?pid=10302&avatarId=10610",
+            "24x24": "https://example.atlassian.net/secure/projectavatar?size=small&pid=10302&avatarId=10610",
+            "16x16": "https://example.atlassian.net/secure/projectavatar?size=xsmall&pid=10302&avatarId=10610",
+            "32x32": "https://example.atlassian.net/secure/projectavatar?size=medium&pid=10302&avatarId=10610"
+          }
+        },
+        "fixVersions": [],
+        "customfield_11200": "0|0zzzzd:vi",
+        "aggregatetimespent": null,
+        "resolution": {
+          "self": "https://example.atlassian.net/rest/api/2/resolution/6",
+          "id": "6",
+          "description": "",
+          "name": "Done"
+        },
+        "customfield_11401": null,
+        "customfield_11400": null,
+        "customfield_10105": 13.0,
+        "customfield_10700": "AR-37",
+        "resolutiondate": "2015-12-07T14:19:13.000-0800",
+        "workratio": -1,
+        "lastViewed": null,
+        "watches": {
+          "self": "https://example.atlassian.net/rest/api/2/issue/AR-86/watchers",
+          "watchCount": 2,
+          "isWatching": true
+        },
+        "created": "2015-12-02T07:39:15.000-0800",
+        "epic": {
+          "id": 11900,
+          "key": "AR-37",
+          "self": "https://example.atlassian.net/rest/agile/1.0/epic/11900",
+          "name": "Moderation: Design",
+          "summary": "Moderation design",
+          "color": {
+            "key": "color_8"
+          },
+          "done": true
+        },
+        "priority": {
+          "self": "https://example.atlassian.net/rest/api/2/priority/3",
+          "iconUrl": "https://example.atlassian.net/images/icons/priorities/major.svg",
+          "name": "Major",
+          "id": "3"
+        },
+        "customfield_10102": null,
+        "customfield_10103": null,
+        "labels": [],
+        "customfield_11700": null,
+        "timeestimate": null,
+        "aggregatetimeoriginalestimate": null,
+        "versions": [],
+        "issuelinks": [],
+        "assignee": {
+          "self": "https://example.atlassian.net/rest/api/2/user?username=mister.morris",
+          "name": "mister.morris",
+          "key": "mister.morris",
+          "emailAddress": "mister.morris@uservoice.com",
+          "avatarUrls": {
+            "48x48": "https://example.atlassian.net/secure/useravatar?ownerId=mister.morris&avatarId=10604",
+            "24x24": "https://example.atlassian.net/secure/useravatar?size=small&ownerId=mister.morris&avatarId=10604",
+            "16x16": "https://example.atlassian.net/secure/useravatar?size=xsmall&ownerId=mister.morris&avatarId=10604",
+            "32x32": "https://example.atlassian.net/secure/useravatar?size=medium&ownerId=mister.morris&avatarId=10604"
+          },
+          "displayName": "mister Morris",
+          "active": true,
+          "timeZone": "America/New_York"
+        },
+        "updated": "2016-02-01T08:17:04.000-0800",
+        "status": {
+          "self": "https://example.atlassian.net/rest/api/2/status/10000",
+          "description": "Ready to move to dev team for grooming",
+          "iconUrl": "https://example.atlassian.net/images/icons/statuses/closed.png",
+          "name": "Ready",
+          "id": "10000",
+          "statusCategory": {
+            "self": "https://example.atlassian.net/rest/api/2/statuscategory/2",
+            "id": 2,
+            "key": "new",
+            "colorName": "blue-gray",
+            "name": "To Do"
+          }
+        }
+      },
+      "changelog": {
+        "histories": [
+          {
+            "id": "11008613",
+            "author": {
+              "self": "https://example.atlassian.net/rest/api/2/user?username=mister.morris%40uservoice.com",
+              "name": "mister.morris@uservoice.com",
+              "key": "mister.morris@uservoice.com",
+              "emailAddress": "mister.morris@uservoice.com",
+              "avatarUrls": {
+                "48x48": "https://example.atlassian.net/secure/useravatar?avatarId=10610",
+                "24x24": "https://example.atlassian.net/secure/useravatar?size=small\u0026avatarId=10610",
+                "16x16": "https://example.atlassian.net/secure/useravatar?size=xsmall\u0026avatarId=10610",
+                "32x32": "https://example.atlassian.net/secure/useravatar?size=medium\u0026avatarId=10610"
+              },
+              "displayName": "mister Morris",
+              "active": true,
+              "timeZone": "America/New_York"
+            },
+            "created": "2016-02-01T08:17:04.000-0800",
+            "items": [
+              {
+                "field": "summary",
+                "fieldtype": "jira",
+                "from": null,
+                "fromString": "A task that needs to be done.",
+                "to": null,
+                "toString": "A task that doesn't need to be done."
+              }
+            ]
+          },
+          {
+            "created": "2016-02-01T08:17:04.000-0800",
+            "items": [
+              {
+                "field": "priority",
+                "fieldtype": "jira",
+                "from": "10300",
+                "fromString": "Major",
+                "to": "10802",
+                "toString": "Minor"
+              }
+            ]
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/sprint_test.go
+++ b/sprint_test.go
@@ -39,18 +39,50 @@ func TestSprintService_MoveIssuesToSprint(t *testing.T) {
 	}
 }
 
+func TestSprintService_GetIssuesForSprintWithOptions(t *testing.T) {
+	setup()
+	defer teardown()
+	testAPIEndpoint := "/rest/agile/1.0/sprint/123/issue"
+
+	raw, err := ioutil.ReadFile("./mocks/issues_in_sprint_with_changelog.json")
+	if err != nil {
+		t.Error(err.Error())
+	}
+	testMux.HandleFunc(testAPIEndpoint, func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "GET")
+		testRequestURL(t, r, testAPIEndpoint)
+		fmt.Fprint(w, string(raw))
+	})
+
+	options := &GetQueryOptions{Expand: "changelog"}
+	issues, _, err := testClient.Sprint.GetIssuesForSprintWithOptions(123, options)
+	if err != nil {
+		t.Errorf("Error given: %v", err)
+	}
+	if issues == nil {
+		t.Error("Expected issues in sprint list. Issues list is nil")
+	}
+	if len(issues) != 1 {
+		t.Errorf("Expect there to be 1 issue in the sprint, found %v", len(issues))
+	}
+	if issues[0].Changelog == nil {
+		t.Errorf("Expect the issue to have not nil Changelog")
+	}
+
+}
+
 func TestSprintService_GetIssuesForSprint(t *testing.T) {
 	setup()
 	defer teardown()
-	testAPIEdpoint := "/rest/agile/1.0/sprint/123/issue"
+	testAPIEndpoint := "/rest/agile/1.0/sprint/123/issue"
 
 	raw, err := ioutil.ReadFile("./mocks/issues_in_sprint.json")
 	if err != nil {
 		t.Error(err.Error())
 	}
-	testMux.HandleFunc(testAPIEdpoint, func(w http.ResponseWriter, r *http.Request) {
+	testMux.HandleFunc(testAPIEndpoint, func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
-		testRequestURL(t, r, testAPIEdpoint)
+		testRequestURL(t, r, testAPIEndpoint)
 		fmt.Fprint(w, string(raw))
 	})
 


### PR DESCRIPTION
# Description

- Add new base method `GetIssuesForSprintWithOptionsWithContext` which accepts a `GetQueryOptions` parameter
- Change `GetIssuesForSprintWithContext` to call the new method with empty options
- Add new `GetIssuesForSprintWithOptions` to call the new method with empty context and received options

This allows us to use common get query parameters (such as `expand`) with this endpoint without having to do a get issue query for fetching issue details.

# Checklist

* [ ] Unit or Integration tests added
  * [x] Good Path
  * [ ] Error Path
* [x] Commits follow conventions described here:
  * [x] [Conventional Commits 1.0.0](https://conventionalcommits.org/en/v1.0.0-beta.4/#summary)
  * [x] [The seven rules of a great Git commit message](https://chris.beams.io/posts/git-commit/#seven-rules)
* [x] Commits are squashed such that
  * [x] There is 1 commit per isolated change
* [x] I've not made extraneous commits/changes that are unrelated to my change.
