### PR TITLE
Make context first class citizen: Remove "WithContext" API methods (Part 1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -135,11 +135,44 @@ Like
 client.NewMultiPartRequest(context.Background(), "GET", .....)
 ```
 
+#### `context` is a first class citizen
+
+All API methods require a `context` as first argument.
+
+In the v1, some methods had a `...WithContext` suffix.
+These methods have been removed.
+
+If you used a service like
+
+```go
+client.Issue.CreateWithContext(ctx, ...)
+```
+
+the new call would be
+
+```go
+client.Issue.Create(ctx, ...)
+```
+
+If you used API calls without a context, like
+
+```go
+client.Issue.Create(...)
+```
+
+the new call would be
+
+```go
+client.Issue.Create(ctx, ...)
+```
+
 ### Breaking changes
 
 * Jira On-Premise and Jira Cloud have now different clients, because the API differs
 * `client.NewRawRequestWithContext()` has been removed in favor of `client.NewRawRequest()`, which requires now a context as first argument
 * `client.NewRequestWithContext()` has been removed in favor of `client.NewRequest()`, which requires now a context as first argument
+* `client.NewMultiPartRequestWithContext()` has been removed in favor of `client.NewMultiPartRequest()`, which requires now a context as first argument
+* `context` is now a first class citizen in all API calls. Functions that had a suffix like `...WithContext` have been removed entirely. The API methods support the context now as first argument.
 
 ### Features
 

--- a/cloud/auth_transport_personal_access_token_test.go
+++ b/cloud/auth_transport_personal_access_token_test.go
@@ -1,6 +1,7 @@
 package cloud
 
 import (
+	"context"
 	"net/http"
 	"testing"
 )
@@ -24,6 +25,6 @@ func TestPATAuthTransport_HeaderContainsAuth(t *testing.T) {
 	})
 
 	client, _ := NewClient(testServer.URL, patTransport.Client())
-	client.User.GetSelf()
+	client.User.GetSelf(context.Background())
 
 }

--- a/cloud/examples/basicauth/main.go
+++ b/cloud/examples/basicauth/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"bufio"
+	"context"
 	"fmt"
 	"os"
 	"strings"
@@ -36,7 +37,7 @@ func main() {
 		return
 	}
 
-	u, _, err := client.User.Get("admin")
+	u, _, err := client.User.Get(context.Background(), "admin")
 
 	if err != nil {
 		fmt.Printf("\nerror: %v\n", err)

--- a/cloud/issue.go
+++ b/cloud/issue.go
@@ -1418,7 +1418,7 @@ func (s *IssueService) GetWatchersWithContext(ctx context.Context, issueID strin
 	for _, watcher := range watches.Watchers {
 		var user *User
 		if watcher.AccountID != "" {
-			user, resp, err = s.client.User.GetByAccountID(watcher.AccountID)
+			user, resp, err = s.client.User.GetByAccountID(context.Background(), watcher.AccountID)
 			if err != nil {
 				return nil, resp, NewJiraError(resp, err)
 			}

--- a/cloud/role.go
+++ b/cloud/role.go
@@ -34,10 +34,10 @@ type ActorUser struct {
 	AccountID string `json:"accountId" structs:"accountId"`
 }
 
-// GetListWithContext returns a list of all available project roles
+// GetList returns a list of all available project roles
 //
 // Jira API docs: https://developer.atlassian.com/cloud/jira/platform/rest/v3/#api-api-3-role-get
-func (s *RoleService) GetListWithContext(ctx context.Context) (*[]Role, *Response, error) {
+func (s *RoleService) GetList(ctx context.Context) (*[]Role, *Response, error) {
 	apiEndpoint := "rest/api/3/role"
 	req, err := s.client.NewRequest(ctx, "GET", apiEndpoint, nil)
 	if err != nil {
@@ -52,15 +52,10 @@ func (s *RoleService) GetListWithContext(ctx context.Context) (*[]Role, *Respons
 	return roles, resp, err
 }
 
-// GetList wraps GetListWithContext using the background context.
-func (s *RoleService) GetList() (*[]Role, *Response, error) {
-	return s.GetListWithContext(context.Background())
-}
-
-// GetWithContext retreives a single Role from Jira
+// Get retreives a single Role from Jira
 //
 // Jira API docs: https://developer.atlassian.com/cloud/jira/platform/rest/v3/#api-api-3-role-id-get
-func (s *RoleService) GetWithContext(ctx context.Context, roleID int) (*Role, *Response, error) {
+func (s *RoleService) Get(ctx context.Context, roleID int) (*Role, *Response, error) {
 	apiEndpoint := fmt.Sprintf("rest/api/3/role/%d", roleID)
 	req, err := s.client.NewRequest(ctx, "GET", apiEndpoint, nil)
 	if err != nil {
@@ -77,9 +72,4 @@ func (s *RoleService) GetWithContext(ctx context.Context, roleID int) (*Role, *R
 	}
 
 	return role, resp, err
-}
-
-// Get wraps GetWithContext using the background context.
-func (s *RoleService) Get(roleID int) (*Role, *Response, error) {
-	return s.GetWithContext(context.Background(), roleID)
 }

--- a/cloud/role_test.go
+++ b/cloud/role_test.go
@@ -1,6 +1,7 @@
 package cloud
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 	"os"
@@ -23,7 +24,7 @@ func TestRoleService_GetList_NoList(t *testing.T) {
 		fmt.Fprint(w, string(raw))
 	})
 
-	roles, _, err := testClient.Role.GetList()
+	roles, _, err := testClient.Role.GetList(context.Background())
 	if roles != nil {
 		t.Errorf("Expected role list has %d entries but should be nil", len(*roles))
 	}
@@ -47,7 +48,7 @@ func TestRoleService_GetList(t *testing.T) {
 		fmt.Fprint(w, string(raw))
 	})
 
-	roles, _, err := testClient.Role.GetList()
+	roles, _, err := testClient.Role.GetList(context.Background())
 	if err != nil {
 		t.Errorf("Error given: %v", err)
 	}
@@ -74,7 +75,7 @@ func TestRoleService_Get_NoRole(t *testing.T) {
 		fmt.Fprint(writer, string(raw))
 	})
 
-	role, _, err := testClient.Role.Get(99999)
+	role, _, err := testClient.Role.Get(context.Background(), 99999)
 	if role != nil {
 		t.Errorf("Expected nil, got role %v", role)
 	}
@@ -97,7 +98,7 @@ func TestRoleService_Get(t *testing.T) {
 		fmt.Fprint(writer, string(raw))
 	})
 
-	role, _, err := testClient.Role.Get(10002)
+	role, _, err := testClient.Role.Get(context.Background(), 10002)
 	if role == nil {
 		t.Errorf("Expected Role, got nil")
 	}

--- a/cloud/servicedesk.go
+++ b/cloud/servicedesk.go
@@ -17,11 +17,11 @@ type ServiceDeskOrganizationDTO struct {
 	OrganizationID int `json:"organizationId,omitempty" structs:"organizationId,omitempty"`
 }
 
-// GetOrganizationsWithContext returns a list of
+// GetOrganizations returns a list of
 // all organizations associated with a service desk.
 //
 // https://developer.atlassian.com/cloud/jira/service-desk/rest/api-group-organization/#api-rest-servicedeskapi-servicedesk-servicedeskid-organization-get
-func (s *ServiceDeskService) GetOrganizationsWithContext(ctx context.Context, serviceDeskID interface{}, start int, limit int, accountID string) (*PagedDTO, *Response, error) {
+func (s *ServiceDeskService) GetOrganizations(ctx context.Context, serviceDeskID interface{}, start int, limit int, accountID string) (*PagedDTO, *Response, error) {
 	apiEndPoint := fmt.Sprintf("rest/servicedeskapi/servicedesk/%v/organization?start=%d&limit=%d", serviceDeskID, start, limit)
 	if accountID != "" {
 		apiEndPoint += fmt.Sprintf("&accountId=%s", accountID)
@@ -44,19 +44,14 @@ func (s *ServiceDeskService) GetOrganizationsWithContext(ctx context.Context, se
 	return orgs, resp, nil
 }
 
-// GetOrganizations wraps GetOrganizationsWithContext using the background context.
-func (s *ServiceDeskService) GetOrganizations(serviceDeskID interface{}, start int, limit int, accountID string) (*PagedDTO, *Response, error) {
-	return s.GetOrganizationsWithContext(context.Background(), serviceDeskID, start, limit, accountID)
-}
-
-// AddOrganizationWithContext adds an organization to
+// AddOrganization adds an organization to
 // a service desk. If the organization ID is already
 // associated with the service desk, no change is made
 // and the resource returns a 204 success code.
 //
 // https://developer.atlassian.com/cloud/jira/service-desk/rest/api-group-organization/#api-rest-servicedeskapi-servicedesk-servicedeskid-organization-post
 // Caller must close resp.Body
-func (s *ServiceDeskService) AddOrganizationWithContext(ctx context.Context, serviceDeskID interface{}, organizationID int) (*Response, error) {
+func (s *ServiceDeskService) AddOrganization(ctx context.Context, serviceDeskID interface{}, organizationID int) (*Response, error) {
 	apiEndPoint := fmt.Sprintf("rest/servicedeskapi/servicedesk/%v/organization", serviceDeskID)
 
 	organization := ServiceDeskOrganizationDTO{
@@ -78,20 +73,14 @@ func (s *ServiceDeskService) AddOrganizationWithContext(ctx context.Context, ser
 	return resp, nil
 }
 
-// AddOrganization wraps AddOrganizationWithContext using the background context.
-// Caller must close resp.Body
-func (s *ServiceDeskService) AddOrganization(serviceDeskID interface{}, organizationID int) (*Response, error) {
-	return s.AddOrganizationWithContext(context.Background(), serviceDeskID, organizationID)
-}
-
-// RemoveOrganizationWithContext removes an organization
+// RemoveOrganization removes an organization
 // from a service desk. If the organization ID does not
 // match an organization associated with the service desk,
 // no change is made and the resource returns a 204 success code.
 //
 // https://developer.atlassian.com/cloud/jira/service-desk/rest/api-group-organization/#api-rest-servicedeskapi-servicedesk-servicedeskid-organization-delete
 // Caller must close resp.Body
-func (s *ServiceDeskService) RemoveOrganizationWithContext(ctx context.Context, serviceDeskID interface{}, organizationID int) (*Response, error) {
+func (s *ServiceDeskService) RemoveOrganization(ctx context.Context, serviceDeskID interface{}, organizationID int) (*Response, error) {
 	apiEndPoint := fmt.Sprintf("rest/servicedeskapi/servicedesk/%v/organization", serviceDeskID)
 
 	organization := ServiceDeskOrganizationDTO{
@@ -113,16 +102,10 @@ func (s *ServiceDeskService) RemoveOrganizationWithContext(ctx context.Context, 
 	return resp, nil
 }
 
-// RemoveOrganization wraps RemoveOrganizationWithContext using the background context.
-// Caller must close resp.Body
-func (s *ServiceDeskService) RemoveOrganization(serviceDeskID interface{}, organizationID int) (*Response, error) {
-	return s.RemoveOrganizationWithContext(context.Background(), serviceDeskID, organizationID)
-}
-
-// AddCustomersWithContext adds customers to the given service desk.
+// AddCustomers adds customers to the given service desk.
 //
 // https://developer.atlassian.com/cloud/jira/service-desk/rest/api-group-servicedesk/#api-rest-servicedeskapi-servicedesk-servicedeskid-customer-post
-func (s *ServiceDeskService) AddCustomersWithContext(ctx context.Context, serviceDeskID interface{}, acountIDs ...string) (*Response, error) {
+func (s *ServiceDeskService) AddCustomers(ctx context.Context, serviceDeskID interface{}, acountIDs ...string) (*Response, error) {
 	apiEndpoint := fmt.Sprintf("rest/servicedeskapi/servicedesk/%v/customer", serviceDeskID)
 
 	payload := struct {
@@ -146,15 +129,10 @@ func (s *ServiceDeskService) AddCustomersWithContext(ctx context.Context, servic
 	return resp, nil
 }
 
-// AddCustomers wraps AddCustomersWithContext using the background context.
-func (s *ServiceDeskService) AddCustomers(serviceDeskID interface{}, acountIDs ...string) (*Response, error) {
-	return s.AddCustomersWithContext(context.Background(), serviceDeskID, acountIDs...)
-}
-
-// RemoveCustomersWithContext removes customers to the given service desk.
+// RemoveCustomers removes customers to the given service desk.
 //
 // https://developer.atlassian.com/cloud/jira/service-desk/rest/api-group-servicedesk/#api-rest-servicedeskapi-servicedesk-servicedeskid-customer-delete
-func (s *ServiceDeskService) RemoveCustomersWithContext(ctx context.Context, serviceDeskID interface{}, acountIDs ...string) (*Response, error) {
+func (s *ServiceDeskService) RemoveCustomers(ctx context.Context, serviceDeskID interface{}, acountIDs ...string) (*Response, error) {
 	apiEndpoint := fmt.Sprintf("rest/servicedeskapi/servicedesk/%v/customer", serviceDeskID)
 
 	payload := struct {
@@ -178,15 +156,10 @@ func (s *ServiceDeskService) RemoveCustomersWithContext(ctx context.Context, ser
 	return resp, nil
 }
 
-// RemoveCustomers wraps RemoveCustomersWithContext using the background context.
-func (s *ServiceDeskService) RemoveCustomers(serviceDeskID interface{}, acountIDs ...string) (*Response, error) {
-	return s.RemoveCustomersWithContext(context.Background(), serviceDeskID, acountIDs...)
-}
-
-// ListCustomersWithContext lists customers for a ServiceDesk.
+// ListCustomers lists customers for a ServiceDesk.
 //
 // https://developer.atlassian.com/cloud/jira/service-desk/rest/api-group-servicedesk/#api-rest-servicedeskapi-servicedesk-servicedeskid-customer-get
-func (s *ServiceDeskService) ListCustomersWithContext(ctx context.Context, serviceDeskID interface{}, options *CustomerListOptions) (*CustomerList, *Response, error) {
+func (s *ServiceDeskService) ListCustomers(ctx context.Context, serviceDeskID interface{}, options *CustomerListOptions) (*CustomerList, *Response, error) {
 	apiEndpoint := fmt.Sprintf("rest/servicedeskapi/servicedesk/%v/customer", serviceDeskID)
 	req, err := s.client.NewRequest(ctx, "GET", apiEndpoint, nil)
 	if err != nil {
@@ -216,9 +189,4 @@ func (s *ServiceDeskService) ListCustomersWithContext(ctx context.Context, servi
 	}
 
 	return customerList, resp, nil
-}
-
-// ListCustomers wraps ListCustomersWithContext using the background context.
-func (s *ServiceDeskService) ListCustomers(serviceDeskID interface{}, options *CustomerListOptions) (*CustomerList, *Response, error) {
-	return s.ListCustomersWithContext(context.Background(), serviceDeskID, options)
 }

--- a/cloud/servicedesk_test.go
+++ b/cloud/servicedesk_test.go
@@ -1,6 +1,7 @@
 package cloud
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -56,7 +57,7 @@ func TestServiceDeskService_GetOrganizations(t *testing.T) {
 		  }`)
 	})
 
