### PR TITLE
feat: add names of response

### DIFF
--- a/issue.go
+++ b/issue.go
@@ -530,10 +530,11 @@ type SearchOptions struct {
 // searchResult is only a small wrapper around the Search (with JQL) method
 // to be able to parse the results
 type searchResult struct {
-	Issues     []Issue `json:"issues" structs:"issues"`
-	StartAt    int     `json:"startAt" structs:"startAt"`
-	MaxResults int     `json:"maxResults" structs:"maxResults"`
-	Total      int     `json:"total" structs:"total"`
+	Issues     []Issue           `json:"issues" structs:"issues"`
+	StartAt    int               `json:"startAt" structs:"startAt"`
+	MaxResults int               `json:"maxResults" structs:"maxResults"`
+	Total      int               `json:"total" structs:"total"`
+	Names      map[string]string `json:"names" structs:"names"`
 }
 
 // GetQueryOptions specifies the optional parameters for the Get Issue methods

--- a/jira.go
+++ b/jira.go
@@ -327,6 +327,7 @@ type Response struct {
 	StartAt    int
 	MaxResults int
 	Total      int
+	Names      map[string]string
 }
 
 func newResponse(r *http.Response, v interface{}) *Response {
@@ -343,6 +344,7 @@ func (r *Response) populatePageValues(v interface{}) {
 		r.StartAt = value.StartAt
 		r.MaxResults = value.MaxResults
 		r.Total = value.Total
+		r.Names = value.Names
 	case *groupMembersResult:
 		r.StartAt = value.StartAt
 		r.MaxResults = value.MaxResults


### PR DESCRIPTION
# Description

Please describe _what does this Pull Request fix or add?_.

Information that is useful here:
* **The What**: Add the names of response
* **The Why**: During my using of go-jira, i need the custome field real name, i can only get it by set search options `expand=names`, however, i can't get the names, so i expand the fields of response to get it
* **Type of change**: Maybe a bugfix
* **Breaking change**: no
* **Related to an issue**: no
* **Jira Version + Type**: v1.15.1 and on-premise

## Example:

Let us know how users can use or test this functionality.

```go
// Example code

```

# Checklist

* [ ] Unit or Integration tests added
  * [ ] Good Path
  * [ ] Error Path
* [ ] Commits follow conventions described here:
  * [ ] [Conventional Commits 1.0.0](https://conventionalcommits.org/en/v1.0.0-beta.4/#summary)
  * [ ] [The seven rules of a great Git commit message](https://chris.beams.io/posts/git-commit/#seven-rules)
* [ ] Commits are squashed such that
  * [ ] There is 1 commit per isolated change
* [ ] I've not made extraneous commits/changes that are unrelated to my change.
