### PR TITLE
Add APIVersion field to control API endpoint path

### DIFF
--- a/component.go
+++ b/component.go
@@ -1,6 +1,9 @@
 package jira
 
-import "context"
+import (
+	"context"
+	"fmt"
+)
 
 // ComponentService handles components for the Jira instance / API.//
 // Jira API docs: https://docs.atlassian.com/software/jira/docs/api/REST/7.10.1/#api/2/component
@@ -22,7 +25,7 @@ type CreateComponentOptions struct {
 
 // CreateWithContext creates a new Jira component based on the given options.
 func (s *ComponentService) CreateWithContext(ctx context.Context, options *CreateComponentOptions) (*ProjectComponent, *Response, error) {
-	apiEndpoint := "rest/api/2/component"
+	apiEndpoint := fmt.Sprintf("rest/api/%s/component", s.client.APIVersion)
 	req, err := s.client.NewRequestWithContext(ctx, "POST", apiEndpoint, options)
 	if err != nil {
 		return nil, nil, err

--- a/filter.go
+++ b/filter.go
@@ -124,7 +124,7 @@ type FilterSearchOptions struct {
 func (fs *FilterService) GetListWithContext(ctx context.Context) ([]*Filter, *Response, error) {
 
 	options := &GetQueryOptions{}
-	apiEndpoint := "rest/api/2/filter"
+	apiEndpoint := fmt.Sprintf("rest/api/%s/filter", fs.client.APIVersion)
 	req, err := fs.client.NewRequestWithContext(ctx, "GET", apiEndpoint, nil)
 	if err != nil {
 		return nil, nil, err
@@ -152,7 +152,7 @@ func (fs *FilterService) GetList() ([]*Filter, *Response, error) {
 
 // GetFavouriteListWithContext retrieves the user's favourited filters from Jira
 func (fs *FilterService) GetFavouriteListWithContext(ctx context.Context) ([]*Filter, *Response, error) {
-	apiEndpoint := "rest/api/2/filter/favourite"
+	apiEndpoint := fmt.Sprintf("rest/api/%s/filter/favourite", fs.client.APIVersion)
 	req, err := fs.client.NewRequestWithContext(ctx, "GET", apiEndpoint, nil)
 	if err != nil {
 		return nil, nil, err
@@ -173,7 +173,7 @@ func (fs *FilterService) GetFavouriteList() ([]*Filter, *Response, error) {
 
 // GetWithContext retrieves a single Filter from Jira
 func (fs *FilterService) GetWithContext(ctx context.Context, filterID int) (*Filter, *Response, error) {
-	apiEndpoint := fmt.Sprintf("rest/api/2/filter/%d", filterID)
+	apiEndpoint := fmt.Sprintf("rest/api/%s/filter/%d", fs.client.APIVersion, filterID)
 	req, err := fs.client.NewRequestWithContext(ctx, "GET", apiEndpoint, nil)
 	if err != nil {
 		return nil, nil, err

--- a/group.go
+++ b/group.go
@@ -95,10 +95,11 @@ func (s *GroupService) Get(name string) ([]GroupMember, *Response, error) {
 func (s *GroupService) GetWithOptionsWithContext(ctx context.Context, name string, options *GroupSearchOptions) ([]GroupMember, *Response, error) {
 	var apiEndpoint string
 	if options == nil {
-		apiEndpoint = fmt.Sprintf("/rest/api/2/group/member?groupname=%s", url.QueryEscape(name))
+		apiEndpoint = fmt.Sprintf("/rest/api/%s/group/member?groupname=%s", s.client.APIVersion, url.QueryEscape(name))
 	} else {
 		apiEndpoint = fmt.Sprintf(
-			"/rest/api/2/group/member?groupname=%s&startAt=%d&maxResults=%d&includeInactiveUsers=%t",
+			"/rest/api/%s/group/member?groupname=%s&startAt=%d&maxResults=%d&includeInactiveUsers=%t",
+			s.client.APIVersion,
 			url.QueryEscape(name),
 			options.StartAt,
 			options.MaxResults,
@@ -127,7 +128,7 @@ func (s *GroupService) GetWithOptions(name string, options *GroupSearchOptions) 
 //
 // Jira API docs: https://docs.atlassian.com/jira/REST/cloud/#api/2/group-addUserToGroup
 func (s *GroupService) AddWithContext(ctx context.Context, groupname string, username string) (*Group, *Response, error) {
-	apiEndpoint := fmt.Sprintf("/rest/api/2/group/user?groupname=%s", groupname)
+	apiEndpoint := fmt.Sprintf("/rest/api/%s/group/user?groupname=%s", s.client.APIVersion, groupname)
 	var user struct {
 		Name string `json:"name"`
 	}
@@ -157,7 +158,7 @@ func (s *GroupService) Add(groupname string, username string) (*Group, *Response
 // Jira API docs: https://docs.atlassian.com/jira/REST/cloud/#api/2/group-removeUserFromGroup
 // Caller must close resp.Body
 func (s *GroupService) RemoveWithContext(ctx context.Context, groupname string, username string) (*Response, error) {
-	apiEndpoint := fmt.Sprintf("/rest/api/2/group/user?groupname=%s&username=%s", groupname, username)
+	apiEndpoint := fmt.Sprintf("/rest/api/%s/group/user?groupname=%s&username=%s", s.client.APIVersion, groupname, username)
 	req, err := s.client.NewRequestWithContext(ctx, "DELETE", apiEndpoint, nil)
 	if err != nil {
 		return nil, err

--- a/issue.go
+++ b/issue.go
@@ -616,7 +616,7 @@ type RemoteLinkStatus struct {
 //
 // Jira API docs: https://docs.atlassian.com/jira/REST/latest/#api/2/issue-getIssue
 func (s *IssueService) GetWithContext(ctx context.Context, issueID string, options *GetQueryOptions) (*Issue, *Response, error) {
-	apiEndpoint := fmt.Sprintf("rest/api/2/issue/%s", issueID)
+	apiEndpoint := fmt.Sprintf("rest/api/%s/issue/%s", s.client.APIVersion, issueID)
 	req, err := s.client.NewRequestWithContext(ctx, "GET", apiEndpoint, nil)
 	if err != nil {
 		return nil, nil, err
@@ -673,7 +673,7 @@ func (s *IssueService) DownloadAttachment(attachmentID string) (*Response, error
 
 // PostAttachmentWithContext uploads r (io.Reader) as an attachment to a given issueID
 func (s *IssueService) PostAttachmentWithContext(ctx context.Context, issueID string, r io.Reader, attachmentName string) (*[]Attachment, *Response, error) {
-	apiEndpoint := fmt.Sprintf("rest/api/2/issue/%s/attachments", issueID)
+	apiEndpoint := fmt.Sprintf("rest/api/%s/issue/%s/attachments", s.client.APIVersion, issueID)
 
 	b := new(bytes.Buffer)
 	writer := multipart.NewWriter(b)
@@ -717,7 +717,7 @@ func (s *IssueService) PostAttachment(issueID string, r io.Reader, attachmentNam
 // DeleteAttachmentWithContext deletes an attachment of a given attachmentID
 // Caller must close resp.Body
 func (s *IssueService) DeleteAttachmentWithContext(ctx context.Context, attachmentID string) (*Response, error) {
-	apiEndpoint := fmt.Sprintf("rest/api/2/attachment/%s", attachmentID)
+	apiEndpoint := fmt.Sprintf("rest/api/%s/attachment/%s", s.client.APIVersion, attachmentID)
 
 	req, err := s.client.NewRequestWithContext(ctx, "DELETE", apiEndpoint, nil)
 	if err != nil {
@@ -742,7 +742,7 @@ func (s *IssueService) DeleteAttachment(attachmentID string) (*Response, error) 
 // DeleteLinkWithContext deletes a link of a given linkID
 // Caller must close resp.Body
 func (s *IssueService) DeleteLinkWithContext(ctx context.Context, linkID string) (*Response, error) {
-	apiEndpoint := fmt.Sprintf("rest/api/2/issueLink/%s", linkID)
+	apiEndpoint := fmt.Sprintf("rest/api/%s/issueLink/%s", s.client.APIVersion, linkID)
 
 	req, err := s.client.NewRequestWithContext(ctx, "DELETE", apiEndpoint, nil)
 	if err != nil {
@@ -769,7 +769,7 @@ func (s *IssueService) DeleteLink(linkID string) (*Response, error) {
 //
 // https://docs.atlassian.com/jira/REST/cloud/#api/2/issue/{issueIdOrKey}/worklog-getIssueWorklog
 func (s *IssueService) GetWorklogsWithContext(ctx context.Context, issueID string, options ...func(*http.Request) error) (*Worklog, *Response, error) {
-	apiEndpoint := fmt.Sprintf("rest/api/2/issue/%s/worklog", issueID)
+	apiEndpoint := fmt.Sprintf("rest/api/%s/issue/%s/worklog", s.client.APIVersion, issueID)
 
 	req, err := s.client.NewRequestWithContext(ctx, "GET", apiEndpoint, nil)
 	if err != nil {
@@ -815,7 +815,7 @@ func WithQueryOptions(options interface{}) func(*http.Request) error {
 //
 // Jira API docs: https://docs.atlassian.com/jira/REST/latest/#api/2/issue-createIssues
 func (s *IssueService) CreateWithContext(ctx context.Context, issue *Issue) (*Issue, *Response, error) {
-	apiEndpoint := "rest/api/2/issue"
+	apiEndpoint := fmt.Sprintf("rest/api/%s/issue", s.client.APIVersion)
 	req, err := s.client.NewRequestWithContext(ctx, "POST", apiEndpoint, issue)
 	if err != nil {
 		return nil, nil, err
@@ -850,7 +850,7 @@ func (s *IssueService) Create(issue *Issue) (*Issue, *Response, error) {
 // Jira API docs: https://docs.atlassian.com/jira/REST/cloud/#api/2/issue-editIssue
 // Caller must close resp.Body
 func (s *IssueService) UpdateWithOptionsWithContext(ctx context.Context, issue *Issue, opts *UpdateQueryOptions) (*Issue, *Response, error) {
-	apiEndpoint := fmt.Sprintf("rest/api/2/issue/%v", issue.Key)
+	apiEndpoint := fmt.Sprintf("rest/api/%s/issue/%v", s.client.APIVersion, issue.Key)
 	url, err := addOptions(apiEndpoint, opts)
 	if err != nil {
 		return nil, nil, err
@@ -894,7 +894,7 @@ func (s *IssueService) Update(issue *Issue) (*Issue, *Response, error) {
 // https://docs.atlassian.com/jira/REST/7.4.0/#api/2/issue-editIssue
 // Caller must close resp.Body
 func (s *IssueService) UpdateIssueWithContext(ctx context.Context, jiraID string, data map[string]interface{}) (*Response, error) {
-	apiEndpoint := fmt.Sprintf("rest/api/2/issue/%v", jiraID)
+	apiEndpoint := fmt.Sprintf("rest/api/%s/issue/%v", s.client.APIVersion, jiraID)
 	req, err := s.client.NewRequestWithContext(ctx, "PUT", apiEndpoint, data)
 	if err != nil {
 		return nil, err
@@ -919,7 +919,7 @@ func (s *IssueService) UpdateIssue(jiraID string, data map[string]interface{}) (
 //
 // Jira API docs: https://docs.atlassian.com/jira/REST/latest/#api/2/issue-addComment
 func (s *IssueService) AddCommentWithContext(ctx context.Context, issueID string, comment *Comment) (*Comment, *Response, error) {
-	apiEndpoint := fmt.Sprintf("rest/api/2/issue/%s/comment", issueID)
+	apiEndpoint := fmt.Sprintf("rest/api/%s/issue/%s/comment", s.client.APIVersion, issueID)
 	req, err := s.client.NewRequestWithContext(ctx, "POST", apiEndpoint, comment)
 	if err != nil {
 		return nil, nil, err
@@ -949,7 +949,7 @@ func (s *IssueService) UpdateCommentWithContext(ctx context.Context, issueID str
 	}{
 		Body: comment.Body,
 	}
-	apiEndpoint := fmt.Sprintf("rest/api/2/issue/%s/comment/%s", issueID, comment.ID)
+	apiEndpoint := fmt.Sprintf("rest/api/%s/issue/%s/comment/%s", s.client.APIVersion, issueID, comment.ID)
 	req, err := s.client.NewRequestWithContext(ctx, "PUT", apiEndpoint, reqBody)
 	if err != nil {
 		return nil, nil, err
@@ -973,7 +973,7 @@ func (s *IssueService) UpdateComment(issueID string, comment *Comment) (*Comment
 //
 // Jira API docs: https://developer.atlassian.com/cloud/jira/platform/rest/v3/#api-api-3-issue-issueIdOrKey-comment-id-delete
 func (s *IssueService) DeleteCommentWithContext(ctx context.Context, issueID, commentID string) error {
-	apiEndpoint := fmt.Sprintf("rest/api/2/issue/%s/comment/%s", issueID, commentID)
+	apiEndpoint := fmt.Sprintf("rest/api/%s/issue/%s/comment/%s", s.client.APIVersion, issueID, commentID)
 	req, err := s.client.NewRequestWithContext(ctx, "DELETE", apiEndpoint, nil)
 	if err != nil {
 		return err
@@ -998,7 +998,7 @@ func (s *IssueService) DeleteComment(issueID, commentID string) error {
 //
 // https://developer.atlassian.com/cloud/jira/platform/rest/#api-api-2-issue-issueIdOrKey-worklog-post
 func (s *IssueService) AddWorklogRecordWithContext(ctx context.Context, issueID string, record *WorklogRecord, options ...func(*http.Request) error) (*WorklogRecord, *Response, error) {
-	apiEndpoint := fmt.Sprintf("rest/api/2/issue/%s/worklog", issueID)
+	apiEndpoint := fmt.Sprintf("rest/api/%s/issue/%s/worklog", s.client.APIVersion, issueID)
 	req, err := s.client.NewRequestWithContext(ctx, "POST", apiEndpoint, record)
 	if err != nil {
 		return nil, nil, err
@@ -1030,7 +1030,7 @@ func (s *IssueService) AddWorklogRecord(issueID string, record *WorklogRecord, o
 //
 // https://docs.atlassian.com/software/jira/docs/api/REST/7.1.2/#api/2/issue-updateWorklog
 func (s *IssueService) UpdateWorklogRecordWithContext(ctx context.Context, issueID, worklogID string, record *WorklogRecord, options ...func(*http.Request) error) (*WorklogRecord, *Response, error) {
-	apiEndpoint := fmt.Sprintf("rest/api/2/issue/%s/worklog/%s", issueID, worklogID)
+	apiEndpoint := fmt.Sprintf("rest/api/%s/issue/%s/worklog/%s", s.client.APIVersion, issueID, worklogID)
 	req, err := s.client.NewRequestWithContext(ctx, "PUT", apiEndpoint, record)
 	if err != nil {
 		return nil, nil, err
@@ -1063,7 +1063,7 @@ func (s *IssueService) UpdateWorklogRecord(issueID, worklogID string, record *Wo
 // Jira API docs: https://docs.atlassian.com/jira/REST/latest/#api/2/issueLink
 // Caller must close resp.Body
 func (s *IssueService) AddLinkWithContext(ctx context.Context, issueLink *IssueLink) (*Response, error) {
-	apiEndpoint := "rest/api/2/issueLink"
+	apiEndpoint := fmt.Sprintf("rest/api/%s/issueLink", s.client.APIVersion)
 	req, err := s.client.NewRequestWithContext(ctx, "POST", apiEndpoint, issueLink)
 	if err != nil {
 		return nil, err
@@ -1088,7 +1088,7 @@ func (s *IssueService) AddLink(issueLink *IssueLink) (*Response, error) {
 // Jira API docs: https://developer.atlassian.com/jiradev/jira-apis/jira-rest-apis/jira-rest-api-tutorials/jira-rest-api-example-query-issues
 func (s *IssueService) SearchWithContext(ctx context.Context, jql string, options *SearchOptions) ([]Issue, *Response, error) {
 	u := url.URL{
-		Path: "rest/api/2/search",
+		Path: fmt.Sprintf("rest/api/%s/search", s.client.APIVersion),
 	}
 	uv := url.Values{}
 	if jql != "" {
@@ -1184,7 +1184,7 @@ func (s *IssueService) SearchPages(jql string, options *SearchOptions, f func(Is
 
 // GetCustomFieldsWithContext returns a map of customfield_* keys with string values
 func (s *IssueService) GetCustomFieldsWithContext(ctx context.Context, issueID string) (CustomFields, *Response, error) {
-	apiEndpoint := fmt.Sprintf("rest/api/2/issue/%s", issueID)
+	apiEndpoint := fmt.Sprintf("rest/api/%s/issue/%s", s.client.APIVersion, issueID)
 	req, err := s.client.NewRequestWithContext(ctx, "GET", apiEndpoint, nil)
 	if err != nil {
 		return nil, nil, err
@@ -1229,7 +1229,7 @@ func (s *IssueService) GetCustomFields(issueID string) (CustomFields, *Response,
 //
 // Jira API docs: https://docs.atlassian.com/jira/REST/latest/#api/2/issue-getTransitions
 func (s *IssueService) GetTransitionsWithContext(ctx context.Context, id string) ([]Transition, *Response, error) {
-	apiEndpoint := fmt.Sprintf("rest/api/2/issue/%s/transitions?expand=transitions.fields", id)
+	apiEndpoint := fmt.Sprintf("rest/api/%s/issue/%s/transitions?expand=transitions.fields", s.client.APIVersion, id)
 	req, err := s.client.NewRequestWithContext(ctx, "GET", apiEndpoint, nil)
 	if err != nil {
 		return nil, nil, err
@@ -1272,7 +1272,7 @@ func (s *IssueService) DoTransition(ticketID, transitionID string) (*Response, e
 // Jira API docs: https://docs.atlassian.com/jira/REST/latest/#api/2/issue-doTransition
 // Caller must close resp.Body
 func (s *IssueService) DoTransitionWithPayloadWithContext(ctx context.Context, ticketID, payload interface{}) (*Response, error) {
-	apiEndpoint := fmt.Sprintf("rest/api/2/issue/%s/transitions", ticketID)
+	apiEndpoint := fmt.Sprintf("rest/api/%s/issue/%s/transitions", s.client.APIVersion, ticketID)
 
 	req, err := s.client.NewRequestWithContext(ctx, "POST", apiEndpoint, payload)
 	if err != nil {
@@ -1377,7 +1377,7 @@ func InitIssueWithMetaAndFields(metaProject *MetaProject, metaIssuetype *MetaIss
 // DeleteWithContext will delete a specified issue.
 // Caller must close resp.Body
 func (s *IssueService) DeleteWithContext(ctx context.Context, issueID string) (*Response, error) {
-	apiEndpoint := fmt.Sprintf("rest/api/2/issue/%s", issueID)
+	apiEndpoint := fmt.Sprintf("rest/api/%s/issue/%s", s.client.APIVersion, issueID)
 
 	// to enable deletion of subtasks; without this, the request will fail if the issue has subtasks
 	deletePayload := make(map[string]interface{})
@@ -1403,7 +1403,7 @@ func (s *IssueService) Delete(issueID string) (*Response, error) {
 //
 // Jira API docs: https://docs.atlassian.com/software/jira/docs/api/REST/latest/#api/2/issue-getIssueWatchers
 func (s *IssueService) GetWatchersWithContext(ctx context.Context, issueID string) (*[]User, *Response, error) {
-	watchesAPIEndpoint := fmt.Sprintf("rest/api/2/issue/%s/watchers", issueID)
+	watchesAPIEndpoint := fmt.Sprintf("rest/api/%s/issue/%s/watchers", s.client.APIVersion, issueID)
 
 	req, err := s.client.NewRequestWithContext(ctx, "GET", watchesAPIEndpoint, nil)
 	if err != nil {
@@ -1441,7 +1441,7 @@ func (s *IssueService) GetWatchers(issueID string) (*[]User, *Response, error) {
 // Jira API docs: https://docs.atlassian.com/software/jira/docs/api/REST/latest/#api/2/issue-addWatcher
 // Caller must close resp.Body
 func (s *IssueService) AddWatcherWithContext(ctx context.Context, issueID string, userName string) (*Response, error) {
-	apiEndPoint := fmt.Sprintf("rest/api/2/issue/%s/watchers", issueID)
+	apiEndPoint := fmt.Sprintf("rest/api/%s/issue/%s/watchers", s.client.APIVersion, issueID)
 
 	req, err := s.client.NewRequestWithContext(ctx, "POST", apiEndPoint, userName)
 	if err != nil {
@@ -1467,7 +1467,7 @@ func (s *IssueService) AddWatcher(issueID string, userName string) (*Response, e
 // Jira API docs: https://docs.atlassian.com/software/jira/docs/api/REST/latest/#api/2/issue-removeWatcher
 // Caller must close resp.Body
 func (s *IssueService) RemoveWatcherWithContext(ctx context.Context, issueID string, userName string) (*Response, error) {
-	apiEndPoint := fmt.Sprintf("rest/api/2/issue/%s/watchers", issueID)
+	apiEndPoint := fmt.Sprintf("rest/api/%s/issue/%s/watchers", s.client.APIVersion, issueID)
 
 	req, err := s.client.NewRequestWithContext(ctx, "DELETE", apiEndPoint, userName)
 	if err != nil {
@@ -1493,7 +1493,7 @@ func (s *IssueService) RemoveWatcher(issueID string, userName string) (*Response
 // Jira API docs: https://docs.atlassian.com/software/jira/docs/api/REST/7.10.2/#api/2/issue-assign
 // Caller must close resp.Body
 func (s *IssueService) UpdateAssigneeWithContext(ctx context.Context, issueID string, assignee *User) (*Response, error) {
-	apiEndPoint := fmt.Sprintf("rest/api/2/issue/%s/assignee", issueID)
+	apiEndPoint := fmt.Sprintf("rest/api/%s/issue/%s/assignee", s.client.APIVersion, issueID)
 
 	req, err := s.client.NewRequestWithContext(ctx, "PUT", apiEndPoint, assignee)
 	if err != nil {
@@ -1528,7 +1528,7 @@ func (c ChangelogHistory) CreatedTime() (time.Time, error) {
 //
 // Jira API docs: https://docs.atlassian.com/jira/REST/latest/#api/2/issue-getRemoteIssueLinks
 func (s *IssueService) GetRemoteLinksWithContext(ctx context.Context, id string) (*[]RemoteLink, *Response, error) {
-	apiEndpoint := fmt.Sprintf("rest/api/2/issue/%s/remotelink", id)
+	apiEndpoint := fmt.Sprintf("rest/api/%s/issue/%s/remotelink", s.client.APIVersion, id)
 	req, err := s.client.NewRequestWithContext(ctx, "GET", apiEndpoint, nil)
 	if err != nil {
 		return nil, nil, err
@@ -1552,7 +1552,7 @@ func (s *IssueService) GetRemoteLinks(id string) (*[]RemoteLink, *Response, erro
 //
 // Jira API docs: https://developer.atlassian.com/cloud/jira/platform/rest/v2/#api-rest-api-2-issue-issueIdOrKey-remotelink-post
 func (s *IssueService) AddRemoteLinkWithContext(ctx context.Context, issueID string, remotelink *RemoteLink) (*RemoteLink, *Response, error) {
-	apiEndpoint := fmt.Sprintf("rest/api/2/issue/%s/remotelink", issueID)
+	apiEndpoint := fmt.Sprintf("rest/api/%s/issue/%s/remotelink", s.client.APIVersion, issueID)
 	req, err := s.client.NewRequestWithContext(ctx, "POST", apiEndpoint, remotelink)
 	if err != nil {
 		return nil, nil, err
@@ -1577,7 +1577,7 @@ func (s *IssueService) AddRemoteLink(issueID string, remotelink *RemoteLink) (*R
 //
 // Jira API docs: https://developer.atlassian.com/cloud/jira/platform/rest/v2/api-group-issue-remote-links/#api-rest-api-2-issue-issueidorkey-remotelink-linkid-put
 func (s *IssueService) UpdateRemoteLinkWithContext(ctx context.Context, issueID string, linkID int, remotelink *RemoteLink) (*Response, error) {
-	apiEndpoint := fmt.Sprintf("rest/api/2/issue/%s/remotelink/%d", issueID, linkID)
+	apiEndpoint := fmt.Sprintf("rest/api/%s/issue/%s/remotelink/%d", s.client.APIVersion, issueID, linkID)
 	req, err := s.client.NewRequestWithContext(ctx, "PUT", apiEndpoint, remotelink)
 	if err != nil {
 		return nil, err

--- a/issuelinktype.go
+++ b/issuelinktype.go
@@ -18,7 +18,7 @@ type IssueLinkTypeService struct {
 //
 // Jira API docs: https://developer.atlassian.com/cloud/jira/platform/rest/v2/#api-rest-api-2-issueLinkType-get
 func (s *IssueLinkTypeService) GetListWithContext(ctx context.Context) ([]IssueLinkType, *Response, error) {
-	apiEndpoint := "rest/api/2/issueLinkType"
+	apiEndpoint := fmt.Sprintf("rest/api/%s/issueLinkType", s.client.APIVersion)
 	req, err := s.client.NewRequestWithContext(ctx, "GET", apiEndpoint, nil)
 	if err != nil {
 		return nil, nil, err
@@ -41,7 +41,7 @@ func (s *IssueLinkTypeService) GetList() ([]IssueLinkType, *Response, error) {
 //
 // Jira API docs: https://developer.atlassian.com/cloud/jira/platform/rest/v2/#api-rest-api-2-issueLinkType-issueLinkTypeId-get
 func (s *IssueLinkTypeService) GetWithContext(ctx context.Context, ID string) (*IssueLinkType, *Response, error) {
-	apiEndPoint := fmt.Sprintf("rest/api/2/issueLinkType/%s", ID)
+	apiEndPoint := fmt.Sprintf("rest/api/%s/issueLinkType/%s", s.client.APIVersion, ID)
 	req, err := s.client.NewRequestWithContext(ctx, "GET", apiEndPoint, nil)
 	if err != nil {
 		return nil, nil, err
@@ -64,7 +64,7 @@ func (s *IssueLinkTypeService) Get(ID string) (*IssueLinkType, *Response, error)
 //
 // Jira API docs: https://developer.atlassian.com/cloud/jira/platform/rest/v2/#api-rest-api-2-issueLinkType-post
 func (s *IssueLinkTypeService) CreateWithContext(ctx context.Context, linkType *IssueLinkType) (*IssueLinkType, *Response, error) {
-	apiEndpoint := "/rest/api/2/issueLinkType"
+	apiEndpoint := fmt.Sprintf("/rest/api/%s/issueLinkType", s.client.APIVersion)
 	req, err := s.client.NewRequestWithContext(ctx, "POST", apiEndpoint, linkType)
 	if err != nil {
 		return nil, nil, err
@@ -100,7 +100,7 @@ func (s *IssueLinkTypeService) Create(linkType *IssueLinkType) (*IssueLinkType, 
 // Jira API docs: https://developer.atlassian.com/cloud/jira/platform/rest/v2/#api-rest-api-2-issueLinkType-issueLinkTypeId-put
 // Caller must close resp.Body
 func (s *IssueLinkTypeService) UpdateWithContext(ctx context.Context, linkType *IssueLinkType) (*IssueLinkType, *Response, error) {
-	apiEndpoint := fmt.Sprintf("rest/api/2/issueLinkType/%s", linkType.ID)
+	apiEndpoint := fmt.Sprintf("rest/api/%s/issueLinkType/%s", s.client.APIVersion, linkType.ID)
 	req, err := s.client.NewRequestWithContext(ctx, "PUT", apiEndpoint, linkType)
 	if err != nil {
 		return nil, nil, err
@@ -124,7 +124,7 @@ func (s *IssueLinkTypeService) Update(linkType *IssueLinkType) (*IssueLinkType, 
 // Jira API docs: https://developer.atlassian.com/cloud/jira/platform/rest/v2/#api-rest-api-2-issueLinkType-issueLinkTypeId-delete
 // Caller must close resp.Body
 func (s *IssueLinkTypeService) DeleteWithContext(ctx context.Context, ID string) (*Response, error) {
-	apiEndpoint := fmt.Sprintf("rest/api/2/issueLinkType/%s", ID)
+	apiEndpoint := fmt.Sprintf("rest/api/%s/issueLinkType/%s", s.client.APIVersion, ID)
 	req, err := s.client.NewRequestWithContext(ctx, "DELETE", apiEndpoint, nil)
 	if err != nil {
 		return nil, err

--- a/jira.go
+++ b/jira.go
@@ -19,6 +19,8 @@ import (
 	"github.com/google/go-querystring/query"
 )
 
+const DefaultClientVersion = "2"
+
 // httpClient defines an interface for an http.Client implementation so that alternative
 // http Clients can be passed in for making requests
 type httpClient interface {
@@ -31,7 +33,8 @@ type Client struct {
 	client httpClient
 
 	// Base URL for API requests.
-	baseURL *url.URL
+	baseURL    *url.URL
+	APIVersion string
 
 	// Session storage if the user authenticates with a Session cookie
 	session *Session
@@ -84,8 +87,9 @@ func NewClient(httpClient httpClient, baseURL string) (*Client, error) {
 	}
 
 	c := &Client{
-		client:  httpClient,
-		baseURL: parsedBaseURL,
+		client:     httpClient,
+		baseURL:    parsedBaseURL,
+		APIVersion: DefaultClientVersion,
 	}
 	c.Authentication = &AuthenticationService{client: c}
 	c.Issue = &IssueService{client: c}

--- a/metaissue.go
+++ b/metaissue.go
@@ -60,7 +60,7 @@ func (s *IssueService) GetCreateMeta(projectkeys string) (*CreateMetaInfo, *Resp
 
 // GetCreateMetaWithOptionsWithContext makes the api call to get the meta information without requiring to have a projectKey
 func (s *IssueService) GetCreateMetaWithOptionsWithContext(ctx context.Context, options *GetQueryOptions) (*CreateMetaInfo, *Response, error) {
-	apiEndpoint := "rest/api/2/issue/createmeta"
+	apiEndpoint := fmt.Sprintf("rest/api/%s/issue/createmeta", s.client.APIVersion)
 
 	req, err := s.client.NewRequestWithContext(ctx, "GET", apiEndpoint, nil)
 	if err != nil {
@@ -91,7 +91,7 @@ func (s *IssueService) GetCreateMetaWithOptions(options *GetQueryOptions) (*Crea
 
 // GetEditMetaWithContext makes the api call to get the edit meta information for an issue
 func (s *IssueService) GetEditMetaWithContext(ctx context.Context, issue *Issue) (*EditMetaInfo, *Response, error) {
-	apiEndpoint := fmt.Sprintf("/rest/api/2/issue/%s/editmeta", issue.Key)
+	apiEndpoint := fmt.Sprintf("/rest/api/%s/issue/%s/editmeta", s.client.APIVersion, issue.Key)
 
 	req, err := s.client.NewRequestWithContext(ctx, "GET", apiEndpoint, nil)
 	if err != nil {

--- a/priority.go
+++ b/priority.go
@@ -1,6 +1,9 @@
 package jira
 
-import "context"
+import (
+	"context"
+	"fmt"
+)
 
 // PriorityService handles priorities for the Jira instance / API.
 //
@@ -24,7 +27,7 @@ type Priority struct {
 //
 // Jira API docs: https://developer.atlassian.com/cloud/jira/platform/rest/#api-api-2-priority-get
 func (s *PriorityService) GetListWithContext(ctx context.Context) ([]Priority, *Response, error) {
-	apiEndpoint := "rest/api/2/priority"
+	apiEndpoint := fmt.Sprintf("rest/api/%s/priority", s.client.APIVersion)
 	req, err := s.client.NewRequestWithContext(ctx, "GET", apiEndpoint, nil)
 	if err != nil {
 		return nil, nil, err

--- a/project.go
+++ b/project.go
@@ -98,7 +98,7 @@ func (s *ProjectService) GetList() (*ProjectList, *Response, error) {
 //
 // Jira API docs: https://docs.atlassian.com/jira/REST/latest/#api/2/project-getAllProjects
 func (s *ProjectService) ListWithOptionsWithContext(ctx context.Context, options *GetQueryOptions) (*ProjectList, *Response, error) {
-	apiEndpoint := "rest/api/2/project"
+	apiEndpoint := fmt.Sprintf("rest/api/%s/project", s.client.APIVersion)
 	req, err := s.client.NewRequestWithContext(ctx, "GET", apiEndpoint, nil)
 	if err != nil {
 		return nil, nil, err
@@ -133,7 +133,7 @@ func (s *ProjectService) ListWithOptions(options *GetQueryOptions) (*ProjectList
 //
 // Jira API docs: https://docs.atlassian.com/jira/REST/latest/#api/2/project-getProject
 func (s *ProjectService) GetWithContext(ctx context.Context, projectID string) (*Project, *Response, error) {
-	apiEndpoint := fmt.Sprintf("rest/api/2/project/%s", projectID)
+	apiEndpoint := fmt.Sprintf("rest/api/%s/project/%s", s.client.APIVersion, projectID)
 	req, err := s.client.NewRequestWithContext(ctx, "GET", apiEndpoint, nil)
 	if err != nil {
 		return nil, nil, err

--- a/status.go
+++ b/status.go
@@ -1,6 +1,9 @@
 package jira
 
-import "context"
+import (
+	"context"
+	"fmt"
+)
 
 // StatusService handles staties for the Jira instance / API.
 //
@@ -25,7 +28,7 @@ type Status struct {
 //
 // Jira API docs: https://developer.atlassian.com/cloud/jira/platform/rest/v2/#api-rest-api-2-status-get
 func (s *StatusService) GetAllStatusesWithContext(ctx context.Context) ([]Status, *Response, error) {
-	apiEndpoint := "rest/api/2/status"
+	apiEndpoint := fmt.Sprintf("rest/api/%s/status", s.client.APIVersion)
 	req, err := s.client.NewRequestWithContext(ctx, "GET", apiEndpoint, nil)
 
 	if err != nil {

--- a/statuscategory.go
+++ b/statuscategory.go
@@ -1,6 +1,9 @@
 package jira
 
-import "context"
+import (
+	"context"
+	"fmt"
+)
 
 // StatusCategoryService handles status categories for the Jira instance / API.
 //
@@ -31,7 +34,7 @@ const (
 //
 // Jira API docs: https://developer.atlassian.com/cloud/jira/platform/rest/#api-api-2-statuscategory-get
 func (s *StatusCategoryService) GetListWithContext(ctx context.Context) ([]StatusCategory, *Response, error) {
-	apiEndpoint := "rest/api/2/statuscategory"
+	apiEndpoint := fmt.Sprintf("rest/api/%s/statuscategory", s.client.APIVersion)
 	req, err := s.client.NewRequestWithContext(ctx, "GET", apiEndpoint, nil)
 	if err != nil {
 		return nil, nil, err

--- a/user.go
+++ b/user.go
@@ -50,7 +50,7 @@ type userSearchF func(userSearch) userSearch
 //
 // Jira API docs: https://developer.atlassian.com/cloud/jira/platform/rest/v2/#api-rest-api-2-user-get
 func (s *UserService) GetWithContext(ctx context.Context, accountId string) (*User, *Response, error) {
-	apiEndpoint := fmt.Sprintf("/rest/api/2/user?accountId=%s", accountId)
+	apiEndpoint := fmt.Sprintf("/rest/api/%s/user?accountId=%s", s.client.APIVersion, accountId)
 	req, err := s.client.NewRequestWithContext(ctx, "GET", apiEndpoint, nil)
 	if err != nil {
 		return nil, nil, err
@@ -74,7 +74,7 @@ func (s *UserService) Get(accountId string) (*User, *Response, error) {
 // but this method is kept for backwards compatibility
 // Jira API docs: https://docs.atlassian.com/jira/REST/cloud/#api/2/user-getUser
 func (s *UserService) GetByAccountIDWithContext(ctx context.Context, accountID string) (*User, *Response, error) {
-	apiEndpoint := fmt.Sprintf("/rest/api/2/user?accountId=%s", accountID)
+	apiEndpoint := fmt.Sprintf("/rest/api/%s/user?accountId=%s", s.client.APIVersion, accountID)
 	req, err := s.client.NewRequestWithContext(ctx, "GET", apiEndpoint, nil)
 	if err != nil {
 		return nil, nil, err
@@ -97,7 +97,7 @@ func (s *UserService) GetByAccountID(accountID string) (*User, *Response, error)
 //
 // Jira API docs: https://docs.atlassian.com/jira/REST/cloud/#api/2/user-createUser
 func (s *UserService) CreateWithContext(ctx context.Context, user *User) (*User, *Response, error) {
-	apiEndpoint := "/rest/api/2/user"
+	apiEndpoint := fmt.Sprintf("/rest/api/%s/user", s.client.APIVersion)
 	req, err := s.client.NewRequestWithContext(ctx, "POST", apiEndpoint, user)
 	if err != nil {
 		return nil, nil, err
@@ -134,7 +134,7 @@ func (s *UserService) Create(user *User) (*User, *Response, error) {
 // Jira API docs: https://developer.atlassian.com/cloud/jira/platform/rest/v2/#api-rest-api-2-user-delete
 // Caller must close resp.Body
 func (s *UserService) DeleteWithContext(ctx context.Context, accountId string) (*Response, error) {
-	apiEndpoint := fmt.Sprintf("/rest/api/2/user?accountId=%s", accountId)
+	apiEndpoint := fmt.Sprintf("/rest/api/%s/user?accountId=%s", s.client.APIVersion, accountId)
 	req, err := s.client.NewRequestWithContext(ctx, "DELETE", apiEndpoint, nil)
 	if err != nil {
 		return nil, err
@@ -157,7 +157,7 @@ func (s *UserService) Delete(accountId string) (*Response, error) {
 //
 // Jira API docs: https://developer.atlassian.com/cloud/jira/platform/rest/v2/#api-rest-api-2-user-groups-get
 func (s *UserService) GetGroupsWithContext(ctx context.Context, accountId string) (*[]UserGroup, *Response, error) {
-	apiEndpoint := fmt.Sprintf("/rest/api/2/user/groups?accountId=%s", accountId)
+	apiEndpoint := fmt.Sprintf("/rest/api/%s/user/groups?accountId=%s", s.client.APIVersion, accountId)
 	req, err := s.client.NewRequestWithContext(ctx, "GET", apiEndpoint, nil)
 	if err != nil {
 		return nil, nil, err
@@ -180,7 +180,7 @@ func (s *UserService) GetGroups(accountId string) (*[]UserGroup, *Response, erro
 //
 // Jira API docs: https://developer.atlassian.com/cloud/jira/platform/rest/v2/#api-rest-api-2-myself-get
 func (s *UserService) GetSelfWithContext(ctx context.Context) (*User, *Response, error) {
-	const apiEndpoint = "rest/api/2/myself"
+	apiEndpoint := fmt.Sprintf("rest/api/%s/myself", s.client.APIVersion)
 	req, err := s.client.NewRequestWithContext(ctx, "GET", apiEndpoint, nil)
 	if err != nil {
 		return nil, nil, err
@@ -274,7 +274,7 @@ func (s *UserService) FindWithContext(ctx context.Context, property string, twea
 		queryString += param.name + "=" + param.value + "&"
 	}
 
-	apiEndpoint := fmt.Sprintf("/rest/api/2/user/search?%s", queryString[:len(queryString)-1])
+	apiEndpoint := fmt.Sprintf("/rest/api/%s/user/search?%s", s.client.APIVersion, queryString[:len(queryString)-1])
 	req, err := s.client.NewRequestWithContext(ctx, "GET", apiEndpoint, nil)
 	if err != nil {
 		return nil, nil, err

--- a/version.go
+++ b/version.go
@@ -32,7 +32,7 @@ type Version struct {
 //
 // Jira API docs: https://developer.atlassian.com/cloud/jira/platform/rest/#api-api-2-version-id-get
 func (s *VersionService) GetWithContext(ctx context.Context, versionID int) (*Version, *Response, error) {
-	apiEndpoint := fmt.Sprintf("/rest/api/2/version/%v", versionID)
+	apiEndpoint := fmt.Sprintf("/rest/api/%s/version/%v", s.client.APIVersion, versionID)
 	req, err := s.client.NewRequestWithContext(ctx, "GET", apiEndpoint, nil)
 	if err != nil {
 		return nil, nil, err
@@ -55,7 +55,7 @@ func (s *VersionService) Get(versionID int) (*Version, *Response, error) {
 //
 // Jira API docs: https://developer.atlassian.com/cloud/jira/platform/rest/#api-api-2-version-post
 func (s *VersionService) CreateWithContext(ctx context.Context, version *Version) (*Version, *Response, error) {
-	apiEndpoint := "/rest/api/2/version"
+	apiEndpoint := fmt.Sprintf("/rest/api/%s/version", s.client.APIVersion)
 	req, err := s.client.NewRequestWithContext(ctx, "POST", apiEndpoint, version)
 	if err != nil {
 		return nil, nil, err
@@ -91,7 +91,7 @@ func (s *VersionService) Create(version *Version) (*Version, *Response, error) {
 // Jira API docs: https://developer.atlassian.com/cloud/jira/platform/rest/#api-api-2-version-id-put
 // Caller must close resp.Body
 func (s *VersionService) UpdateWithContext(ctx context.Context, version *Version) (*Version, *Response, error) {
-	apiEndpoint := fmt.Sprintf("rest/api/2/version/%v", version.ID)
+	apiEndpoint := fmt.Sprintf("rest/api/%s/version/%v", s.client.APIVersion, version.ID)
 	req, err := s.client.NewRequestWithContext(ctx, "PUT", apiEndpoint, version)
 	if err != nil {
 		return nil, nil, err


### PR DESCRIPTION
This adds a field `APIVersion` into the `Client` struct that can be overriden from the outside if someone is running with a non-default API version on their Jira servers that conforms to the same rest API standards as the current default `2`.

Usage would be:

```go
jiraClient, _ := jira.NewClient(nil, "https://issues.apache.org/jira/")
jiraClient.APIVersion = "latest"
```