-	orgs, _, err := testClient.ServiceDesk.GetOrganizations(10001, 3, 3, "")
+	orgs, _, err := testClient.ServiceDesk.GetOrganizations(context.Background(), 10001, 3, 3, "")
 
 	if orgs == nil {
 		t.Error("Expected Organizations. Result is nil")
@@ -79,7 +80,7 @@ func TestServiceDeskService_AddOrganizations(t *testing.T) {
 		w.WriteHeader(http.StatusNoContent)
 	})
 
-	_, err := testClient.ServiceDesk.AddOrganization(10001, 1)
+	_, err := testClient.ServiceDesk.AddOrganization(context.Background(), 10001, 1)
 
 	if err != nil {
 		t.Errorf("Error given: %s", err)
@@ -96,7 +97,7 @@ func TestServiceDeskService_RemoveOrganizations(t *testing.T) {
 		w.WriteHeader(http.StatusNoContent)
 	})
 
-	_, err := testClient.ServiceDesk.RemoveOrganization(10001, 1)
+	_, err := testClient.ServiceDesk.RemoveOrganization(context.Background(), 10001, 1)
 
 	if err != nil {
 		t.Errorf("Error given: %s", err)
@@ -149,7 +150,7 @@ func TestServiceDeskServiceStringServiceDeskID_GetOrganizations(t *testing.T) {
 		  }`)
 	})
 
-	orgs, _, err := testClient.ServiceDesk.GetOrganizations("TEST", 3, 3, "")
+	orgs, _, err := testClient.ServiceDesk.GetOrganizations(context.Background(), "TEST", 3, 3, "")
 
 	if orgs == nil {
 		t.Error("Expected Organizations. Result is nil")
@@ -172,7 +173,7 @@ func TestServiceDeskServiceStringServiceDeskID_AddOrganizations(t *testing.T) {
 		w.WriteHeader(http.StatusNoContent)
 	})
 
-	_, err := testClient.ServiceDesk.AddOrganization("TEST", 1)
+	_, err := testClient.ServiceDesk.AddOrganization(context.Background(), "TEST", 1)
 
 	if err != nil {
 		t.Errorf("Error given: %s", err)
@@ -189,7 +190,7 @@ func TestServiceDeskServiceStringServiceDeskID_RemoveOrganizations(t *testing.T)
 		w.WriteHeader(http.StatusNoContent)
 	})
 
-	_, err := testClient.ServiceDesk.RemoveOrganization("TEST", 1)
+	_, err := testClient.ServiceDesk.RemoveOrganization(context.Background(), "TEST", 1)
 
 	if err != nil {
 		t.Errorf("Error given: %s", err)
@@ -242,7 +243,7 @@ func TestServiceDeskService_AddCustomers(t *testing.T) {
 				w.WriteHeader(http.StatusNoContent)
 			})
 
-			_, err := testClient.ServiceDesk.AddCustomers(test.serviceDeskID, wantAccountIDs...)
+			_, err := testClient.ServiceDesk.AddCustomers(context.Background(), test.serviceDeskID, wantAccountIDs...)
 
 			if err != nil {
 				t.Errorf("Error given: %s", err)
@@ -308,7 +309,7 @@ func TestServiceDeskService_RemoveCustomers(t *testing.T) {
 				w.WriteHeader(http.StatusNoContent)
 			})
 
-			_, err := testClient.ServiceDesk.RemoveCustomers(test.serviceDeskID, wantAccountIDs...)
+			_, err := testClient.ServiceDesk.RemoveCustomers(context.Background(), test.serviceDeskID, wantAccountIDs...)
 
 			if err != nil {
 				t.Errorf("Error given: %s", err)
@@ -409,7 +410,7 @@ func TestServiceDeskService_ListCustomers(t *testing.T) {
 				}`))
 			})
 
-			customerList, _, err := testClient.ServiceDesk.ListCustomers(test.serviceDeskID, wantOptions)
+			customerList, _, err := testClient.ServiceDesk.ListCustomers(context.Background(), test.serviceDeskID, wantOptions)
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/cloud/sprint.go
+++ b/cloud/sprint.go
@@ -21,13 +21,13 @@ type IssuesInSprintResult struct {
 	Issues []Issue `json:"issues"`
 }
 
-// MoveIssuesToSprintWithContext moves issues to a sprint, for a given sprint Id.
+// MoveIssuesToSprint moves issues to a sprint, for a given sprint Id.
 // Issues can only be moved to open or active sprints.
 // The maximum number of issues that can be moved in one operation is 50.
 //
 // Jira API docs: https://docs.atlassian.com/jira-software/REST/cloud/#agile/1.0/sprint-moveIssuesToSprint
 // Caller must close resp.Body
