### PR TITLE
GitHub Actions Update: Run tests on macOS, deprecate Go v1.15 and Go v1.16, introduce Go v1.18, run CI every night

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -10,9 +10,10 @@ jobs:
   test:
     name: Test and lint
     strategy:
+      fail-fast: false
       matrix:
-        go-version: [1.15.x, 1.16.x, 1.17.x]
-        platform: [ubuntu-latest, windows-latest]
+        go-version: [ '1.18', '1.17' ]
+        os: ["windows-latest", "ubuntu-latest", "macOS-latest"]
     runs-on: ${{ matrix.platform }}
 
     steps:

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -5,6 +5,9 @@ on:
     branches:
       - master
   pull_request:
+  workflow_dispatch:
+  schedule:
+    - cron: "5 1 * * *"
 
 jobs:
   test:


### PR DESCRIPTION
# Description

A major upgrade to our GitHub Actions workflow:

- Run tests on macOS
- Deprecate Go v1.15
- Deprecate Go v1.16
- Introduce Go v1.18
- Run CI every night
- Being able to run the workflow on click