### PR TITLE
Go: Raise supported version to v1.18

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        go: [ '1.18', '1.17' ]
+        go: [ '1.19', '1.18' ]
         os: [ 'windows-latest', 'ubuntu-latest', 'macOS-latest' ]
     runs-on: ${{ matrix.os }}
 

--- a/README.md
+++ b/README.md
@@ -8,6 +8,22 @@
 
 ![Go client library for Atlassian Jira](./img/logo_small.png "Go client library for Atlassian Jira.")
 
+## State of this library
+
+v2 of this library is in development.
+The goals of v2 are:
+
+* idiomatic go usage
+* proper documentation
+* being compliant with different kinds of Atlassian Jira products (on-premise vs. cloud)
+* remove flaws introduced during the early times of this library
+
+See our milestone [Road to v2](https://github.com/andygrunwald/go-jira/milestone/1) and provide feedback in [Development is kicking: Road to v2 🚀 #489](https://github.com/andygrunwald/go-jira/issues/489).
+Attention: The current `main` branch represents the v2 development version - we treat this version as unstable and breaking changes are expected.
+
+If you want to stay more stable, please use v1.* - See our [releases](https://github.com/andygrunwald/go-jira/releases).
+Latest stable release: [v1.16.0](https://github.com/andygrunwald/go-jira/releases/tag/v1.16.0)
+
 ## Features
 
 * Authentication (HTTP Basic, OAuth, Session Cookie)

--- a/README.md
+++ b/README.md
@@ -317,11 +317,11 @@ A few examples:
 
 If you are new to pull requests, checkout [Collaborating on projects using issues and pull requests / Creating a pull request](https://help.github.com/articles/creating-a-pull-request/).
 
-### Dependency management
+### Supported Go versions
 
-`go-jira` uses `go modules` for dependency management.  After cloning the repo, it's easy to make sure you have the correct dependencies by running `go mod tidy`.
+We follow the [Go Release Policy](https://go.dev/doc/devel/release#policy):
 
-For adding new dependencies, updating dependencies, and other operations, the [Daily workflow](https://github.com/golang/go/wiki/Modules#daily-workflow) is a good place to start.
+> Each major Go release is supported until there are two newer major releases. For example, Go 1.5 was supported until the Go 1.7 release, and Go 1.6 was supported until the Go 1.8 release. We fix critical problems, including [critical security problems](https://go.dev/security), in supported releases as needed by issuing minor revisions (for example, Go 1.6.1, Go 1.6.2, and so on).
 
 ### Sandbox environment for testing
 

--- a/authentication.go
+++ b/authentication.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 )
 
@@ -188,7 +188,7 @@ func (s *AuthenticationService) GetCurrentUserWithContext(ctx context.Context) (
 		return nil, fmt.Errorf("getting user info failed with status : %d", resp.StatusCode)
 	}
 	ret := new(Session)
-	data, err := ioutil.ReadAll(resp.Body)
+	data, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return nil, fmt.Errorf("couldn't read body from the response : %s", err)
 	}

--- a/authentication_test.go
+++ b/authentication_test.go
@@ -3,7 +3,7 @@ package jira
 import (
 	"bytes"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"reflect"
 	"testing"
@@ -15,7 +15,7 @@ func TestAuthenticationService_AcquireSessionCookie_Failure(t *testing.T) {
 	testMux.HandleFunc("/rest/auth/1/session", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "POST")
 		testRequestURL(t, r, "/rest/auth/1/session")
-		b, err := ioutil.ReadAll(r.Body)
+		b, err := io.ReadAll(r.Body)
 		if err != nil {
 			t.Errorf("Error in read body: %s", err)
 		}
@@ -49,7 +49,7 @@ func TestAuthenticationService_AcquireSessionCookie_Success(t *testing.T) {
 	testMux.HandleFunc("/rest/auth/1/session", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "POST")
 		testRequestURL(t, r, "/rest/auth/1/session")
-		b, err := ioutil.ReadAll(r.Body)
+		b, err := io.ReadAll(r.Body)
 		if err != nil {
 			t.Errorf("Error in read body: %s", err)
 		}
@@ -140,7 +140,7 @@ func TestAuthenticationService_GetUserInfo_AccessForbidden_Fail(t *testing.T) {
 		if r.Method == "POST" {
 			testMethod(t, r, "POST")
 			testRequestURL(t, r, "/rest/auth/1/session")
-			b, err := ioutil.ReadAll(r.Body)
+			b, err := io.ReadAll(r.Body)
 			if err != nil {
 				t.Errorf("Error in read body: %s", err)
 			}
@@ -178,7 +178,7 @@ func TestAuthenticationService_GetUserInfo_NonOkStatusCode_Fail(t *testing.T) {
 		if r.Method == "POST" {
 			testMethod(t, r, "POST")
 			testRequestURL(t, r, "/rest/auth/1/session")
-			b, err := ioutil.ReadAll(r.Body)
+			b, err := io.ReadAll(r.Body)
 			if err != nil {
 				t.Errorf("Error in read body: %s", err)
 			}
@@ -234,7 +234,7 @@ func TestAuthenticationService_GetUserInfo_Success(t *testing.T) {
 		if r.Method == "POST" {
 			testMethod(t, r, "POST")
 			testRequestURL(t, r, "/rest/auth/1/session")
-			b, err := ioutil.ReadAll(r.Body)
+			b, err := io.ReadAll(r.Body)
 			if err != nil {
 				t.Errorf("Error in read body: %s", err)
 			}
@@ -276,7 +276,7 @@ func TestAuthenticationService_Logout_Success(t *testing.T) {
 		if r.Method == "POST" {
 			testMethod(t, r, "POST")
 			testRequestURL(t, r, "/rest/auth/1/session")
-			b, err := ioutil.ReadAll(r.Body)
+			b, err := io.ReadAll(r.Body)
 			if err != nil {
 				t.Errorf("Error in read body: %s", err)
 			}

--- a/board_test.go
+++ b/board_test.go
@@ -2,8 +2,8 @@ package jira
 
 import (
 	"fmt"
-	"io/ioutil"
 	"net/http"
+	"os"
 	"testing"
 )
 
@@ -12,7 +12,7 @@ func TestBoardService_GetAllBoards(t *testing.T) {
 	defer teardown()
 	testAPIEdpoint := "/rest/agile/1.0/board"
 
-	raw, err := ioutil.ReadFile("./mocks/all_boards.json")
+	raw, err := os.ReadFile("./mocks/all_boards.json")
 	if err != nil {
 		t.Error(err.Error())
 	}
@@ -37,7 +37,7 @@ func TestBoardService_GetAllBoards_WithFilter(t *testing.T) {
 	defer teardown()
 	testAPIEdpoint := "/rest/agile/1.0/board"
 
-	raw, err := ioutil.ReadFile("./mocks/all_boards_filtered.json")
+	raw, err := os.ReadFile("./mocks/all_boards_filtered.json")
 	if err != nil {
 		t.Error(err.Error())
 	}
@@ -160,7 +160,7 @@ func TestBoardService_GetAllSprints(t *testing.T) {
 
 	testAPIEndpoint := "/rest/agile/1.0/board/123/sprint"
 
-	raw, err := ioutil.ReadFile("./mocks/sprints.json")
+	raw, err := os.ReadFile("./mocks/sprints.json")
 	if err != nil {
 		t.Error(err.Error())
 	}
@@ -192,7 +192,7 @@ func TestBoardService_GetAllSprintsWithOptions(t *testing.T) {
 
 	testAPIEndpoint := "/rest/agile/1.0/board/123/sprint"
 
-	raw, err := ioutil.ReadFile("./mocks/sprints_filtered.json")
+	raw, err := os.ReadFile("./mocks/sprints_filtered.json")
 	if err != nil {
 		t.Error(err.Error())
 	}
@@ -223,7 +223,7 @@ func TestBoardService_GetBoardConfigoration(t *testing.T) {
 	defer teardown()
 	testAPIEndpoint := "/rest/agile/1.0/board/35/configuration"
 
-	raw, err := ioutil.ReadFile("./mocks/board_configuration.json")
+	raw, err := os.ReadFile("./mocks/board_configuration.json")
 	if err != nil {
 		t.Error(err.Error())
 	}

--- a/error.go
+++ b/error.go
@@ -4,7 +4,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"strings"
 
 	"github.com/pkg/errors"
@@ -25,7 +25,7 @@ func NewJiraError(resp *Response, httpError error) error {
 	}
 
 	defer resp.Body.Close()
-	body, err := ioutil.ReadAll(resp.Body)
+	body, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return errors.Wrap(err, httpError.Error())
 	}

--- a/examples/addlabel/main.go
+++ b/examples/addlabel/main.go
@@ -3,7 +3,7 @@ package main
 import (
 	"bufio"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"os"
 	"strings"
 	"syscall"
@@ -67,7 +67,7 @@ func main() {
 	if err != nil {
 		fmt.Println(err)
 	}
-	body, _ := ioutil.ReadAll(resp.Body)
+	body, _ := io.ReadAll(resp.Body)
 	fmt.Println(string(body))
 
 	issue, _, _ := client.Issue.Get(issueId, nil)

--- a/field_test.go
+++ b/field_test.go
@@ -2,8 +2,8 @@ package jira
 
 import (
 	"fmt"
-	"io/ioutil"
 	"net/http"
+	"os"
 	"testing"
 )
 
@@ -12,7 +12,7 @@ func TestFieldService_GetList(t *testing.T) {
 	defer teardown()
 	testAPIEdpoint := "/rest/api/2/field"
 
-	raw, err := ioutil.ReadFile("./mocks/all_fields.json")
+	raw, err := os.ReadFile("./mocks/all_fields.json")
 	if err != nil {
 		t.Error(err.Error())
 	}

--- a/filter_test.go
+++ b/filter_test.go
@@ -2,8 +2,8 @@ package jira
 
 import (
 	"fmt"
-	"io/ioutil"
 	"net/http"
+	"os"
 	"testing"
 )
 
@@ -11,7 +11,7 @@ func TestFilterService_GetList(t *testing.T) {
 	setup()
 	defer teardown()
 	testAPIEndpoint := "/rest/api/2/filter"
-	raw, err := ioutil.ReadFile("./mocks/all_filters.json")
+	raw, err := os.ReadFile("./mocks/all_filters.json")
 	if err != nil {
 		t.Error(err.Error())
 	}
@@ -34,7 +34,7 @@ func TestFilterService_Get(t *testing.T) {
 	setup()
 	defer teardown()
 	testAPIEndpoint := "/rest/api/2/filter/10000"
-	raw, err := ioutil.ReadFile("./mocks/filter.json")
+	raw, err := os.ReadFile("./mocks/filter.json")
 	if err != nil {
 		t.Error(err.Error())
 	}
@@ -58,7 +58,7 @@ func TestFilterService_GetFavouriteList(t *testing.T) {
 	setup()
 	defer teardown()
 	testAPIEndpoint := "/rest/api/2/filter/favourite"
-	raw, err := ioutil.ReadFile("./mocks/favourite_filters.json")
+	raw, err := os.ReadFile("./mocks/favourite_filters.json")
 	if err != nil {
 		t.Error(err.Error())
 	}
@@ -81,7 +81,7 @@ func TestFilterService_GetMyFilters(t *testing.T) {
 	setup()
 	defer teardown()
 	testAPIEndpoint := "/rest/api/3/filter/my"
-	raw, err := ioutil.ReadFile("./mocks/my_filters.json")
+	raw, err := os.ReadFile("./mocks/my_filters.json")
 	if err != nil {
 		t.Error(err.Error())
 	}
@@ -105,7 +105,7 @@ func TestFilterService_Search(t *testing.T) {
 	setup()
 	defer teardown()
 	testAPIEndpoint := "/rest/api/3/filter/search"
-	raw, err := ioutil.ReadFile("./mocks/search_filters.json")
+	raw, err := os.ReadFile("./mocks/search_filters.json")
 	if err != nil {
 		t.Error(err.Error())
 	}

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/andygrunwald/go-jira
 
-go 1.15
+go 1.18
 
 require (
 	github.com/fatih/structs v1.1.0
@@ -9,6 +9,7 @@ require (
 	github.com/google/go-querystring v1.1.0
 	github.com/pkg/errors v0.9.1
 	github.com/trivago/tgo v1.0.7
-	golang.org/x/sys v0.0.0-20220330033206-e17cdc41300f // indirect
 	golang.org/x/term v0.0.0-20210220032956-6a3ed077a48d
 )
+
+require golang.org/x/sys v0.0.0-20220330033206-e17cdc41300f // indirect

--- a/issue.go
+++ b/issue.go
@@ -6,7 +6,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"mime/multipart"
 	"net/http"
 	"net/url"
@@ -613,7 +612,7 @@ type RemoteLinkStatus struct {
 // This can be an issue id, or an issue key.
 // If the issue cannot be found via an exact match, Jira will also look for the issue in a case-insensitive way, or by looking to see if the issue was moved.
 //
-// The given options will be appended to the query string
+// # The given options will be appended to the query string
 //
 // Jira API docs: https://docs.atlassian.com/jira/REST/latest/#api/2/issue-getIssue
 func (s *IssueService) GetWithContext(ctx context.Context, issueID string, options *GetQueryOptions) (*Issue, *Response, error) {
@@ -829,7 +828,7 @@ func (s *IssueService) CreateWithContext(ctx context.Context, issue *Issue) (*Is
 
 	responseIssue := new(Issue)
 	defer resp.Body.Close()
-	data, err := ioutil.ReadAll(resp.Body)
+	data, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return nil, resp, fmt.Errorf("could not read the returned data")
 	}
@@ -1295,15 +1294,17 @@ func (s *IssueService) DoTransitionWithPayload(ticketID, payload interface{}) (*
 }
 
 // InitIssueWithMetaAndFields returns Issue with with values from fieldsConfig properly set.
-//  * metaProject should contain metaInformation about the project where the issue should be created.
-//  * metaIssuetype is the MetaInformation about the Issuetype that needs to be created.
-//  * fieldsConfig is a key->value pair where key represents the name of the field as seen in the UI
-//		And value is the string value for that particular key.
+//   - metaProject should contain metaInformation about the project where the issue should be created.
+//   - metaIssuetype is the MetaInformation about the Issuetype that needs to be created.
+//   - fieldsConfig is a key->value pair where key represents the name of the field as seen in the UI
+//     And value is the string value for that particular key.
+//
 // Note: This method doesn't verify that the fieldsConfig is complete with mandatory fields. The fieldsConfig is
-//		 supposed to be already verified with MetaIssueType.CheckCompleteAndAvailable. It will however return
-//		 error if the key is not found.
-//		 All values will be packed into Unknowns. This is much convenient. If the struct fields needs to be
-//		 configured as well, marshalling and unmarshalling will set the proper fields.
+//
+//	supposed to be already verified with MetaIssueType.CheckCompleteAndAvailable. It will however return
+//	error if the key is not found.
+//	All values will be packed into Unknowns. This is much convenient. If the struct fields needs to be
+//	configured as well, marshalling and unmarshalling will set the proper fields.
 func InitIssueWithMetaAndFields(metaProject *MetaProject, metaIssuetype *MetaIssueType, fieldsConfig map[string]string) (*Issue, error) {
 	issue := new(Issue)
 	issueFields := new(IssueFields)

--- a/issue_test.go
+++ b/issue_test.go
@@ -4,8 +4,8 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
+	"os"
 	"reflect"
 	"strings"
 	"testing"
@@ -418,7 +418,7 @@ func TestIssueService_DownloadAttachment(t *testing.T) {
 	}
 	defer resp.Body.Close()
 
-	attachment, err := ioutil.ReadAll(resp.Body)
+	attachment, err := io.ReadAll(resp.Body)
 	if err != nil {
 		t.Error("Expected attachment text", err)
 	}
@@ -477,7 +477,7 @@ func TestIssueService_PostAttachment(t *testing.T) {
 			status = http.StatusNoContent
 		} else {
 			// Read the file into memory
-			data, err := ioutil.ReadAll(file)
+			data, err := io.ReadAll(file)
 			if err != nil {
 				status = http.StatusInternalServerError
 			}
@@ -823,7 +823,7 @@ func TestIssueService_GetTransitions(t *testing.T) {
 
 	testAPIEndpoint := "/rest/api/2/issue/123/transitions"
 
-	raw, err := ioutil.ReadFile("./mocks/transitions.json")
+	raw, err := os.ReadFile("./mocks/transitions.json")
 	if err != nil {
 		t.Error(err.Error())
 	}
@@ -1787,7 +1787,7 @@ func TestIssueService_GetRemoteLinks(t *testing.T) {
 
 	testAPIEndpoint := "/rest/api/2/issue/123/remotelink"
 
-	raw, err := ioutil.ReadFile("./mocks/remote_links.json")
+	raw, err := os.ReadFile("./mocks/remote_links.json")
 	if err != nil {
 		t.Error(err.Error())
 	}

--- a/issuelinktype.go
+++ b/issuelinktype.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 )
 
 // IssueLinkTypeService handles issue link types for the Jira instance / API.
@@ -77,7 +77,7 @@ func (s *IssueLinkTypeService) CreateWithContext(ctx context.Context, linkType *
 
 	responseLinkType := new(IssueLinkType)
 	defer resp.Body.Close()
-	data, err := ioutil.ReadAll(resp.Body)
+	data, err := io.ReadAll(resp.Body)
 	if err != nil {
 		e := fmt.Errorf("could not read the returned data")
 		return nil, resp, NewJiraError(resp, e)

--- a/issuelinktype_test.go
+++ b/issuelinktype_test.go
@@ -2,8 +2,8 @@ package jira
 
 import (
 	"fmt"
-	"io/ioutil"
 	"net/http"
+	"os"
 	"testing"
 )
 
@@ -12,7 +12,7 @@ func TestIssueLinkTypeService_GetList(t *testing.T) {
 	defer teardown()
 	testAPIEndpoint := "/rest/api/2/issueLinkType"
 
-	raw, err := ioutil.ReadFile("./mocks/all_issuelinktypes.json")
+	raw, err := os.ReadFile("./mocks/all_issuelinktypes.json")
 	if err != nil {
 		t.Error(err.Error())
 	}

--- a/jira.go
+++ b/jira.go
@@ -561,8 +561,9 @@ func (t *CookieAuthTransport) transport() http.RoundTripper {
 //
 // Jira docs: https://developer.atlassian.com/cloud/jira/platform/understanding-jwt
 // Examples in other languages:
-//    https://bitbucket.org/atlassian/atlassian-jwt-ruby/src/d44a8e7a4649e4f23edaa784402655fda7c816ea/lib/atlassian/jwt.rb
-//    https://bitbucket.org/atlassian/atlassian-jwt-py/src/master/atlassian_jwt/url_utils.py
+//
+//	https://bitbucket.org/atlassian/atlassian-jwt-ruby/src/d44a8e7a4649e4f23edaa784402655fda7c816ea/lib/atlassian/jwt.rb
+//	https://bitbucket.org/atlassian/atlassian-jwt-py/src/master/atlassian_jwt/url_utils.py
 type JWTAuthTransport struct {
 	Secret []byte
 	Issuer string

--- a/jira_test.go
+++ b/jira_test.go
@@ -3,7 +3,7 @@ package jira
 import (
 	"bytes"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -172,7 +172,7 @@ func TestClient_NewRequest(t *testing.T) {
 	}
 
 	// Test that body was JSON encoded
-	body, _ := ioutil.ReadAll(req.Body)
+	body, _ := io.ReadAll(req.Body)
 	if got, want := string(body), outBody; got != want {
 		t.Errorf("NewRequest(%v) Body is %v, want %v", inBody, got, want)
 	}
@@ -196,7 +196,7 @@ func TestClient_NewRawRequest(t *testing.T) {
 	}
 
 	// Test that body was JSON encoded
-	body, _ := ioutil.ReadAll(req.Body)
+	body, _ := io.ReadAll(req.Body)
 	if got, want := string(body), outBody; got != want {
 		t.Errorf("NewRawRequest(%v) Body is %v, want %v", inBody, got, want)
 	}
@@ -386,7 +386,7 @@ func TestClient_Do_HTTPResponse(t *testing.T) {
 
 	req, _ := testClient.NewRequest("GET", "/", nil)
 	res, _ := testClient.Do(req, nil)
-	_, err := ioutil.ReadAll(res.Body)
+	_, err := io.ReadAll(res.Body)
 
 	if err != nil {
 		t.Errorf("Error on parsing HTTP Response = %v", err.Error())

--- a/metaissue.go
+++ b/metaissue.go
@@ -148,19 +148,21 @@ func (p *MetaProject) GetIssueTypeWithName(name string) *MetaIssueType {
 
 // GetMandatoryFields returns a map of all the required fields from the MetaIssueTypes.
 // if a field returned by the api was:
-// "customfield_10806": {
-//					"required": true,
-//					"schema": {
-//						"type": "any",
-//						"custom": "com.pyxis.greenhopper.jira:gh-epic-link",
-//						"customId": 10806
-//					},
-//					"name": "Epic Link",
-//					"hasDefaultValue": false,
-//					"operations": [
-//						"set"
-//					]
-//				}
+//
+//	"customfield_10806": {
+//						"required": true,
+//						"schema": {
+//							"type": "any",
+//							"custom": "com.pyxis.greenhopper.jira:gh-epic-link",
+//							"customId": 10806
+//						},
+//						"name": "Epic Link",
+//						"hasDefaultValue": false,
+//						"operations": [
+//							"set"
+//						]
+//					}
+//
 // the returned map would have "Epic Link" as the key and "customfield_10806" as value.
 // This choice has been made so that the it is easier to generate the create api request later.
 func (t *MetaIssueType) GetMandatoryFields() (map[string]string, error) {

--- a/permissionschemes_test.go
+++ b/permissionschemes_test.go
@@ -2,8 +2,8 @@ package jira
 
 import (
 	"fmt"
-	"io/ioutil"
 	"net/http"
+	"os"
 	"testing"
 )
 
@@ -12,7 +12,7 @@ func TestPermissionSchemeService_GetList(t *testing.T) {
 	defer teardown()
 	testAPIEndpoint := "/rest/api/3/permissionscheme"
 
-	raw, err := ioutil.ReadFile("./mocks/all_permissionschemes.json")
+	raw, err := os.ReadFile("./mocks/all_permissionschemes.json")
 	if err != nil {
 		t.Error(err.Error())
 	}
@@ -40,7 +40,7 @@ func TestPermissionSchemeService_GetList_NoList(t *testing.T) {
 	defer teardown()
 	testAPIEndpoint := "/rest/api/3/permissionscheme"
 
-	raw, err := ioutil.ReadFile("./mocks/no_permissionschemes.json")
+	raw, err := os.ReadFile("./mocks/no_permissionschemes.json")
 	if err != nil {
 		t.Error(err.Error())
 	}
@@ -63,7 +63,7 @@ func TestPermissionSchemeService_Get(t *testing.T) {
 	setup()
 	defer teardown()
 	testAPIEdpoint := "/rest/api/3/permissionscheme/10100"
-	raw, err := ioutil.ReadFile("./mocks/permissionscheme.json")
+	raw, err := os.ReadFile("./mocks/permissionscheme.json")
 	if err != nil {
 		t.Error(err.Error())
 	}
@@ -86,7 +86,7 @@ func TestPermissionSchemeService_Get_NoScheme(t *testing.T) {
 	setup()
 	defer teardown()
 	testAPIEdpoint := "/rest/api/3/permissionscheme/99999"
-	raw, err := ioutil.ReadFile("./mocks/no_permissionscheme.json")
+	raw, err := os.ReadFile("./mocks/no_permissionscheme.json")
 	if err != nil {
 		t.Error(err.Error())
 	}

--- a/priority_test.go
+++ b/priority_test.go
@@ -2,8 +2,8 @@ package jira
 
 import (
 	"fmt"
-	"io/ioutil"
 	"net/http"
+	"os"
 	"testing"
 )
 
@@ -12,7 +12,7 @@ func TestPriorityService_GetList(t *testing.T) {
 	defer teardown()
 	testAPIEdpoint := "/rest/api/2/priority"
 
-	raw, err := ioutil.ReadFile("./mocks/all_priorities.json")
+	raw, err := os.ReadFile("./mocks/all_priorities.json")
 	if err != nil {
 		t.Error(err.Error())
 	}

--- a/project_test.go
+++ b/project_test.go
@@ -2,8 +2,8 @@ package jira
 
 import (
 	"fmt"
-	"io/ioutil"
 	"net/http"
+	"os"
 	"testing"
 )
 
@@ -12,7 +12,7 @@ func TestProjectService_GetList(t *testing.T) {
 	defer teardown()
 	testAPIEdpoint := "/rest/api/2/project"
 
-	raw, err := ioutil.ReadFile("./mocks/all_projects.json")
+	raw, err := os.ReadFile("./mocks/all_projects.json")
 	if err != nil {
 		t.Error(err.Error())
 	}
@@ -36,7 +36,7 @@ func TestProjectService_ListWithOptions(t *testing.T) {
 	defer teardown()
 	testAPIEdpoint := "/rest/api/2/project"
 
-	raw, err := ioutil.ReadFile("./mocks/all_projects.json")
+	raw, err := os.ReadFile("./mocks/all_projects.json")
 	if err != nil {
 		t.Error(err.Error())
 	}
@@ -60,7 +60,7 @@ func TestProjectService_Get(t *testing.T) {
 	defer teardown()
 	testAPIEdpoint := "/rest/api/2/project/12310505"
 
-	raw, err := ioutil.ReadFile("./mocks/project.json")
+	raw, err := os.ReadFile("./mocks/project.json")
 	if err != nil {
 		t.Error(err.Error())
 	}

--- a/resolution_test.go
+++ b/resolution_test.go
@@ -2,8 +2,8 @@ package jira
 
 import (
 	"fmt"
-	"io/ioutil"
 	"net/http"
+	"os"
 	"testing"
 )
 
@@ -12,7 +12,7 @@ func TestResolutionService_GetList(t *testing.T) {
 	defer teardown()
 	testAPIEdpoint := "/rest/api/2/resolution"
 
-	raw, err := ioutil.ReadFile("./mocks/all_resolutions.json")
+	raw, err := os.ReadFile("./mocks/all_resolutions.json")
 	if err != nil {
 		t.Error(err.Error())
 	}

--- a/role_test.go
+++ b/role_test.go
@@ -2,8 +2,8 @@ package jira
 
 import (
 	"fmt"
-	"io/ioutil"
 	"net/http"
+	"os"
 	"testing"
 )
 
@@ -12,7 +12,7 @@ func TestRoleService_GetList_NoList(t *testing.T) {
 	defer teardown()
 	testAPIEndpoint := "/rest/api/3/role"
 
-	raw, err := ioutil.ReadFile("./mocks/no_roles.json")
+	raw, err := os.ReadFile("./mocks/no_roles.json")
 	if err != nil {
 		t.Error(err.Error())
 	}
@@ -37,7 +37,7 @@ func TestRoleService_GetList(t *testing.T) {
 	defer teardown()
 	testAPIEndpoint := "/rest/api/3/role"
 
-	raw, err := ioutil.ReadFile("./mocks/all_roles.json")
+	raw, err := os.ReadFile("./mocks/all_roles.json")
 	if err != nil {
 		t.Error(err.Error())
 	}
@@ -64,7 +64,7 @@ func TestRoleService_Get_NoRole(t *testing.T) {
 	setup()
 	defer teardown()
 	testAPIEdpoint := "/rest/api/3/role/99999"
-	raw, err := ioutil.ReadFile("./mocks/no_role.json")
+	raw, err := os.ReadFile("./mocks/no_role.json")
 	if err != nil {
 		t.Error(err.Error())
 	}
@@ -87,7 +87,7 @@ func TestRoleService_Get(t *testing.T) {
 	setup()
 	defer teardown()
 	testAPIEdpoint := "/rest/api/3/role/10002"
-	raw, err := ioutil.ReadFile("./mocks/role.json")
+	raw, err := os.ReadFile("./mocks/role.json")
 	if err != nil {
 		t.Error(err.Error())
 	}

--- a/servicedesk.go
+++ b/servicedesk.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 
 	"github.com/google/go-querystring/query"
 )
@@ -144,7 +143,7 @@ func (s *ServiceDeskService) AddCustomersWithContext(ctx context.Context, servic
 	}
 
 	defer resp.Body.Close()
-	_, _ = io.Copy(ioutil.Discard, resp.Body)
+	_, _ = io.Copy(io.Discard, resp.Body)
 
 	return resp, nil
 }
@@ -176,7 +175,7 @@ func (s *ServiceDeskService) RemoveCustomersWithContext(ctx context.Context, ser
 	}
 
 	defer resp.Body.Close()
-	_, _ = io.Copy(ioutil.Discard, resp.Body)
+	_, _ = io.Copy(io.Discard, resp.Body)
 
 	return resp, nil
 }

--- a/sprint.go
+++ b/sprint.go
@@ -86,7 +86,7 @@ func (s *SprintService) GetIssuesForSprint(sprintID int) ([]Issue, *Response, er
 // This can be an issue id, or an issue key.
 // If the issue cannot be found via an exact match, Jira will also look for the issue in a case-insensitive way, or by looking to see if the issue was moved.
 //
-// The given options will be appended to the query string
+// # The given options will be appended to the query string
 //
 // Jira API docs: https://docs.atlassian.com/jira-software/REST/7.3.1/#agile/1.0/issue-getIssue
 //

--- a/sprint_test.go
+++ b/sprint_test.go
@@ -3,8 +3,8 @@ package jira
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"net/http"
+	"os"
 	"reflect"
 	"testing"
 )
@@ -44,7 +44,7 @@ func TestSprintService_GetIssuesForSprint(t *testing.T) {
 	defer teardown()
 	testAPIEdpoint := "/rest/agile/1.0/sprint/123/issue"
 
-	raw, err := ioutil.ReadFile("./mocks/issues_in_sprint.json")
+	raw, err := os.ReadFile("./mocks/issues_in_sprint.json")
 	if err != nil {
 		t.Error(err.Error())
 	}

--- a/status_test.go
+++ b/status_test.go
@@ -2,8 +2,8 @@ package jira
 
 import (
 	"fmt"
-	"io/ioutil"
 	"net/http"
+	"os"
 	"testing"
 )
 
@@ -12,7 +12,7 @@ func TestStatusService_GetAllStatuses(t *testing.T) {
 	defer teardown()
 	testAPIEdpoint := "/rest/api/2/status"
 
-	raw, err := ioutil.ReadFile("./mocks/all_statuses.json")
+	raw, err := os.ReadFile("./mocks/all_statuses.json")
 	if err != nil {
 		t.Error(err.Error())
 	}

--- a/statuscategory_test.go
+++ b/statuscategory_test.go
@@ -2,8 +2,8 @@ package jira
 
 import (
 	"fmt"
-	"io/ioutil"
 	"net/http"
+	"os"
 	"testing"
 )
 
@@ -12,7 +12,7 @@ func TestStatusCategoryService_GetList(t *testing.T) {
 	defer teardown()
 	testAPIEdpoint := "/rest/api/2/statuscategory"
 
-	raw, err := ioutil.ReadFile("./mocks/all_statuscategories.json")
+	raw, err := os.ReadFile("./mocks/all_statuscategories.json")
 	if err != nil {
 		t.Error(err.Error())
 	}

--- a/user.go
+++ b/user.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 )
 
 // UserService handles users for the Jira instance / API.
@@ -110,7 +110,7 @@ func (s *UserService) CreateWithContext(ctx context.Context, user *User) (*User,
 
 	responseUser := new(User)
 	defer resp.Body.Close()
-	data, err := ioutil.ReadAll(resp.Body)
+	data, err := io.ReadAll(resp.Body)
 	if err != nil {
 		e := fmt.Errorf("could not read the returned data")
 		return nil, resp, NewJiraError(resp, e)

--- a/version.go
+++ b/version.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 )
 
 // VersionService handles Versions for the Jira instance / API.
@@ -68,7 +68,7 @@ func (s *VersionService) CreateWithContext(ctx context.Context, version *Version
 
 	responseVersion := new(Version)
 	defer resp.Body.Close()
-	data, err := ioutil.ReadAll(resp.Body)
+	data, err := io.ReadAll(resp.Body)
 	if err != nil {
 		e := fmt.Errorf("could not read the returned data")
 		return nil, resp, NewJiraError(resp, e)


### PR DESCRIPTION
* [README: Add chapter "Supported Go versions"](https://github.com/andygrunwald/go-jira/commit/327bb0beaf431ee3f1bde867fb3bd67579911124)
* [Go: Raise supported version to v1.18](https://github.com/andygrunwald/go-jira/commit/d46911661c68c1a7750d39e1eb3d373aeb7f3cc2)

Important: Merge https://github.com/andygrunwald/go-jira/pull/490 for before this one.