### PR TITLE
feat: Add sprint goal

### DIFF
--- a/board.go
+++ b/board.go
@@ -73,6 +73,7 @@ type Sprint struct {
 	OriginBoardID int        `json:"originBoardId" structs:"originBoardId"`
 	Self          string     `json:"self" structs:"self"`
 	State         string     `json:"state" structs:"state"`
+	Goal          string     `json:"goal,omitempty" structs:"goal"`
 }
 
 // BoardConfiguration represents a boardConfiguration of a jira board

--- a/board_test.go
+++ b/board_test.go
@@ -181,8 +181,8 @@ func TestBoardService_GetAllSprints(t *testing.T) {
 		t.Error("Expected sprint list. Got nil.")
 	}
 
-	if len(sprints) != 4 {
-		t.Errorf("Expected 4 transitions. Got %d", len(sprints))
+	if len(sprints) != 6 {
+		t.Errorf("Expected 6 transitions. Got %d", len(sprints))
 	}
 }
 

--- a/mocks/sprints.json
+++ b/mocks/sprints.json
@@ -41,6 +41,21 @@
             "self": "https://jira.com/rest/agile/1.0/sprint/832",
             "startDate": "2016-06-20T13:24:39.161-07:00",
             "state": "active"
+        },
+        {
+            "id": 845,
+            "self":"https://jira.com/rest/agile/1.0/sprint/845",
+            "state": "future",
+            "name": "Minimal Example Sprint",
+            "originBoardId": 734
+        },
+        {
+            "id": 846,
+            "self": "https://jira.com/rest/agile/1.0/sprint/846",
+            "state": "future",
+            "name": "Sprint with a Goal",
+            "originBoardId": 734,
+            "goal": "My Goal"
         }
     ]
 }


### PR DESCRIPTION
# Description

Adds the optional Goal field to the Sprint Struct

## Example:

```go
// Example code
sprints, _, _ := jiraClient.Board.GetAllSprints(boardID)
fmt.Println(sprints[0].Goal)
```

# Checklist

* [x] Unit or Integration tests added
  * [x] Good Path
  * [x] Error Path
* [x] Commits follow conventions described here:
  * [x] [Conventional Commits 1.0.0](https://conventionalcommits.org/en/v1.0.0-beta.4/#summary)
  * [x] [The seven rules of a great Git commit message](https://chris.beams.io/posts/git-commit/#seven-rules)
* [x] Commits are squashed such that
  * [x] There is 1 commit per isolated change
* [x] I've not made extraneous commits/changes that are unrelated to my change.