-func (s *SprintService) MoveIssuesToSprintWithContext(ctx context.Context, sprintID int, issueIDs []string) (*Response, error) {
+func (s *SprintService) MoveIssuesToSprint(ctx context.Context, sprintID int, issueIDs []string) (*Response, error) {
 	apiEndpoint := fmt.Sprintf("rest/agile/1.0/sprint/%d/issue", sprintID)
 
 	payload := IssuesWrapper{Issues: issueIDs}
@@ -45,18 +45,12 @@ func (s *SprintService) MoveIssuesToSprintWithContext(ctx context.Context, sprin
 	return resp, err
 }
 
-// MoveIssuesToSprint wraps MoveIssuesToSprintWithContext using the background context.
-// Caller must close resp.Body
-func (s *SprintService) MoveIssuesToSprint(sprintID int, issueIDs []string) (*Response, error) {
-	return s.MoveIssuesToSprintWithContext(context.Background(), sprintID, issueIDs)
-}
-
-// GetIssuesForSprintWithContext returns all issues in a sprint, for a given sprint Id.
+// GetIssuesForSprint returns all issues in a sprint, for a given sprint Id.
 // This only includes issues that the user has permission to view.
 // By default, the returned issues are ordered by rank.
 //
 // Jira API Docs: https://docs.atlassian.com/jira-software/REST/cloud/#agile/1.0/sprint-getIssuesForSprint
-func (s *SprintService) GetIssuesForSprintWithContext(ctx context.Context, sprintID int) ([]Issue, *Response, error) {
+func (s *SprintService) GetIssuesForSprint(ctx context.Context, sprintID int) ([]Issue, *Response, error) {
 	apiEndpoint := fmt.Sprintf("rest/agile/1.0/sprint/%d/issue", sprintID)
 
 	req, err := s.client.NewRequest(ctx, "GET", apiEndpoint, nil)
@@ -74,12 +68,7 @@ func (s *SprintService) GetIssuesForSprintWithContext(ctx context.Context, sprin
 	return result.Issues, resp, err
 }
 
-// GetIssuesForSprint wraps GetIssuesForSprintWithContext using the background context.
-func (s *SprintService) GetIssuesForSprint(sprintID int) ([]Issue, *Response, error) {
-	return s.GetIssuesForSprintWithContext(context.Background(), sprintID)
-}
-
-// GetIssueWithContext returns a full representation of the issue for the given issue key.
+// GetIssue returns a full representation of the issue for the given issue key.
 // Jira will attempt to identify the issue by the issueIdOrKey path parameter.
 // This can be an issue id, or an issue key.
 // If the issue cannot be found via an exact match, Jira will also look for the issue in a case-insensitive way, or by looking to see if the issue was moved.
@@ -89,7 +78,7 @@ func (s *SprintService) GetIssuesForSprint(sprintID int) ([]Issue, *Response, er
 // Jira API docs: https://docs.atlassian.com/jira-software/REST/7.3.1/#agile/1.0/issue-getIssue
 //
 // TODO: create agile service for holding all agile apis' implementation
-func (s *SprintService) GetIssueWithContext(ctx context.Context, issueID string, options *GetQueryOptions) (*Issue, *Response, error) {
+func (s *SprintService) GetIssue(ctx context.Context, issueID string, options *GetQueryOptions) (*Issue, *Response, error) {
 	apiEndpoint := fmt.Sprintf("rest/agile/1.0/issue/%s", issueID)
 
 	req, err := s.client.NewRequest(ctx, "GET", apiEndpoint, nil)
@@ -115,9 +104,4 @@ func (s *SprintService) GetIssueWithContext(ctx context.Context, issueID string,
 	}
 
 	return issue, resp, nil
-}
-
-// GetIssue wraps GetIssueWithContext using the background context.
-func (s *SprintService) GetIssue(issueID string, options *GetQueryOptions) (*Issue, *Response, error) {
-	return s.GetIssueWithContext(context.Background(), issueID, options)
 }

--- a/cloud/sprint_test.go
+++ b/cloud/sprint_test.go
@@ -1,6 +1,7 @@
 package cloud
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -32,7 +33,7 @@ func TestSprintService_MoveIssuesToSprint(t *testing.T) {
 			t.Errorf("Expected %s to be in payload, got %s instead", issuesToMove[0], payload.Issues[0])
 		}
 	})
-	_, err := testClient.Sprint.MoveIssuesToSprint(123, issuesToMove)
+	_, err := testClient.Sprint.MoveIssuesToSprint(context.Background(), 123, issuesToMove)
 
 	if err != nil {
 		t.Errorf("Got error: %v", err)
@@ -54,7 +55,7 @@ func TestSprintService_GetIssuesForSprint(t *testing.T) {
 		fmt.Fprint(w, string(raw))
 	})
 
-	issues, _, err := testClient.Sprint.GetIssuesForSprint(123)
+	issues, _, err := testClient.Sprint.GetIssuesForSprint(context.Background(), 123)
 	if err != nil {
 		t.Errorf("Error given: %v", err)
 	}
@@ -79,7 +80,7 @@ func TestSprintService_GetIssue(t *testing.T) {
 		fmt.Fprint(w, `{"expand":"renderedFields,names,schema,transitions,operations,editmeta,changelog,versionedRepresentations","id":"10002","self":"http://www.example.com/jira/rest/api/2/issue/10002","key":"EX-1","fields":{"labels":["test"],"watcher":{"self":"http://www.example.com/jira/rest/api/2/issue/EX-1/watchers","isWatching":false,"watchCount":1,"watchers":[{"self":"http://www.example.com/jira/rest/api/2/user?username=fred","name":"fred","displayName":"Fred F. User","active":false}]},"sprint": {"id": 37,"self": "http://www.example.com/jira/rest/agile/1.0/sprint/13", "state": "future", "name": "sprint 2"}, "epic": {"id": 19415,"key": "EPIC-77","self": "https://example.atlassian.net/rest/agile/1.0/epic/19415","name": "Epic Name","summary": "Do it","color": {"key": "color_11"},"done": false},"attachment":[{"self":"http://www.example.com/jira/rest/api/2.0/attachments/10000","filename":"picture.jpg","author":{"self":"http://www.example.com/jira/rest/api/2/user?username=fred","name":"fred","avatarUrls":{"48x48":"http://www.example.com/jira/secure/useravatar?size=large&ownerId=fred","24x24":"http://www.example.com/jira/secure/useravatar?size=small&ownerId=fred","16x16":"http://www.example.com/jira/secure/useravatar?size=xsmall&ownerId=fred","32x32":"http://www.example.com/jira/secure/useravatar?size=medium&ownerId=fred"},"displayName":"Fred F. User","active":false},"created":"2016-03-16T04:22:37.461+0000","size":23123,"mimeType":"image/jpeg","content":"http://www.example.com/jira/attachments/10000","thumbnail":"http://www.example.com/jira/secure/thumbnail/10000"}],"sub-tasks":[{"id":"10000","type":{"id":"10000","name":"","inward":"Parent","outward":"Sub-task"},"outwardIssue":{"id":"10003","key":"EX-2","self":"http://www.example.com/jira/rest/api/2/issue/EX-2","fields":{"status":{"iconUrl":"http://www.example.com/jira//images/icons/statuses/open.png","name":"Open"}}}}],"description":"example bug report","project":{"self":"http://www.example.com/jira/rest/api/2/project/EX","id":"10000","key":"EX","name":"Example","avatarUrls":{"48x48":"http://www.example.com/jira/secure/projectavatar?size=large&pid=10000","24x24":"http://www.example.com/jira/secure/projectavatar?size=small&pid=10000","16x16":"http://www.example.com/jira/secure/projectavatar?size=xsmall&pid=10000","32x32":"http://www.example.com/jira/secure/projectavatar?size=medium&pid=10000"},"projectCategory":{"self":"http://www.example.com/jira/rest/api/2/projectCategory/10000","id":"10000","name":"FIRST","description":"First Project Category"}},"comment":{"comments":[{"self":"http://www.example.com/jira/rest/api/2/issue/10010/comment/10000","id":"10000","author":{"self":"http://www.example.com/jira/rest/api/2/user?username=fred","name":"fred","displayName":"Fred F. User","active":false},"body":"Lorem ipsum dolor sit amet, consectetur adipiscing elit. Pellentesque eget venenatis elit. Duis eu justo eget augue iaculis fermentum. Sed semper quam laoreet nisi egestas at posuere augue semper.","updateAuthor":{"self":"http://www.example.com/jira/rest/api/2/user?username=fred","name":"fred","displayName":"Fred F. User","active":false},"created":"2016-03-16T04:22:37.356+0000","updated":"2016-03-16T04:22:37.356+0000","visibility":{"type":"role","value":"Administrators"}}]},"issuelinks":[{"id":"10001","type":{"id":"10000","name":"Dependent","inward":"depends on","outward":"is depended by"},"outwardIssue":{"id":"10004L","key":"PRJ-2","self":"http://www.example.com/jira/rest/api/2/issue/PRJ-2","fields":{"status":{"iconUrl":"http://www.example.com/jira//images/icons/statuses/open.png","name":"Open"}}}},{"id":"10002","type":{"id":"10000","name":"Dependent","inward":"depends on","outward":"is depended by"},"inwardIssue":{"id":"10004","key":"PRJ-3","self":"http://www.example.com/jira/rest/api/2/issue/PRJ-3","fields":{"status":{"iconUrl":"http://www.example.com/jira//images/icons/statuses/open.png","name":"Open"}}}}],"worklog":{"worklogs":[{"self":"http://www.example.com/jira/rest/api/2/issue/10010/worklog/10000","author":{"self":"http://www.example.com/jira/rest/api/2/user?username=fred","name":"fred","displayName":"Fred F. User","active":false},"updateAuthor":{"self":"http://www.example.com/jira/rest/api/2/user?username=fred","name":"fred","displayName":"Fred F. User","active":false},"comment":"I did some work here.","updated":"2016-03-16T04:22:37.471+0000","visibility":{"type":"group","value":"jira-developers"},"started":"2016-03-16T04:22:37.471+0000","timeSpent":"3h 20m","timeSpentSeconds":12000,"id":"100028","issueId":"10002"}]},"updated":"2016-04-06T02:36:53.594-0700","duedate":"2018-01-19","timetracking":{"originalEstimate":"10m","remainingEstimate":"3m","timeSpent":"6m","originalEstimateSeconds":600,"remainingEstimateSeconds":200,"timeSpentSeconds":400}},"names":{"watcher":"watcher","attachment":"attachment","sub-tasks":"sub-tasks","description":"description","project":"project","comment":"comment","issuelinks":"issuelinks","worklog":"worklog","updated":"updated","timetracking":"timetracking"},"schema":{}}`)
 	})
 
-	issue, _, err := testClient.Sprint.GetIssue("10002", nil)
+	issue, _, err := testClient.Sprint.GetIssue(context.Background(), "10002", nil)
 	if err != nil {
 		t.Errorf("Error given: %s", err)
 	}

--- a/cloud/status.go
+++ b/cloud/status.go
@@ -19,10 +19,10 @@ type Status struct {
 	StatusCategory StatusCategory `json:"statusCategory" structs:"statusCategory"`
 }
 
-// GetAllStatusesWithContext returns a list of all statuses associated with workflows.
+// GetAllStatuses returns a list of all statuses associated with workflows.
 //
 // Jira API docs: https://developer.atlassian.com/cloud/jira/platform/rest/v2/#api-rest-api-2-status-get
-func (s *StatusService) GetAllStatusesWithContext(ctx context.Context) ([]Status, *Response, error) {
+func (s *StatusService) GetAllStatuses(ctx context.Context) ([]Status, *Response, error) {
 	apiEndpoint := "rest/api/2/status"
 	req, err := s.client.NewRequest(ctx, "GET", apiEndpoint, nil)
 
@@ -37,9 +37,4 @@ func (s *StatusService) GetAllStatusesWithContext(ctx context.Context) ([]Status
 	}
 
 	return statusList, resp, nil
-}
-
-// GetAllStatuses wraps GetAllStatusesWithContext using the background context.
-func (s *StatusService) GetAllStatuses() ([]Status, *Response, error) {
-	return s.GetAllStatusesWithContext(context.Background())
 }

--- a/cloud/status_test.go
+++ b/cloud/status_test.go
@@ -1,6 +1,7 @@
 package cloud
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 	"os"
@@ -23,7 +24,7 @@ func TestStatusService_GetAllStatuses(t *testing.T) {
 		fmt.Fprint(w, string(raw))
 	})
 
-	statusList, _, err := testClient.Status.GetAllStatuses()
+	statusList, _, err := testClient.Status.GetAllStatuses(context.Background())
 
 	if statusList == nil {
 		t.Error("Expected statusList. statusList is nill")

--- a/cloud/statuscategory.go
+++ b/cloud/statuscategory.go
@@ -25,10 +25,10 @@ const (
 	StatusCategoryUndefined  = "undefined"
 )
 
-// GetListWithContext gets all status categories from Jira
+// GetList gets all status categories from Jira
 //
 // Jira API docs: https://developer.atlassian.com/cloud/jira/platform/rest/#api-api-2-statuscategory-get
-func (s *StatusCategoryService) GetListWithContext(ctx context.Context) ([]StatusCategory, *Response, error) {
+func (s *StatusCategoryService) GetList(ctx context.Context) ([]StatusCategory, *Response, error) {
 	apiEndpoint := "rest/api/2/statuscategory"
 	req, err := s.client.NewRequest(ctx, "GET", apiEndpoint, nil)
 	if err != nil {
@@ -41,9 +41,4 @@ func (s *StatusCategoryService) GetListWithContext(ctx context.Context) ([]Statu
 		return nil, resp, NewJiraError(resp, err)
 	}
 	return statusCategoryList, resp, nil
-}
-
-// GetList wraps GetListWithContext using the background context.
-func (s *StatusCategoryService) GetList() ([]StatusCategory, *Response, error) {
-	return s.GetListWithContext(context.Background())
 }

--- a/cloud/statuscategory_test.go
+++ b/cloud/statuscategory_test.go
@@ -1,6 +1,7 @@
 package cloud
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 	"os"
@@ -22,7 +23,7 @@ func TestStatusCategoryService_GetList(t *testing.T) {
 		fmt.Fprint(w, string(raw))
 	})
 
-	statusCategory, _, err := testClient.StatusCategory.GetList()
+	statusCategory, _, err := testClient.StatusCategory.GetList(context.Background())
 	if statusCategory == nil {
 		t.Error("Expected statusCategory list. StatusCategory list is nil")
 	}

--- a/cloud/user.go
+++ b/cloud/user.go
@@ -44,10 +44,10 @@ type userSearch []userSearchParam
 
 type userSearchF func(userSearch) userSearch
 
-// GetWithContext gets user info from Jira using its Account Id
+// Get gets user info from Jira using its Account Id
 //
 // Jira API docs: https://developer.atlassian.com/cloud/jira/platform/rest/v2/#api-rest-api-2-user-get
-func (s *UserService) GetWithContext(ctx context.Context, accountId string) (*User, *Response, error) {
+func (s *UserService) Get(ctx context.Context, accountId string) (*User, *Response, error) {
 	apiEndpoint := fmt.Sprintf("/rest/api/2/user?accountId=%s", accountId)
 	req, err := s.client.NewRequest(ctx, "GET", apiEndpoint, nil)
 	if err != nil {
@@ -62,16 +62,11 @@ func (s *UserService) GetWithContext(ctx context.Context, accountId string) (*Us
 	return user, resp, nil
 }
 
-// Get wraps GetWithContext using the background context.
-func (s *UserService) Get(accountId string) (*User, *Response, error) {
-	return s.GetWithContext(context.Background(), accountId)
-}
-
-// GetByAccountIDWithContext gets user info from Jira
+// GetByAccountID gets user info from Jira
 // Searching by another parameter that is not accountId is deprecated,
 // but this method is kept for backwards compatibility
 // Jira API docs: https://docs.atlassian.com/jira/REST/cloud/#api/2/user-getUser
-func (s *UserService) GetByAccountIDWithContext(ctx context.Context, accountID string) (*User, *Response, error) {
+func (s *UserService) GetByAccountID(ctx context.Context, accountID string) (*User, *Response, error) {
 	apiEndpoint := fmt.Sprintf("/rest/api/2/user?accountId=%s", accountID)
 	req, err := s.client.NewRequest(ctx, "GET", apiEndpoint, nil)
 	if err != nil {
@@ -86,15 +81,10 @@ func (s *UserService) GetByAccountIDWithContext(ctx context.Context, accountID s
 	return user, resp, nil
 }
 
-// GetByAccountID wraps GetByAccountIDWithContext using the background context.
-func (s *UserService) GetByAccountID(accountID string) (*User, *Response, error) {
-	return s.GetByAccountIDWithContext(context.Background(), accountID)
-}
-
-// CreateWithContext creates an user in Jira.
+// Create creates an user in Jira.
 //
 // Jira API docs: https://docs.atlassian.com/jira/REST/cloud/#api/2/user-createUser
-func (s *UserService) CreateWithContext(ctx context.Context, user *User) (*User, *Response, error) {
+func (s *UserService) Create(ctx context.Context, user *User) (*User, *Response, error) {
 	apiEndpoint := "/rest/api/2/user"
 	req, err := s.client.NewRequest(ctx, "POST", apiEndpoint, user)
 	if err != nil {
@@ -121,17 +111,12 @@ func (s *UserService) CreateWithContext(ctx context.Context, user *User) (*User,
 	return responseUser, resp, nil
 }
 
-// Create wraps CreateWithContext using the background context.
-func (s *UserService) Create(user *User) (*User, *Response, error) {
-	return s.CreateWithContext(context.Background(), user)
-}
-
-// DeleteWithContext deletes an user from Jira.
+// Delete deletes an user from Jira.
 // Returns http.StatusNoContent on success.
 //
 // Jira API docs: https://developer.atlassian.com/cloud/jira/platform/rest/v2/#api-rest-api-2-user-delete
 // Caller must close resp.Body
-func (s *UserService) DeleteWithContext(ctx context.Context, accountId string) (*Response, error) {
+func (s *UserService) Delete(ctx context.Context, accountId string) (*Response, error) {
 	apiEndpoint := fmt.Sprintf("/rest/api/2/user?accountId=%s", accountId)
 	req, err := s.client.NewRequest(ctx, "DELETE", apiEndpoint, nil)
 	if err != nil {
@@ -145,16 +130,10 @@ func (s *UserService) DeleteWithContext(ctx context.Context, accountId string) (
 	return resp, nil
 }
 
-// Delete wraps DeleteWithContext using the background context.
-// Caller must close resp.Body
-func (s *UserService) Delete(accountId string) (*Response, error) {
-	return s.DeleteWithContext(context.Background(), accountId)
-}
-
-// GetGroupsWithContext returns the groups which the user belongs to
+// GetGroups returns the groups which the user belongs to
 //
 // Jira API docs: https://developer.atlassian.com/cloud/jira/platform/rest/v2/#api-rest-api-2-user-groups-get
-func (s *UserService) GetGroupsWithContext(ctx context.Context, accountId string) (*[]UserGroup, *Response, error) {
+func (s *UserService) GetGroups(ctx context.Context, accountId string) (*[]UserGroup, *Response, error) {
 	apiEndpoint := fmt.Sprintf("/rest/api/2/user/groups?accountId=%s", accountId)
 	req, err := s.client.NewRequest(ctx, "GET", apiEndpoint, nil)
 	if err != nil {
@@ -169,15 +148,10 @@ func (s *UserService) GetGroupsWithContext(ctx context.Context, accountId string
 	return userGroups, resp, nil
 }
 
-// GetGroups wraps GetGroupsWithContext using the background context.
-func (s *UserService) GetGroups(accountId string) (*[]UserGroup, *Response, error) {
-	return s.GetGroupsWithContext(context.Background(), accountId)
-}
-
-// GetSelfWithContext information about the current logged-in user
+// GetSelf information about the current logged-in user
 //
 // Jira API docs: https://developer.atlassian.com/cloud/jira/platform/rest/v2/#api-rest-api-2-myself-get
-func (s *UserService) GetSelfWithContext(ctx context.Context) (*User, *Response, error) {
+func (s *UserService) GetSelf(ctx context.Context) (*User, *Response, error) {
 	const apiEndpoint = "rest/api/2/myself"
 	req, err := s.client.NewRequest(ctx, "GET", apiEndpoint, nil)
 	if err != nil {
@@ -189,11 +163,6 @@ func (s *UserService) GetSelfWithContext(ctx context.Context) (*User, *Response,
 		return nil, resp, NewJiraError(resp, err)
 	}
 	return &user, resp, nil
-}
-
-// GetSelf wraps GetSelfWithContext using the background context.
-func (s *UserService) GetSelf() (*User, *Response, error) {
-	return s.GetSelfWithContext(context.Background())
 }
 
 // WithMaxResults sets the max results to return
@@ -252,11 +221,11 @@ func WithProperty(property string) userSearchF {
 	}
 }
 
-// FindWithContext searches for user info from Jira:
+// Find searches for user info from Jira:
 // It can find users by email or display name using the query parameter
 //
 // Jira API docs: https://developer.atlassian.com/cloud/jira/platform/rest/v2/#api-rest-api-2-user-search-get
-func (s *UserService) FindWithContext(ctx context.Context, property string, tweaks ...userSearchF) ([]User, *Response, error) {
+func (s *UserService) Find(ctx context.Context, property string, tweaks ...userSearchF) ([]User, *Response, error) {
 	search := []userSearchParam{
 		{
 			name:  "query",
@@ -284,9 +253,4 @@ func (s *UserService) FindWithContext(ctx context.Context, property string, twea
 		return nil, resp, NewJiraError(resp, err)
 	}
 	return users, resp, nil
-}
-
-// Find wraps FindWithContext using the background context.
-func (s *UserService) Find(property string, tweaks ...userSearchF) ([]User, *Response, error) {
-	return s.FindWithContext(context.Background(), property, tweaks...)
 }

--- a/cloud/user_test.go
+++ b/cloud/user_test.go
@@ -1,6 +1,7 @@
 package cloud
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 	"testing"
@@ -22,7 +23,7 @@ func TestUserService_Get_Success(t *testing.T) {
         }]},"applicationRoles":{"size":1,"items":[]},"expand":"groups,applicationRoles"}`)
 	})
 
-	if user, _, err := testClient.User.Get("000000000000000000000000"); err != nil {
+	if user, _, err := testClient.User.Get(context.Background(), "000000000000000000000000"); err != nil {
 		t.Errorf("Error given: %s", err)
 	} else if user == nil {
 		t.Error("Expected user. User is nil")
@@ -45,7 +46,7 @@ func TestUserService_GetByAccountID_Success(t *testing.T) {
         }]},"applicationRoles":{"size":1,"items":[]},"expand":"groups,applicationRoles"}`)
 	})
 
-	if user, _, err := testClient.User.GetByAccountID("000000000000000000000000"); err != nil {
+	if user, _, err := testClient.User.GetByAccountID(context.Background(), "000000000000000000000000"); err != nil {
 		t.Errorf("Error given: %s", err)
 	} else if user == nil {
 		t.Error("Expected user. User is nil")
@@ -72,7 +73,7 @@ func TestUserService_Create(t *testing.T) {
 		ApplicationKeys: []string{"jira-core"},
 	}
 
-	if user, _, err := testClient.User.Create(u); err != nil {
+	if user, _, err := testClient.User.Create(context.Background(), u); err != nil {
 		t.Errorf("Error given: %s", err)
 	} else if user == nil {
 		t.Error("Expected user. User is nil")
@@ -89,7 +90,7 @@ func TestUserService_Delete(t *testing.T) {
 		w.WriteHeader(http.StatusNoContent)
 	})
 
-	resp, err := testClient.User.Delete("000000000000000000000000")
+	resp, err := testClient.User.Delete(context.Background(), "000000000000000000000000")
 	if err != nil {
 		t.Errorf("Error given: %s", err)
 	}
@@ -110,7 +111,7 @@ func TestUserService_GetGroups(t *testing.T) {
 		fmt.Fprint(w, `[{"name":"jira-software-users","self":"http://www.example.com/jira/rest/api/2/user?accountId=000000000000000000000000"}]`)
 	})
 
-	if groups, _, err := testClient.User.GetGroups("000000000000000000000000"); err != nil {
+	if groups, _, err := testClient.User.GetGroups(context.Background(), "000000000000000000000000"); err != nil {
 		t.Errorf("Error given: %s", err)
 	} else if groups == nil {
 		t.Error("Expected user groups. []UserGroup is nil")
@@ -134,7 +135,7 @@ func TestUserService_GetSelf(t *testing.T) {
         }]},"applicationRoles":{"size":1,"items":[]},"expand":"groups,applicationRoles"}`)
 	})
 
-	if user, _, err := testClient.User.GetSelf(); err != nil {
+	if user, _, err := testClient.User.GetSelf(context.Background()); err != nil {
 		t.Errorf("Error given: %s", err)
 	} else if user == nil {
 		t.Error("Expected user groups. []UserGroup is nil")
@@ -161,7 +162,7 @@ func TestUserService_Find_Success(t *testing.T) {
         }]},"applicationRoles":{"size":1,"items":[]},"expand":"groups,applicationRoles"}]`)
 	})
 
-	if user, _, err := testClient.User.Find("fred@example.com"); err != nil {
+	if user, _, err := testClient.User.Find(context.Background(), "fred@example.com"); err != nil {
 		t.Errorf("Error given: %s", err)
 	} else if user == nil {
 		t.Error("Expected user. User is nil")
@@ -184,7 +185,7 @@ func TestUserService_Find_SuccessParams(t *testing.T) {
         }]},"applicationRoles":{"size":1,"items":[]},"expand":"groups,applicationRoles"}]`)
 	})
 
-	if user, _, err := testClient.User.Find("fred@example.com", WithStartAt(100), WithMaxResults(1000)); err != nil {
+	if user, _, err := testClient.User.Find(context.Background(), "fred@example.com", WithStartAt(100), WithMaxResults(1000)); err != nil {
 		t.Errorf("Error given: %s", err)
 	} else if user == nil {
 		t.Error("Expected user. User is nil")

--- a/cloud/version.go
+++ b/cloud/version.go
@@ -26,10 +26,10 @@ type Version struct {
 	StartDate       string `json:"startDate,omitempty" structs:"startDate,omitempty"`
 }
 
-// GetWithContext gets version info from Jira
+// Get gets version info from Jira
 //
 // Jira API docs: https://developer.atlassian.com/cloud/jira/platform/rest/#api-api-2-version-id-get
-func (s *VersionService) GetWithContext(ctx context.Context, versionID int) (*Version, *Response, error) {
+func (s *VersionService) Get(ctx context.Context, versionID int) (*Version, *Response, error) {
 	apiEndpoint := fmt.Sprintf("/rest/api/2/version/%v", versionID)
 	req, err := s.client.NewRequest(ctx, "GET", apiEndpoint, nil)
 	if err != nil {
@@ -44,15 +44,10 @@ func (s *VersionService) GetWithContext(ctx context.Context, versionID int) (*Ve
 	return version, resp, nil
 }
 
-// Get wraps GetWithContext using the background context.
-func (s *VersionService) Get(versionID int) (*Version, *Response, error) {
-	return s.GetWithContext(context.Background(), versionID)
-}
-
-// CreateWithContext creates a version in Jira.
+// Create creates a version in Jira.
 //
 // Jira API docs: https://developer.atlassian.com/cloud/jira/platform/rest/#api-api-2-version-post
-func (s *VersionService) CreateWithContext(ctx context.Context, version *Version) (*Version, *Response, error) {
+func (s *VersionService) Create(ctx context.Context, version *Version) (*Version, *Response, error) {
 	apiEndpoint := "/rest/api/2/version"
 	req, err := s.client.NewRequest(ctx, "POST", apiEndpoint, version)
 	if err != nil {
@@ -79,16 +74,11 @@ func (s *VersionService) CreateWithContext(ctx context.Context, version *Version
 	return responseVersion, resp, nil
 }
 
-// Create wraps CreateWithContext using the background context.
-func (s *VersionService) Create(version *Version) (*Version, *Response, error) {
-	return s.CreateWithContext(context.Background(), version)
-}
-
-// UpdateWithContext updates a version from a JSON representation.
+// Update updates a version from a JSON representation.
 //
 // Jira API docs: https://developer.atlassian.com/cloud/jira/platform/rest/#api-api-2-version-id-put
 // Caller must close resp.Body
-func (s *VersionService) UpdateWithContext(ctx context.Context, version *Version) (*Version, *Response, error) {
+func (s *VersionService) Update(ctx context.Context, version *Version) (*Version, *Response, error) {
 	apiEndpoint := fmt.Sprintf("rest/api/2/version/%v", version.ID)
 	req, err := s.client.NewRequest(ctx, "PUT", apiEndpoint, version)
 	if err != nil {
@@ -104,10 +94,4 @@ func (s *VersionService) UpdateWithContext(ctx context.Context, version *Version
 	// Returning the same pointer here is pointless, so we return a copy instead.
 	ret := *version
 	return &ret, resp, nil
-}
-
-// Update wraps UpdateWithContext using the background context.
-// Caller must close resp.Body
-func (s *VersionService) Update(version *Version) (*Version, *Response, error) {
-	return s.UpdateWithContext(context.Background(), version)
 }

--- a/cloud/version_test.go
+++ b/cloud/version_test.go
@@ -1,6 +1,7 @@
 package cloud
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 	"testing"
@@ -28,7 +29,7 @@ func TestVersionService_Get_Success(t *testing.T) {
 		}`)
 	})
 
-	version, _, err := testClient.Version.Get(10002)
+	version, _, err := testClient.Version.Get(context.Background(), 10002)
 	if version == nil {
 		t.Error("Expected version. Issue is nil")
 	}
@@ -68,7 +69,7 @@ func TestVersionService_Create(t *testing.T) {
 		StartDate:       "2018-07-01",
 	}
 
-	version, _, err := testClient.Version.Create(v)
+	version, _, err := testClient.Version.Create(context.Background(), v)
 	if version == nil {
 		t.Error("Expected version. Version is nil")
 	}
@@ -102,7 +103,7 @@ func TestServiceService_Update(t *testing.T) {
 		Description: "An excellent updated version",
 	}
 
-	version, _, err := testClient.Version.Update(v)
+	version, _, err := testClient.Version.Update(context.Background(), v)
 	if version == nil {
 		t.Error("Expected version. Version is nil")
 	}

--- a/onpremise/auth_transport_personal_access_token_test.go
+++ b/onpremise/auth_transport_personal_access_token_test.go
@@ -1,6 +1,7 @@
 package onpremise
 
 import (
+	"context"
 	"net/http"
 	"testing"
 )
@@ -24,6 +25,6 @@ func TestPATAuthTransport_HeaderContainsAuth(t *testing.T) {
 	})
 
 	client, _ := NewClient(testServer.URL, patTransport.Client())
-	client.User.GetSelf()
+	client.User.GetSelf(context.Background())
 
 }

--- a/onpremise/examples/addlabel/main.go
+++ b/onpremise/examples/addlabel/main.go
@@ -8,7 +8,7 @@ import (
 	"strings"
 	"syscall"
 
-	jira "github.com/andygrunwald/go-jira/cloud"
+	jira "github.com/andygrunwald/go-jira/onpremise"
 	"golang.org/x/term"
 )
 

--- a/onpremise/examples/basicauth/main.go
+++ b/onpremise/examples/basicauth/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"bufio"
+	"context"
 	"fmt"
 	"os"
 	"strings"
@@ -36,7 +37,7 @@ func main() {
 		return
 	}
 
-	u, _, err := client.User.Get("admin")
+	u, _, err := client.User.Get(context.Background(), "admin")
 
 	if err != nil {
 		fmt.Printf("\nerror: %v\n", err)

--- a/onpremise/examples/basicauth/main.go
+++ b/onpremise/examples/basicauth/main.go
@@ -9,7 +9,7 @@ import (
 
 	"golang.org/x/term"
 
-	jira "github.com/andygrunwald/go-jira/cloud"
+	jira "github.com/andygrunwald/go-jira/onpremise"
 )
 
 func main() {

--- a/onpremise/examples/create/main.go
+++ b/onpremise/examples/create/main.go
@@ -7,7 +7,7 @@ import (
 	"strings"
 	"syscall"
 
-	jira "github.com/andygrunwald/go-jira/cloud"
+	jira "github.com/andygrunwald/go-jira/onpremise"
 	"golang.org/x/term"
 )
 

--- a/onpremise/examples/createwithcustomfields/main.go
+++ b/onpremise/examples/createwithcustomfields/main.go
@@ -7,7 +7,7 @@ import (
 	"strings"
 	"syscall"
 
-	jira "github.com/andygrunwald/go-jira/cloud"
+	jira "github.com/andygrunwald/go-jira/onpremise"
 	"github.com/trivago/tgo/tcontainer"
 	"golang.org/x/term"
 )

--- a/onpremise/examples/do/main.go
+++ b/onpremise/examples/do/main.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"fmt"
 
-	jira "github.com/andygrunwald/go-jira/cloud"
+	jira "github.com/andygrunwald/go-jira/onpremise"
 )
 
 func main() {

--- a/onpremise/examples/ignorecerts/main.go
+++ b/onpremise/examples/ignorecerts/main.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"net/http"
 
-	jira "github.com/andygrunwald/go-jira/cloud"
+	jira "github.com/andygrunwald/go-jira/onpremise"
 )
 
 func main() {

--- a/onpremise/examples/jql/main.go
+++ b/onpremise/examples/jql/main.go
@@ -3,7 +3,7 @@ package main
 import (
 	"fmt"
 
-	jira "github.com/andygrunwald/go-jira/cloud"
+	jira "github.com/andygrunwald/go-jira/onpremise"
 )
 
 func main() {

--- a/onpremise/examples/newclient/main.go
+++ b/onpremise/examples/newclient/main.go
@@ -3,7 +3,7 @@ package main
 import (
 	"fmt"
 
-	jira "github.com/andygrunwald/go-jira/cloud"
+	jira "github.com/andygrunwald/go-jira/onpremise"
 )
 
 func main() {

--- a/onpremise/examples/pagination/main.go
+++ b/onpremise/examples/pagination/main.go
@@ -3,7 +3,7 @@ package main
 import (
 	"fmt"
 
-	jira "github.com/andygrunwald/go-jira/cloud"
+	jira "github.com/andygrunwald/go-jira/onpremise"
 )
 
 // GetAllIssues will implement pagination of api and get all the issues.

--- a/onpremise/examples/renderedfields/main.go
+++ b/onpremise/examples/renderedfields/main.go
@@ -10,7 +10,7 @@ import (
 
 	"golang.org/x/term"
 
-	jira "github.com/andygrunwald/go-jira/cloud"
+	jira "github.com/andygrunwald/go-jira/onpremise"
 )
 
 func main() {

--- a/onpremise/examples/searchpages/main.go
+++ b/onpremise/examples/searchpages/main.go
@@ -9,7 +9,7 @@ import (
 	"syscall"
 	"time"
 
-	jira "github.com/andygrunwald/go-jira/cloud"
+	jira "github.com/andygrunwald/go-jira/onpremise"
 	"golang.org/x/term"
 )
 

--- a/onpremise/issue.go
+++ b/onpremise/issue.go
@@ -1418,7 +1418,7 @@ func (s *IssueService) GetWatchersWithContext(ctx context.Context, issueID strin
 	for _, watcher := range watches.Watchers {
 		var user *User
 		if watcher.AccountID != "" {
-			user, resp, err = s.client.User.GetByAccountID(watcher.AccountID)
+			user, resp, err = s.client.User.GetByAccountID(context.Background(), watcher.AccountID)
 			if err != nil {
 				return nil, resp, NewJiraError(resp, err)
 			}

--- a/onpremise/role.go
+++ b/onpremise/role.go
@@ -34,10 +34,10 @@ type ActorUser struct {
 	AccountID string `json:"accountId" structs:"accountId"`
 }
 
-// GetListWithContext returns a list of all available project roles
+// GetList returns a list of all available project roles
 //
 // Jira API docs: https://developer.atlassian.com/cloud/jira/platform/rest/v3/#api-api-3-role-get
-func (s *RoleService) GetListWithContext(ctx context.Context) (*[]Role, *Response, error) {
+func (s *RoleService) GetList(ctx context.Context) (*[]Role, *Response, error) {
 	apiEndpoint := "rest/api/3/role"
 	req, err := s.client.NewRequest(ctx, "GET", apiEndpoint, nil)
 	if err != nil {
@@ -52,15 +52,10 @@ func (s *RoleService) GetListWithContext(ctx context.Context) (*[]Role, *Respons
 	return roles, resp, err
 }
 
-// GetList wraps GetListWithContext using the background context.
-func (s *RoleService) GetList() (*[]Role, *Response, error) {
-	return s.GetListWithContext(context.Background())
-}
-
-// GetWithContext retreives a single Role from Jira
+// Get retreives a single Role from Jira
 //
 // Jira API docs: https://developer.atlassian.com/cloud/jira/platform/rest/v3/#api-api-3-role-id-get
-func (s *RoleService) GetWithContext(ctx context.Context, roleID int) (*Role, *Response, error) {
+func (s *RoleService) Get(ctx context.Context, roleID int) (*Role, *Response, error) {
 	apiEndpoint := fmt.Sprintf("rest/api/3/role/%d", roleID)
 	req, err := s.client.NewRequest(ctx, "GET", apiEndpoint, nil)
 	if err != nil {
@@ -77,9 +72,4 @@ func (s *RoleService) GetWithContext(ctx context.Context, roleID int) (*Role, *R
 	}
 
 	return role, resp, err
-}
-
-// Get wraps GetWithContext using the background context.
-func (s *RoleService) Get(roleID int) (*Role, *Response, error) {
-	return s.GetWithContext(context.Background(), roleID)
 }

--- a/onpremise/role_test.go
+++ b/onpremise/role_test.go
@@ -1,6 +1,7 @@
 package onpremise
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 	"os"
@@ -23,7 +24,7 @@ func TestRoleService_GetList_NoList(t *testing.T) {
 		fmt.Fprint(w, string(raw))
 	})
 
-	roles, _, err := testClient.Role.GetList()
+	roles, _, err := testClient.Role.GetList(context.Background())
 	if roles != nil {
 		t.Errorf("Expected role list has %d entries but should be nil", len(*roles))
 	}
@@ -47,7 +48,7 @@ func TestRoleService_GetList(t *testing.T) {
 		fmt.Fprint(w, string(raw))
 	})
 
-	roles, _, err := testClient.Role.GetList()
+	roles, _, err := testClient.Role.GetList(context.Background())
 	if err != nil {
 		t.Errorf("Error given: %v", err)
 	}
@@ -74,7 +75,7 @@ func TestRoleService_Get_NoRole(t *testing.T) {
 		fmt.Fprint(writer, string(raw))
 	})
 
-	role, _, err := testClient.Role.Get(99999)
+	role, _, err := testClient.Role.Get(context.Background(), 99999)
 	if role != nil {
 		t.Errorf("Expected nil, got role %v", role)
 	}
@@ -97,7 +98,7 @@ func TestRoleService_Get(t *testing.T) {
 		fmt.Fprint(writer, string(raw))
 	})
 
-	role, _, err := testClient.Role.Get(10002)
+	role, _, err := testClient.Role.Get(context.Background(), 10002)
 	if role == nil {
 		t.Errorf("Expected Role, got nil")
 	}

--- a/onpremise/servicedesk.go
+++ b/onpremise/servicedesk.go
@@ -17,11 +17,11 @@ type ServiceDeskOrganizationDTO struct {
 	OrganizationID int `json:"organizationId,omitempty" structs:"organizationId,omitempty"`
 }
 
-// GetOrganizationsWithContext returns a list of
+// GetOrganizations returns a list of
 // all organizations associated with a service desk.
 //
 // https://developer.atlassian.com/cloud/jira/service-desk/rest/api-group-organization/#api-rest-servicedeskapi-servicedesk-servicedeskid-organization-get
-func (s *ServiceDeskService) GetOrganizationsWithContext(ctx context.Context, serviceDeskID interface{}, start int, limit int, accountID string) (*PagedDTO, *Response, error) {
+func (s *ServiceDeskService) GetOrganizations(ctx context.Context, serviceDeskID interface{}, start int, limit int, accountID string) (*PagedDTO, *Response, error) {
 	apiEndPoint := fmt.Sprintf("rest/servicedeskapi/servicedesk/%v/organization?start=%d&limit=%d", serviceDeskID, start, limit)
 	if accountID != "" {
 		apiEndPoint += fmt.Sprintf("&accountId=%s", accountID)
@@ -44,19 +44,14 @@ func (s *ServiceDeskService) GetOrganizationsWithContext(ctx context.Context, se
 	return orgs, resp, nil
 }
 
-// GetOrganizations wraps GetOrganizationsWithContext using the background context.
-func (s *ServiceDeskService) GetOrganizations(serviceDeskID interface{}, start int, limit int, accountID string) (*PagedDTO, *Response, error) {
-	return s.GetOrganizationsWithContext(context.Background(), serviceDeskID, start, limit, accountID)
-}
-
-// AddOrganizationWithContext adds an organization to
+// AddOrganization adds an organization to
 // a service desk. If the organization ID is already
 // associated with the service desk, no change is made
 // and the resource returns a 204 success code.
 //
 // https://developer.atlassian.com/cloud/jira/service-desk/rest/api-group-organization/#api-rest-servicedeskapi-servicedesk-servicedeskid-organization-post
 // Caller must close resp.Body
-func (s *ServiceDeskService) AddOrganizationWithContext(ctx context.Context, serviceDeskID interface{}, organizationID int) (*Response, error) {
+func (s *ServiceDeskService) AddOrganization(ctx context.Context, serviceDeskID interface{}, organizationID int) (*Response, error) {
 	apiEndPoint := fmt.Sprintf("rest/servicedeskapi/servicedesk/%v/organization", serviceDeskID)
 
 	organization := ServiceDeskOrganizationDTO{
@@ -78,20 +73,14 @@ func (s *ServiceDeskService) AddOrganizationWithContext(ctx context.Context, ser
 	return resp, nil
 }
 
-// AddOrganization wraps AddOrganizationWithContext using the background context.
-// Caller must close resp.Body
-func (s *ServiceDeskService) AddOrganization(serviceDeskID interface{}, organizationID int) (*Response, error) {
-	return s.AddOrganizationWithContext(context.Background(), serviceDeskID, organizationID)
-}
-
-// RemoveOrganizationWithContext removes an organization
+// RemoveOrganization removes an organization
 // from a service desk. If the organization ID does not
 // match an organization associated with the service desk,
 // no change is made and the resource returns a 204 success code.
 //
 // https://developer.atlassian.com/cloud/jira/service-desk/rest/api-group-organization/#api-rest-servicedeskapi-servicedesk-servicedeskid-organization-delete
 // Caller must close resp.Body
-func (s *ServiceDeskService) RemoveOrganizationWithContext(ctx context.Context, serviceDeskID interface{}, organizationID int) (*Response, error) {
+func (s *ServiceDeskService) RemoveOrganization(ctx context.Context, serviceDeskID interface{}, organizationID int) (*Response, error) {
 	apiEndPoint := fmt.Sprintf("rest/servicedeskapi/servicedesk/%v/organization", serviceDeskID)
 
 	organization := ServiceDeskOrganizationDTO{
@@ -113,16 +102,10 @@ func (s *ServiceDeskService) RemoveOrganizationWithContext(ctx context.Context, 
 	return resp, nil
 }
 
-// RemoveOrganization wraps RemoveOrganizationWithContext using the background context.
-// Caller must close resp.Body
-func (s *ServiceDeskService) RemoveOrganization(serviceDeskID interface{}, organizationID int) (*Response, error) {
-	return s.RemoveOrganizationWithContext(context.Background(), serviceDeskID, organizationID)
-}
-
-// AddCustomersWithContext adds customers to the given service desk.
+// AddCustomers adds customers to the given service desk.
 //
 // https://developer.atlassian.com/cloud/jira/service-desk/rest/api-group-servicedesk/#api-rest-servicedeskapi-servicedesk-servicedeskid-customer-post
-func (s *ServiceDeskService) AddCustomersWithContext(ctx context.Context, serviceDeskID interface{}, acountIDs ...string) (*Response, error) {
+func (s *ServiceDeskService) AddCustomers(ctx context.Context, serviceDeskID interface{}, acountIDs ...string) (*Response, error) {
 	apiEndpoint := fmt.Sprintf("rest/servicedeskapi/servicedesk/%v/customer", serviceDeskID)
 
 	payload := struct {
@@ -146,15 +129,10 @@ func (s *ServiceDeskService) AddCustomersWithContext(ctx context.Context, servic
 	return resp, nil
 }
 
-// AddCustomers wraps AddCustomersWithContext using the background context.
-func (s *ServiceDeskService) AddCustomers(serviceDeskID interface{}, acountIDs ...string) (*Response, error) {
-	return s.AddCustomersWithContext(context.Background(), serviceDeskID, acountIDs...)
-}
-
-// RemoveCustomersWithContext removes customers to the given service desk.
+// RemoveCustomers removes customers to the given service desk.
 //
 // https://developer.atlassian.com/cloud/jira/service-desk/rest/api-group-servicedesk/#api-rest-servicedeskapi-servicedesk-servicedeskid-customer-delete
-func (s *ServiceDeskService) RemoveCustomersWithContext(ctx context.Context, serviceDeskID interface{}, acountIDs ...string) (*Response, error) {
+func (s *ServiceDeskService) RemoveCustomers(ctx context.Context, serviceDeskID interface{}, acountIDs ...string) (*Response, error) {
 	apiEndpoint := fmt.Sprintf("rest/servicedeskapi/servicedesk/%v/customer", serviceDeskID)
 
 	payload := struct {
@@ -178,15 +156,10 @@ func (s *ServiceDeskService) RemoveCustomersWithContext(ctx context.Context, ser
 	return resp, nil
 }
 
-// RemoveCustomers wraps RemoveCustomersWithContext using the background context.
-func (s *ServiceDeskService) RemoveCustomers(serviceDeskID interface{}, acountIDs ...string) (*Response, error) {
-	return s.RemoveCustomersWithContext(context.Background(), serviceDeskID, acountIDs...)
-}
-
-// ListCustomersWithContext lists customers for a ServiceDesk.
+// ListCustomers lists customers for a ServiceDesk.
 //
 // https://developer.atlassian.com/cloud/jira/service-desk/rest/api-group-servicedesk/#api-rest-servicedeskapi-servicedesk-servicedeskid-customer-get
-func (s *ServiceDeskService) ListCustomersWithContext(ctx context.Context, serviceDeskID interface{}, options *CustomerListOptions) (*CustomerList, *Response, error) {
+func (s *ServiceDeskService) ListCustomers(ctx context.Context, serviceDeskID interface{}, options *CustomerListOptions) (*CustomerList, *Response, error) {
 	apiEndpoint := fmt.Sprintf("rest/servicedeskapi/servicedesk/%v/customer", serviceDeskID)
 	req, err := s.client.NewRequest(ctx, "GET", apiEndpoint, nil)
 	if err != nil {
@@ -216,9 +189,4 @@ func (s *ServiceDeskService) ListCustomersWithContext(ctx context.Context, servi
 	}
 
 	return customerList, resp, nil
-}
-
-// ListCustomers wraps ListCustomersWithContext using the background context.
-func (s *ServiceDeskService) ListCustomers(serviceDeskID interface{}, options *CustomerListOptions) (*CustomerList, *Response, error) {
-	return s.ListCustomersWithContext(context.Background(), serviceDeskID, options)
 }

--- a/onpremise/servicedesk_test.go
+++ b/onpremise/servicedesk_test.go
@@ -1,6 +1,7 @@
 package onpremise
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -56,7 +57,7 @@ func TestServiceDeskService_GetOrganizations(t *testing.T) {
 		  }`)
 	})
 
-	orgs, _, err := testClient.ServiceDesk.GetOrganizations(10001, 3, 3, "")
+	orgs, _, err := testClient.ServiceDesk.GetOrganizations(context.Background(), 10001, 3, 3, "")
 
 	if orgs == nil {
 		t.Error("Expected Organizations. Result is nil")
@@ -79,7 +80,7 @@ func TestServiceDeskService_AddOrganizations(t *testing.T) {
 		w.WriteHeader(http.StatusNoContent)
 	})
 
-	_, err := testClient.ServiceDesk.AddOrganization(10001, 1)
+	_, err := testClient.ServiceDesk.AddOrganization(context.Background(), 10001, 1)
 
 	if err != nil {
 		t.Errorf("Error given: %s", err)
@@ -96,7 +97,7 @@ func TestServiceDeskService_RemoveOrganizations(t *testing.T) {
 		w.WriteHeader(http.StatusNoContent)
 	})
 
-	_, err := testClient.ServiceDesk.RemoveOrganization(10001, 1)
+	_, err := testClient.ServiceDesk.RemoveOrganization(context.Background(), 10001, 1)
 
 	if err != nil {
 		t.Errorf("Error given: %s", err)
@@ -149,7 +150,7 @@ func TestServiceDeskServiceStringServiceDeskID_GetOrganizations(t *testing.T) {
 		  }`)
 	})
 
-	orgs, _, err := testClient.ServiceDesk.GetOrganizations("TEST", 3, 3, "")
+	orgs, _, err := testClient.ServiceDesk.GetOrganizations(context.Background(), "TEST", 3, 3, "")
 
 	if orgs == nil {
 		t.Error("Expected Organizations. Result is nil")
@@ -172,7 +173,7 @@ func TestServiceDeskServiceStringServiceDeskID_AddOrganizations(t *testing.T) {
 		w.WriteHeader(http.StatusNoContent)
 	})
 
-	_, err := testClient.ServiceDesk.AddOrganization("TEST", 1)
+	_, err := testClient.ServiceDesk.AddOrganization(context.Background(), "TEST", 1)
 
 	if err != nil {
 		t.Errorf("Error given: %s", err)
@@ -189,7 +190,7 @@ func TestServiceDeskServiceStringServiceDeskID_RemoveOrganizations(t *testing.T)
 		w.WriteHeader(http.StatusNoContent)
 	})
 
-	_, err := testClient.ServiceDesk.RemoveOrganization("TEST", 1)
+	_, err := testClient.ServiceDesk.RemoveOrganization(context.Background(), "TEST", 1)
 
 	if err != nil {
 		t.Errorf("Error given: %s", err)
@@ -242,7 +243,7 @@ func TestServiceDeskService_AddCustomers(t *testing.T) {
 				w.WriteHeader(http.StatusNoContent)
 			})
 
-			_, err := testClient.ServiceDesk.AddCustomers(test.serviceDeskID, wantAccountIDs...)
+			_, err := testClient.ServiceDesk.AddCustomers(context.Background(), test.serviceDeskID, wantAccountIDs...)
 
 			if err != nil {
 				t.Errorf("Error given: %s", err)
@@ -308,7 +309,7 @@ func TestServiceDeskService_RemoveCustomers(t *testing.T) {
 				w.WriteHeader(http.StatusNoContent)
 			})
 
-			_, err := testClient.ServiceDesk.RemoveCustomers(test.serviceDeskID, wantAccountIDs...)
+			_, err := testClient.ServiceDesk.RemoveCustomers(context.Background(), test.serviceDeskID, wantAccountIDs...)
 
 			if err != nil {
 				t.Errorf("Error given: %s", err)
@@ -409,7 +410,7 @@ func TestServiceDeskService_ListCustomers(t *testing.T) {
 				}`))
 			})
 
-			customerList, _, err := testClient.ServiceDesk.ListCustomers(test.serviceDeskID, wantOptions)
+			customerList, _, err := testClient.ServiceDesk.ListCustomers(context.Background(), test.serviceDeskID, wantOptions)
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/onpremise/sprint.go
+++ b/onpremise/sprint.go
@@ -21,13 +21,13 @@ type IssuesInSprintResult struct {
 	Issues []Issue `json:"issues"`
 }
 
-// MoveIssuesToSprintWithContext moves issues to a sprint, for a given sprint Id.
+// MoveIssuesToSprint moves issues to a sprint, for a given sprint Id.
 // Issues can only be moved to open or active sprints.
 // The maximum number of issues that can be moved in one operation is 50.
 //
 // Jira API docs: https://docs.atlassian.com/jira-software/REST/cloud/#agile/1.0/sprint-moveIssuesToSprint
 // Caller must close resp.Body
-func (s *SprintService) MoveIssuesToSprintWithContext(ctx context.Context, sprintID int, issueIDs []string) (*Response, error) {
+func (s *SprintService) MoveIssuesToSprint(ctx context.Context, sprintID int, issueIDs []string) (*Response, error) {
 	apiEndpoint := fmt.Sprintf("rest/agile/1.0/sprint/%d/issue", sprintID)
 
 	payload := IssuesWrapper{Issues: issueIDs}
@@ -45,18 +45,12 @@ func (s *SprintService) MoveIssuesToSprintWithContext(ctx context.Context, sprin
 	return resp, err
 }
 
-// MoveIssuesToSprint wraps MoveIssuesToSprintWithContext using the background context.
-// Caller must close resp.Body
-func (s *SprintService) MoveIssuesToSprint(sprintID int, issueIDs []string) (*Response, error) {
-	return s.MoveIssuesToSprintWithContext(context.Background(), sprintID, issueIDs)
-}
-
-// GetIssuesForSprintWithContext returns all issues in a sprint, for a given sprint Id.
+// GetIssuesForSprint returns all issues in a sprint, for a given sprint Id.
 // This only includes issues that the user has permission to view.
 // By default, the returned issues are ordered by rank.
 //
 // Jira API Docs: https://docs.atlassian.com/jira-software/REST/cloud/#agile/1.0/sprint-getIssuesForSprint
-func (s *SprintService) GetIssuesForSprintWithContext(ctx context.Context, sprintID int) ([]Issue, *Response, error) {
+func (s *SprintService) GetIssuesForSprint(ctx context.Context, sprintID int) ([]Issue, *Response, error) {
 	apiEndpoint := fmt.Sprintf("rest/agile/1.0/sprint/%d/issue", sprintID)
 
 	req, err := s.client.NewRequest(ctx, "GET", apiEndpoint, nil)
@@ -74,12 +68,7 @@ func (s *SprintService) GetIssuesForSprintWithContext(ctx context.Context, sprin
 	return result.Issues, resp, err
 }
 
-// GetIssuesForSprint wraps GetIssuesForSprintWithContext using the background context.
-func (s *SprintService) GetIssuesForSprint(sprintID int) ([]Issue, *Response, error) {
-	return s.GetIssuesForSprintWithContext(context.Background(), sprintID)
-}
-
-// GetIssueWithContext returns a full representation of the issue for the given issue key.
+// GetIssue returns a full representation of the issue for the given issue key.
 // Jira will attempt to identify the issue by the issueIdOrKey path parameter.
 // This can be an issue id, or an issue key.
 // If the issue cannot be found via an exact match, Jira will also look for the issue in a case-insensitive way, or by looking to see if the issue was moved.
@@ -89,7 +78,7 @@ func (s *SprintService) GetIssuesForSprint(sprintID int) ([]Issue, *Response, er
 // Jira API docs: https://docs.atlassian.com/jira-software/REST/7.3.1/#agile/1.0/issue-getIssue
 //
 // TODO: create agile service for holding all agile apis' implementation
-func (s *SprintService) GetIssueWithContext(ctx context.Context, issueID string, options *GetQueryOptions) (*Issue, *Response, error) {
+func (s *SprintService) GetIssue(ctx context.Context, issueID string, options *GetQueryOptions) (*Issue, *Response, error) {
 	apiEndpoint := fmt.Sprintf("rest/agile/1.0/issue/%s", issueID)
 
 	req, err := s.client.NewRequest(ctx, "GET", apiEndpoint, nil)
@@ -115,9 +104,4 @@ func (s *SprintService) GetIssueWithContext(ctx context.Context, issueID string,
 	}
 
 	return issue, resp, nil
-}
-
-// GetIssue wraps GetIssueWithContext using the background context.
-func (s *SprintService) GetIssue(issueID string, options *GetQueryOptions) (*Issue, *Response, error) {
-	return s.GetIssueWithContext(context.Background(), issueID, options)
 }

--- a/onpremise/sprint_test.go
+++ b/onpremise/sprint_test.go
@@ -1,6 +1,7 @@
 package onpremise
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -32,7 +33,7 @@ func TestSprintService_MoveIssuesToSprint(t *testing.T) {
 			t.Errorf("Expected %s to be in payload, got %s instead", issuesToMove[0], payload.Issues[0])
 		}
 	})
-	_, err := testClient.Sprint.MoveIssuesToSprint(123, issuesToMove)
+	_, err := testClient.Sprint.MoveIssuesToSprint(context.Background(), 123, issuesToMove)
 
 	if err != nil {
 		t.Errorf("Got error: %v", err)
@@ -54,7 +55,7 @@ func TestSprintService_GetIssuesForSprint(t *testing.T) {
 		fmt.Fprint(w, string(raw))
 	})
 
-	issues, _, err := testClient.Sprint.GetIssuesForSprint(123)
+	issues, _, err := testClient.Sprint.GetIssuesForSprint(context.Background(), 123)
 	if err != nil {
 		t.Errorf("Error given: %v", err)
 	}
@@ -79,7 +80,7 @@ func TestSprintService_GetIssue(t *testing.T) {
 		fmt.Fprint(w, `{"expand":"renderedFields,names,schema,transitions,operations,editmeta,changelog,versionedRepresentations","id":"10002","self":"http://www.example.com/jira/rest/api/2/issue/10002","key":"EX-1","fields":{"labels":["test"],"watcher":{"self":"http://www.example.com/jira/rest/api/2/issue/EX-1/watchers","isWatching":false,"watchCount":1,"watchers":[{"self":"http://www.example.com/jira/rest/api/2/user?username=fred","name":"fred","displayName":"Fred F. User","active":false}]},"sprint": {"id": 37,"self": "http://www.example.com/jira/rest/agile/1.0/sprint/13", "state": "future", "name": "sprint 2"}, "epic": {"id": 19415,"key": "EPIC-77","self": "https://example.atlassian.net/rest/agile/1.0/epic/19415","name": "Epic Name","summary": "Do it","color": {"key": "color_11"},"done": false},"attachment":[{"self":"http://www.example.com/jira/rest/api/2.0/attachments/10000","filename":"picture.jpg","author":{"self":"http://www.example.com/jira/rest/api/2/user?username=fred","name":"fred","avatarUrls":{"48x48":"http://www.example.com/jira/secure/useravatar?size=large&ownerId=fred","24x24":"http://www.example.com/jira/secure/useravatar?size=small&ownerId=fred","16x16":"http://www.example.com/jira/secure/useravatar?size=xsmall&ownerId=fred","32x32":"http://www.example.com/jira/secure/useravatar?size=medium&ownerId=fred"},"displayName":"Fred F. User","active":false},"created":"2016-03-16T04:22:37.461+0000","size":23123,"mimeType":"image/jpeg","content":"http://www.example.com/jira/attachments/10000","thumbnail":"http://www.example.com/jira/secure/thumbnail/10000"}],"sub-tasks":[{"id":"10000","type":{"id":"10000","name":"","inward":"Parent","outward":"Sub-task"},"outwardIssue":{"id":"10003","key":"EX-2","self":"http://www.example.com/jira/rest/api/2/issue/EX-2","fields":{"status":{"iconUrl":"http://www.example.com/jira//images/icons/statuses/open.png","name":"Open"}}}}],"description":"example bug report","project":{"self":"http://www.example.com/jira/rest/api/2/project/EX","id":"10000","key":"EX","name":"Example","avatarUrls":{"48x48":"http://www.example.com/jira/secure/projectavatar?size=large&pid=10000","24x24":"http://www.example.com/jira/secure/projectavatar?size=small&pid=10000","16x16":"http://www.example.com/jira/secure/projectavatar?size=xsmall&pid=10000","32x32":"http://www.example.com/jira/secure/projectavatar?size=medium&pid=10000"},"projectCategory":{"self":"http://www.example.com/jira/rest/api/2/projectCategory/10000","id":"10000","name":"FIRST","description":"First Project Category"}},"comment":{"comments":[{"self":"http://www.example.com/jira/rest/api/2/issue/10010/comment/10000","id":"10000","author":{"self":"http://www.example.com/jira/rest/api/2/user?username=fred","name":"fred","displayName":"Fred F. User","active":false},"body":"Lorem ipsum dolor sit amet, consectetur adipiscing elit. Pellentesque eget venenatis elit. Duis eu justo eget augue iaculis fermentum. Sed semper quam laoreet nisi egestas at posuere augue semper.","updateAuthor":{"self":"http://www.example.com/jira/rest/api/2/user?username=fred","name":"fred","displayName":"Fred F. User","active":false},"created":"2016-03-16T04:22:37.356+0000","updated":"2016-03-16T04:22:37.356+0000","visibility":{"type":"role","value":"Administrators"}}]},"issuelinks":[{"id":"10001","type":{"id":"10000","name":"Dependent","inward":"depends on","outward":"is depended by"},"outwardIssue":{"id":"10004L","key":"PRJ-2","self":"http://www.example.com/jira/rest/api/2/issue/PRJ-2","fields":{"status":{"iconUrl":"http://www.example.com/jira//images/icons/statuses/open.png","name":"Open"}}}},{"id":"10002","type":{"id":"10000","name":"Dependent","inward":"depends on","outward":"is depended by"},"inwardIssue":{"id":"10004","key":"PRJ-3","self":"http://www.example.com/jira/rest/api/2/issue/PRJ-3","fields":{"status":{"iconUrl":"http://www.example.com/jira//images/icons/statuses/open.png","name":"Open"}}}}],"worklog":{"worklogs":[{"self":"http://www.example.com/jira/rest/api/2/issue/10010/worklog/10000","author":{"self":"http://www.example.com/jira/rest/api/2/user?username=fred","name":"fred","displayName":"Fred F. User","active":false},"updateAuthor":{"self":"http://www.example.com/jira/rest/api/2/user?username=fred","name":"fred","displayName":"Fred F. User","active":false},"comment":"I did some work here.","updated":"2016-03-16T04:22:37.471+0000","visibility":{"type":"group","value":"jira-developers"},"started":"2016-03-16T04:22:37.471+0000","timeSpent":"3h 20m","timeSpentSeconds":12000,"id":"100028","issueId":"10002"}]},"updated":"2016-04-06T02:36:53.594-0700","duedate":"2018-01-19","timetracking":{"originalEstimate":"10m","remainingEstimate":"3m","timeSpent":"6m","originalEstimateSeconds":600,"remainingEstimateSeconds":200,"timeSpentSeconds":400}},"names":{"watcher":"watcher","attachment":"attachment","sub-tasks":"sub-tasks","description":"description","project":"project","comment":"comment","issuelinks":"issuelinks","worklog":"worklog","updated":"updated","timetracking":"timetracking"},"schema":{}}`)
 	})
 
-	issue, _, err := testClient.Sprint.GetIssue("10002", nil)
+	issue, _, err := testClient.Sprint.GetIssue(context.Background(), "10002", nil)
 	if err != nil {
 		t.Errorf("Error given: %s", err)
 	}

--- a/onpremise/status.go
+++ b/onpremise/status.go
@@ -19,10 +19,10 @@ type Status struct {
 	StatusCategory StatusCategory `json:"statusCategory" structs:"statusCategory"`
 }
 
-// GetAllStatusesWithContext returns a list of all statuses associated with workflows.
+// GetAllStatuses returns a list of all statuses associated with workflows.
 //
 // Jira API docs: https://developer.atlassian.com/cloud/jira/platform/rest/v2/#api-rest-api-2-status-get
-func (s *StatusService) GetAllStatusesWithContext(ctx context.Context) ([]Status, *Response, error) {
+func (s *StatusService) GetAllStatuses(ctx context.Context) ([]Status, *Response, error) {
 	apiEndpoint := "rest/api/2/status"
 	req, err := s.client.NewRequest(ctx, "GET", apiEndpoint, nil)
 
@@ -37,9 +37,4 @@ func (s *StatusService) GetAllStatusesWithContext(ctx context.Context) ([]Status
 	}
 
 	return statusList, resp, nil
-}
-
-// GetAllStatuses wraps GetAllStatusesWithContext using the background context.
-func (s *StatusService) GetAllStatuses() ([]Status, *Response, error) {
-	return s.GetAllStatusesWithContext(context.Background())
 }

--- a/onpremise/status_test.go
+++ b/onpremise/status_test.go
@@ -1,6 +1,7 @@
 package onpremise
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 	"os"
@@ -23,7 +24,7 @@ func TestStatusService_GetAllStatuses(t *testing.T) {
 		fmt.Fprint(w, string(raw))
 	})
 
-	statusList, _, err := testClient.Status.GetAllStatuses()
+	statusList, _, err := testClient.Status.GetAllStatuses(context.Background())
 
 	if statusList == nil {
 		t.Error("Expected statusList. statusList is nill")

--- a/onpremise/statuscategory.go
+++ b/onpremise/statuscategory.go
@@ -25,10 +25,10 @@ const (
 	StatusCategoryUndefined  = "undefined"
 )
 
-// GetListWithContext gets all status categories from Jira
+// GetList gets all status categories from Jira
 //
 // Jira API docs: https://developer.atlassian.com/cloud/jira/platform/rest/#api-api-2-statuscategory-get
-func (s *StatusCategoryService) GetListWithContext(ctx context.Context) ([]StatusCategory, *Response, error) {
+func (s *StatusCategoryService) GetList(ctx context.Context) ([]StatusCategory, *Response, error) {
 	apiEndpoint := "rest/api/2/statuscategory"
 	req, err := s.client.NewRequest(ctx, "GET", apiEndpoint, nil)
 	if err != nil {
@@ -41,9 +41,4 @@ func (s *StatusCategoryService) GetListWithContext(ctx context.Context) ([]Statu
 		return nil, resp, NewJiraError(resp, err)
 	}
 	return statusCategoryList, resp, nil
-}
-
-// GetList wraps GetListWithContext using the background context.
-func (s *StatusCategoryService) GetList() ([]StatusCategory, *Response, error) {
-	return s.GetListWithContext(context.Background())
 }

--- a/onpremise/statuscategory_test.go
+++ b/onpremise/statuscategory_test.go
@@ -1,6 +1,7 @@
 package onpremise
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 	"os"
@@ -22,7 +23,7 @@ func TestStatusCategoryService_GetList(t *testing.T) {
 		fmt.Fprint(w, string(raw))
 	})
 
-	statusCategory, _, err := testClient.StatusCategory.GetList()
+	statusCategory, _, err := testClient.StatusCategory.GetList(context.Background())
 	if statusCategory == nil {
 		t.Error("Expected statusCategory list. StatusCategory list is nil")
 	}

--- a/onpremise/user.go
+++ b/onpremise/user.go
@@ -44,10 +44,10 @@ type userSearch []userSearchParam
 
 type userSearchF func(userSearch) userSearch
 
-// GetWithContext gets user info from Jira using its Account Id
+// Get gets user info from Jira using its Account Id
 //
 // Jira API docs: https://developer.atlassian.com/cloud/jira/platform/rest/v2/#api-rest-api-2-user-get
-func (s *UserService) GetWithContext(ctx context.Context, accountId string) (*User, *Response, error) {
+func (s *UserService) Get(ctx context.Context, accountId string) (*User, *Response, error) {
 	apiEndpoint := fmt.Sprintf("/rest/api/2/user?accountId=%s", accountId)
 	req, err := s.client.NewRequest(ctx, "GET", apiEndpoint, nil)
 	if err != nil {
@@ -62,16 +62,11 @@ func (s *UserService) GetWithContext(ctx context.Context, accountId string) (*Us
 	return user, resp, nil
 }
 
-// Get wraps GetWithContext using the background context.
-func (s *UserService) Get(accountId string) (*User, *Response, error) {
-	return s.GetWithContext(context.Background(), accountId)
-}
-
-// GetByAccountIDWithContext gets user info from Jira
+// GetByAccountID gets user info from Jira
 // Searching by another parameter that is not accountId is deprecated,
 // but this method is kept for backwards compatibility
 // Jira API docs: https://docs.atlassian.com/jira/REST/cloud/#api/2/user-getUser
-func (s *UserService) GetByAccountIDWithContext(ctx context.Context, accountID string) (*User, *Response, error) {
+func (s *UserService) GetByAccountID(ctx context.Context, accountID string) (*User, *Response, error) {
 	apiEndpoint := fmt.Sprintf("/rest/api/2/user?accountId=%s", accountID)
 	req, err := s.client.NewRequest(ctx, "GET", apiEndpoint, nil)
 	if err != nil {
@@ -86,15 +81,10 @@ func (s *UserService) GetByAccountIDWithContext(ctx context.Context, accountID s
 	return user, resp, nil
 }
 
-// GetByAccountID wraps GetByAccountIDWithContext using the background context.
-func (s *UserService) GetByAccountID(accountID string) (*User, *Response, error) {
-	return s.GetByAccountIDWithContext(context.Background(), accountID)
-}
-
-// CreateWithContext creates an user in Jira.
+// Create creates an user in Jira.
 //
 // Jira API docs: https://docs.atlassian.com/jira/REST/cloud/#api/2/user-createUser
-func (s *UserService) CreateWithContext(ctx context.Context, user *User) (*User, *Response, error) {
+func (s *UserService) Create(ctx context.Context, user *User) (*User, *Response, error) {
 	apiEndpoint := "/rest/api/2/user"
 	req, err := s.client.NewRequest(ctx, "POST", apiEndpoint, user)
 	if err != nil {
@@ -121,17 +111,12 @@ func (s *UserService) CreateWithContext(ctx context.Context, user *User) (*User,
 	return responseUser, resp, nil
 }
 
-// Create wraps CreateWithContext using the background context.
-func (s *UserService) Create(user *User) (*User, *Response, error) {
-	return s.CreateWithContext(context.Background(), user)
-}
-
-// DeleteWithContext deletes an user from Jira.
+// Delete deletes an user from Jira.
 // Returns http.StatusNoContent on success.
 //
 // Jira API docs: https://developer.atlassian.com/cloud/jira/platform/rest/v2/#api-rest-api-2-user-delete
 // Caller must close resp.Body
-func (s *UserService) DeleteWithContext(ctx context.Context, accountId string) (*Response, error) {
+func (s *UserService) Delete(ctx context.Context, accountId string) (*Response, error) {
 	apiEndpoint := fmt.Sprintf("/rest/api/2/user?accountId=%s", accountId)
 	req, err := s.client.NewRequest(ctx, "DELETE", apiEndpoint, nil)
 	if err != nil {
@@ -145,16 +130,10 @@ func (s *UserService) DeleteWithContext(ctx context.Context, accountId string) (
 	return resp, nil
 }
 
-// Delete wraps DeleteWithContext using the background context.
-// Caller must close resp.Body
-func (s *UserService) Delete(accountId string) (*Response, error) {
-	return s.DeleteWithContext(context.Background(), accountId)
-}
-
-// GetGroupsWithContext returns the groups which the user belongs to
+// GetGroups returns the groups which the user belongs to
 //
 // Jira API docs: https://developer.atlassian.com/cloud/jira/platform/rest/v2/#api-rest-api-2-user-groups-get
-func (s *UserService) GetGroupsWithContext(ctx context.Context, accountId string) (*[]UserGroup, *Response, error) {
+func (s *UserService) GetGroups(ctx context.Context, accountId string) (*[]UserGroup, *Response, error) {
 	apiEndpoint := fmt.Sprintf("/rest/api/2/user/groups?accountId=%s", accountId)
 	req, err := s.client.NewRequest(ctx, "GET", apiEndpoint, nil)
 	if err != nil {
@@ -169,15 +148,10 @@ func (s *UserService) GetGroupsWithContext(ctx context.Context, accountId string
 	return userGroups, resp, nil
 }
 
-// GetGroups wraps GetGroupsWithContext using the background context.
-func (s *UserService) GetGroups(accountId string) (*[]UserGroup, *Response, error) {
-	return s.GetGroupsWithContext(context.Background(), accountId)
-}
-
-// GetSelfWithContext information about the current logged-in user
+// GetSelf information about the current logged-in user
 //
 // Jira API docs: https://developer.atlassian.com/cloud/jira/platform/rest/v2/#api-rest-api-2-myself-get
-func (s *UserService) GetSelfWithContext(ctx context.Context) (*User, *Response, error) {
+func (s *UserService) GetSelf(ctx context.Context) (*User, *Response, error) {
 	const apiEndpoint = "rest/api/2/myself"
 	req, err := s.client.NewRequest(ctx, "GET", apiEndpoint, nil)
 	if err != nil {
@@ -189,11 +163,6 @@ func (s *UserService) GetSelfWithContext(ctx context.Context) (*User, *Response,
 		return nil, resp, NewJiraError(resp, err)
 	}
 	return &user, resp, nil
-}
-
-// GetSelf wraps GetSelfWithContext using the background context.
-func (s *UserService) GetSelf() (*User, *Response, error) {
-	return s.GetSelfWithContext(context.Background())
 }
 
 // WithMaxResults sets the max results to return
@@ -252,11 +221,11 @@ func WithProperty(property string) userSearchF {
 	}
 }
 
-// FindWithContext searches for user info from Jira:
+// Find searches for user info from Jira:
 // It can find users by email or display name using the query parameter
 //
 // Jira API docs: https://developer.atlassian.com/cloud/jira/platform/rest/v2/#api-rest-api-2-user-search-get
-func (s *UserService) FindWithContext(ctx context.Context, property string, tweaks ...userSearchF) ([]User, *Response, error) {
+func (s *UserService) Find(ctx context.Context, property string, tweaks ...userSearchF) ([]User, *Response, error) {
 	search := []userSearchParam{
 		{
 			name:  "query",
@@ -284,9 +253,4 @@ func (s *UserService) FindWithContext(ctx context.Context, property string, twea
 		return nil, resp, NewJiraError(resp, err)
 	}
 	return users, resp, nil
-}
-
-// Find wraps FindWithContext using the background context.
-func (s *UserService) Find(property string, tweaks ...userSearchF) ([]User, *Response, error) {
-	return s.FindWithContext(context.Background(), property, tweaks...)
 }

--- a/onpremise/user_test.go
+++ b/onpremise/user_test.go
@@ -1,6 +1,7 @@
 package onpremise
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 	"testing"
@@ -22,7 +23,7 @@ func TestUserService_Get_Success(t *testing.T) {
         }]},"applicationRoles":{"size":1,"items":[]},"expand":"groups,applicationRoles"}`)
 	})
 
-	if user, _, err := testClient.User.Get("000000000000000000000000"); err != nil {
+	if user, _, err := testClient.User.Get(context.Background(), "000000000000000000000000"); err != nil {
 		t.Errorf("Error given: %s", err)
 	} else if user == nil {
 		t.Error("Expected user. User is nil")
@@ -45,7 +46,7 @@ func TestUserService_GetByAccountID_Success(t *testing.T) {
         }]},"applicationRoles":{"size":1,"items":[]},"expand":"groups,applicationRoles"}`)
 	})
 
-	if user, _, err := testClient.User.GetByAccountID("000000000000000000000000"); err != nil {
+	if user, _, err := testClient.User.GetByAccountID(context.Background(), "000000000000000000000000"); err != nil {
 		t.Errorf("Error given: %s", err)
 	} else if user == nil {
 		t.Error("Expected user. User is nil")
@@ -72,7 +73,7 @@ func TestUserService_Create(t *testing.T) {
 		ApplicationKeys: []string{"jira-core"},
 	}
 
-	if user, _, err := testClient.User.Create(u); err != nil {
+	if user, _, err := testClient.User.Create(context.Background(), u); err != nil {
 		t.Errorf("Error given: %s", err)
 	} else if user == nil {
 		t.Error("Expected user. User is nil")
@@ -89,7 +90,7 @@ func TestUserService_Delete(t *testing.T) {
 		w.WriteHeader(http.StatusNoContent)
 	})
 
-	resp, err := testClient.User.Delete("000000000000000000000000")
+	resp, err := testClient.User.Delete(context.Background(), "000000000000000000000000")
 	if err != nil {
 		t.Errorf("Error given: %s", err)
 	}
@@ -110,7 +111,7 @@ func TestUserService_GetGroups(t *testing.T) {
 		fmt.Fprint(w, `[{"name":"jira-software-users","self":"http://www.example.com/jira/rest/api/2/user?accountId=000000000000000000000000"}]`)
 	})
 
-	if groups, _, err := testClient.User.GetGroups("000000000000000000000000"); err != nil {
+	if groups, _, err := testClient.User.GetGroups(context.Background(), "000000000000000000000000"); err != nil {
 		t.Errorf("Error given: %s", err)
 	} else if groups == nil {
 		t.Error("Expected user groups. []UserGroup is nil")
@@ -134,7 +135,7 @@ func TestUserService_GetSelf(t *testing.T) {
         }]},"applicationRoles":{"size":1,"items":[]},"expand":"groups,applicationRoles"}`)
 	})
 
-	if user, _, err := testClient.User.GetSelf(); err != nil {
+	if user, _, err := testClient.User.GetSelf(context.Background()); err != nil {
 		t.Errorf("Error given: %s", err)
 	} else if user == nil {
 		t.Error("Expected user groups. []UserGroup is nil")
@@ -161,7 +162,7 @@ func TestUserService_Find_Success(t *testing.T) {
         }]},"applicationRoles":{"size":1,"items":[]},"expand":"groups,applicationRoles"}]`)
 	})
 
-	if user, _, err := testClient.User.Find("fred@example.com"); err != nil {
+	if user, _, err := testClient.User.Find(context.Background(), "fred@example.com"); err != nil {
 		t.Errorf("Error given: %s", err)
 	} else if user == nil {
 		t.Error("Expected user. User is nil")
@@ -184,7 +185,7 @@ func TestUserService_Find_SuccessParams(t *testing.T) {
         }]},"applicationRoles":{"size":1,"items":[]},"expand":"groups,applicationRoles"}]`)
 	})
 
-	if user, _, err := testClient.User.Find("fred@example.com", WithStartAt(100), WithMaxResults(1000)); err != nil {
+	if user, _, err := testClient.User.Find(context.Background(), "fred@example.com", WithStartAt(100), WithMaxResults(1000)); err != nil {
 		t.Errorf("Error given: %s", err)
 	} else if user == nil {
 		t.Error("Expected user. User is nil")

--- a/onpremise/version.go
+++ b/onpremise/version.go
@@ -26,10 +26,10 @@ type Version struct {
 	StartDate       string `json:"startDate,omitempty" structs:"startDate,omitempty"`
 }
 
-// GetWithContext gets version info from Jira
+// Get gets version info from Jira
 //
 // Jira API docs: https://developer.atlassian.com/cloud/jira/platform/rest/#api-api-2-version-id-get
-func (s *VersionService) GetWithContext(ctx context.Context, versionID int) (*Version, *Response, error) {
+func (s *VersionService) Get(ctx context.Context, versionID int) (*Version, *Response, error) {
 	apiEndpoint := fmt.Sprintf("/rest/api/2/version/%v", versionID)
 	req, err := s.client.NewRequest(ctx, "GET", apiEndpoint, nil)
 	if err != nil {
@@ -44,15 +44,10 @@ func (s *VersionService) GetWithContext(ctx context.Context, versionID int) (*Ve
 	return version, resp, nil
 }
 
-// Get wraps GetWithContext using the background context.
-func (s *VersionService) Get(versionID int) (*Version, *Response, error) {
-	return s.GetWithContext(context.Background(), versionID)
-}
-
-// CreateWithContext creates a version in Jira.
+// Create creates a version in Jira.
 //
 // Jira API docs: https://developer.atlassian.com/cloud/jira/platform/rest/#api-api-2-version-post
-func (s *VersionService) CreateWithContext(ctx context.Context, version *Version) (*Version, *Response, error) {
+func (s *VersionService) Create(ctx context.Context, version *Version) (*Version, *Response, error) {
 	apiEndpoint := "/rest/api/2/version"
 	req, err := s.client.NewRequest(ctx, "POST", apiEndpoint, version)
 	if err != nil {
@@ -79,16 +74,11 @@ func (s *VersionService) CreateWithContext(ctx context.Context, version *Version
 	return responseVersion, resp, nil
 }
 
-// Create wraps CreateWithContext using the background context.
-func (s *VersionService) Create(version *Version) (*Version, *Response, error) {
-	return s.CreateWithContext(context.Background(), version)
-}
-
-// UpdateWithContext updates a version from a JSON representation.
+// Update updates a version from a JSON representation.
 //
 // Jira API docs: https://developer.atlassian.com/cloud/jira/platform/rest/#api-api-2-version-id-put
 // Caller must close resp.Body
-func (s *VersionService) UpdateWithContext(ctx context.Context, version *Version) (*Version, *Response, error) {
+func (s *VersionService) Update(ctx context.Context, version *Version) (*Version, *Response, error) {
 	apiEndpoint := fmt.Sprintf("rest/api/2/version/%v", version.ID)
 	req, err := s.client.NewRequest(ctx, "PUT", apiEndpoint, version)
 	if err != nil {
@@ -104,10 +94,4 @@ func (s *VersionService) UpdateWithContext(ctx context.Context, version *Version
 	// Returning the same pointer here is pointless, so we return a copy instead.
 	ret := *version
 	return &ret, resp, nil
-}
-
-// Update wraps UpdateWithContext using the background context.
-// Caller must close resp.Body
-func (s *VersionService) Update(version *Version) (*Version, *Response, error) {
-	return s.UpdateWithContext(context.Background(), version)
 }

--- a/onpremise/version_test.go
+++ b/onpremise/version_test.go
@@ -1,6 +1,7 @@
 package onpremise
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 	"testing"
@@ -28,7 +29,7 @@ func TestVersionService_Get_Success(t *testing.T) {
 		}`)
 	})
 
-	version, _, err := testClient.Version.Get(10002)
+	version, _, err := testClient.Version.Get(context.Background(), 10002)
 	if version == nil {
 		t.Error("Expected version. Issue is nil")
 	}
@@ -68,7 +69,7 @@ func TestVersionService_Create(t *testing.T) {
 		StartDate:       "2018-07-01",
 	}
 
-	version, _, err := testClient.Version.Create(v)
+	version, _, err := testClient.Version.Create(context.Background(), v)
 	if version == nil {
 		t.Error("Expected version. Version is nil")
 	}
@@ -102,7 +103,7 @@ func TestServiceService_Update(t *testing.T) {
 		Description: "An excellent updated version",
 	}
 
-	version, _, err := testClient.Version.Update(v)
+	version, _, err := testClient.Version.Update(context.Background(), v)
 	if version == nil {
 		t.Error("Expected version. Version is nil")
 	}


### PR DESCRIPTION
Remove "WithContext" API methods for the following services:

* Role Service
* ServiceDesk Service
* Sprint Service
* Status Service
* Status Category Service
* User Service
* Version Service

Related: #337