### PR TITLE
adds missing struct omitempty tags to the Parent struct

### DIFF
--- a/issue.go
+++ b/issue.go
@@ -283,8 +283,8 @@ type Progress struct {
 
 // Parent represents the parent of a Jira issue, to be used with subtask issue types.
 type Parent struct {
-	ID  string `json:"id,omitempty" structs:"id"`
-	Key string `json:"key,omitempty" structs:"key"`
+	ID  string `json:"id,omitempty" structs:"id,omitempty"`
+	Key string `json:"key,omitempty" structs:"key,omitempty"`
 }
 
 // Time represents the Time definition of Jira as a time.Time of go

--- a/issue_test.go
+++ b/issue_test.go
@@ -1031,6 +1031,7 @@ func TestIssueFields_MarshalJSON_OmitsEmptyFields(t *testing.T) {
 			Name: "Story",
 		},
 		Labels: []string{"aws-docker"},
+		Parent: &Parent{Key: "FOO-300"},
 	}
 
 	rawdata, err := json.Marshal(i)
@@ -1050,6 +1051,12 @@ func TestIssueFields_MarshalJSON_OmitsEmptyFields(t *testing.T) {
 		t.Error("Expected non nil error, received nil")
 	}
 
+	// verify Parent nil values are being omitted
+	_, err = issuef.String("parent/id")
+	if err == nil {
+		t.Error("Expected non nil err, received nil")
+	}
+
 	// verify that the field that should be there, is.
 	name, err := issuef.String("issuetype/name")
 	if err != nil {
@@ -1059,7 +1066,6 @@ func TestIssueFields_MarshalJSON_OmitsEmptyFields(t *testing.T) {
 	if name != "Story" {
 		t.Errorf("Expected Story, received %s", name)
 	}
-
 }
 
 func TestIssueFields_MarshalJSON_Success(t *testing.T) {


### PR DESCRIPTION
updates TestIssueFields_MarshalJSON_OmitsEmptyFields to check for ignored parent fields

# Description

Fixes issue #426, `omitempty` struct tags were missing from jira.Parent, making it impossible to link a parent ticket by only providing the `key` or `id`.

# Checklist

* [x] Unit or Integration tests added
  * [x] Good Path
  * [x] Error Path
* [x] Commits follow conventions described here:
  * [x] [Conventional Commits 1.0.0](https://conventionalcommits.org/en/v1.0.0-beta.4/#summary)
  * [x] [The seven rules of a great Git commit message](https://chris.beams.io/posts/git-commit/#seven-rules)
* [x] Commits are squashed such that
  * [x] There is 1 commit per isolated change
* [x] I've not made extraneous commits/changes that are unrelated to my change.
