### PR TITLE
Make context first class citizen: Remove "WithContext" API methods (Part 2)

### DIFF
--- a/cloud/component.go
+++ b/cloud/component.go
@@ -18,8 +18,8 @@ type CreateComponentOptions struct {
 	ProjectID    int    `json:"projectId,omitempty" structs:"projectId,omitempty"`
 }
 
-// CreateWithContext creates a new Jira component based on the given options.
-func (s *ComponentService) CreateWithContext(ctx context.Context, options *CreateComponentOptions) (*ProjectComponent, *Response, error) {
+// Create creates a new Jira component based on the given options.
+func (s *ComponentService) Create(ctx context.Context, options *CreateComponentOptions) (*ProjectComponent, *Response, error) {
 	apiEndpoint := "rest/api/2/component"
 	req, err := s.client.NewRequest(ctx, "POST", apiEndpoint, options)
 	if err != nil {
@@ -34,9 +34,4 @@ func (s *ComponentService) CreateWithContext(ctx context.Context, options *Creat
 	}
 
 	return component, resp, nil
-}
-
-// Create wraps CreateWithContext using the background context.
-func (s *ComponentService) Create(options *CreateComponentOptions) (*ProjectComponent, *Response, error) {
-	return s.CreateWithContext(context.Background(), options)
 }

--- a/cloud/component_test.go
+++ b/cloud/component_test.go
@@ -1,6 +1,7 @@
 package cloud
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 	"testing"
@@ -17,7 +18,7 @@ func TestComponentService_Create_Success(t *testing.T) {
 		fmt.Fprint(w, `{ "self": "http://www.example.com/jira/rest/api/2/component/10000", "id": "10000", "name": "Component 1", "description": "This is a Jira component", "lead": { "self": "http://www.example.com/jira/rest/api/2/user?username=fred", "name": "fred", "avatarUrls": { "48x48": "http://www.example.com/jira/secure/useravatar?size=large&ownerId=fred", "24x24": "http://www.example.com/jira/secure/useravatar?size=small&ownerId=fred", "16x16": "http://www.example.com/jira/secure/useravatar?size=xsmall&ownerId=fred", "32x32": "http://www.example.com/jira/secure/useravatar?size=medium&ownerId=fred" }, "displayName": "Fred F. User", "active": false }, "assigneeType": "PROJECT_LEAD", "assignee": { "self": "http://www.example.com/jira/rest/api/2/user?username=fred", "name": "fred", "avatarUrls": { "48x48": "http://www.example.com/jira/secure/useravatar?size=large&ownerId=fred", "24x24": "http://www.example.com/jira/secure/useravatar?size=small&ownerId=fred", "16x16": "http://www.example.com/jira/secure/useravatar?size=xsmall&ownerId=fred", "32x32": "http://www.example.com/jira/secure/useravatar?size=medium&ownerId=fred" }, "displayName": "Fred F. User", "active": false }, "realAssigneeType": "PROJECT_LEAD", "realAssignee": { "self": "http://www.example.com/jira/rest/api/2/user?username=fred", "name": "fred", "avatarUrls": { "48x48": "http://www.example.com/jira/secure/useravatar?size=large&ownerId=fred", "24x24": "http://www.example.com/jira/secure/useravatar?size=small&ownerId=fred", "16x16": "http://www.example.com/jira/secure/useravatar?size=xsmall&ownerId=fred", "32x32": "http://www.example.com/jira/secure/useravatar?size=medium&ownerId=fred" }, "displayName": "Fred F. User", "active": false }, "isAssigneeTypeValid": false, "project": "HSP", "projectId": 10000 }`)
 	})
 
-	component, _, err := testClient.Component.Create(&CreateComponentOptions{
+	component, _, err := testClient.Component.Create(context.Background(), &CreateComponentOptions{
 		Name: "foo-bar",
 	})
 	if component == nil {

--- a/cloud/customer.go
+++ b/cloud/customer.go
@@ -36,10 +36,10 @@ type CustomerList struct {
 	Expands []string   `json:"_expands,omitempty" structs:"_expands,omitempty"`
 }
 
-// CreateWithContext creates a ServiceDesk customer.
+// Create creates a ServiceDesk customer.
 //
 // https://developer.atlassian.com/cloud/jira/service-desk/rest/api-group-customer/#api-rest-servicedeskapi-customer-post
-func (c *CustomerService) CreateWithContext(ctx context.Context, email, displayName string) (*Customer, *Response, error) {
+func (c *CustomerService) Create(ctx context.Context, email, displayName string) (*Customer, *Response, error) {
 	const apiEndpoint = "rest/servicedeskapi/customer"
 
 	payload := struct {
@@ -62,9 +62,4 @@ func (c *CustomerService) CreateWithContext(ctx context.Context, email, displayN
 	}
 
 	return responseCustomer, resp, nil
-}
-
-// Create wraps CreateWithContext using the background context.
-func (c *CustomerService) Create(email, displayName string) (*Customer, *Response, error) {
-	return c.CreateWithContext(context.Background(), email, displayName)
 }

--- a/cloud/customer_test.go
+++ b/cloud/customer_test.go
@@ -1,6 +1,7 @@
 package cloud
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 	"testing"
@@ -41,7 +42,7 @@ func TestCustomerService_Create(t *testing.T) {
 		}`, wantEmailAddress, wantDisplayName)
 	})
 
-	gotCustomer, _, err := testClient.Customer.Create(wantEmailAddress, wantDisplayName)
+	gotCustomer, _, err := testClient.Customer.Create(context.Background(), wantEmailAddress, wantDisplayName)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/cloud/field.go
+++ b/cloud/field.go
@@ -29,10 +29,10 @@ type FieldSchema struct {
 	CustomID int64  `json:"customId,omitempty" structs:"customId,omitempty"`
 }
 
-// GetListWithContext gets all fields from Jira
+// GetList gets all fields from Jira
 //
 // Jira API docs: https://developer.atlassian.com/cloud/jira/platform/rest/#api-api-2-field-get
-func (s *FieldService) GetListWithContext(ctx context.Context) ([]Field, *Response, error) {
+func (s *FieldService) GetList(ctx context.Context) ([]Field, *Response, error) {
 	apiEndpoint := "rest/api/2/field"
 	req, err := s.client.NewRequest(ctx, "GET", apiEndpoint, nil)
 	if err != nil {
@@ -45,9 +45,4 @@ func (s *FieldService) GetListWithContext(ctx context.Context) ([]Field, *Respon
 		return nil, resp, NewJiraError(resp, err)
 	}
 	return fieldList, resp, nil
-}
-
-// GetList wraps GetListWithContext using the background context.
-func (s *FieldService) GetList() ([]Field, *Response, error) {
-	return s.GetListWithContext(context.Background())
 }

--- a/cloud/field_test.go
+++ b/cloud/field_test.go
@@ -1,6 +1,7 @@
 package cloud
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 	"os"
@@ -22,7 +23,7 @@ func TestFieldService_GetList(t *testing.T) {
 		fmt.Fprint(w, string(raw))
 	})
 
-	fields, _, err := testClient.Field.GetList()
+	fields, _, err := testClient.Field.GetList(context.Background())
 	if fields == nil {
 		t.Error("Expected field list. Field list is nil")
 	}

--- a/cloud/filter.go
+++ b/cloud/filter.go
@@ -118,8 +118,8 @@ type FilterSearchOptions struct {
 	Expand string `url:"expand,omitempty"`
 }
 
-// GetListWithContext retrieves all filters from Jira
-func (fs *FilterService) GetListWithContext(ctx context.Context) ([]*Filter, *Response, error) {
+// GetList retrieves all filters from Jira
+func (fs *FilterService) GetList(ctx context.Context) ([]*Filter, *Response, error) {
 
 	options := &GetQueryOptions{}
 	apiEndpoint := "rest/api/2/filter"
@@ -143,13 +143,8 @@ func (fs *FilterService) GetListWithContext(ctx context.Context) ([]*Filter, *Re
 	return filters, resp, err
 }
 
-// GetList wraps GetListWithContext using the background context.
-func (fs *FilterService) GetList() ([]*Filter, *Response, error) {
-	return fs.GetListWithContext(context.Background())
-}
-
-// GetFavouriteListWithContext retrieves the user's favourited filters from Jira
-func (fs *FilterService) GetFavouriteListWithContext(ctx context.Context) ([]*Filter, *Response, error) {
+// GetFavouriteList retrieves the user's favourited filters from Jira
+func (fs *FilterService) GetFavouriteList(ctx context.Context) ([]*Filter, *Response, error) {
 	apiEndpoint := "rest/api/2/filter/favourite"
 	req, err := fs.client.NewRequest(ctx, "GET", apiEndpoint, nil)
 	if err != nil {
@@ -164,13 +159,8 @@ func (fs *FilterService) GetFavouriteListWithContext(ctx context.Context) ([]*Fi
 	return filters, resp, err
 }
 
-// GetFavouriteList wraps GetFavouriteListWithContext using the background context.
-func (fs *FilterService) GetFavouriteList() ([]*Filter, *Response, error) {
-	return fs.GetFavouriteListWithContext(context.Background())
-}
-
-// GetWithContext retrieves a single Filter from Jira
-func (fs *FilterService) GetWithContext(ctx context.Context, filterID int) (*Filter, *Response, error) {
+// Get retrieves a single Filter from Jira
+func (fs *FilterService) Get(ctx context.Context, filterID int) (*Filter, *Response, error) {
 	apiEndpoint := fmt.Sprintf("rest/api/2/filter/%d", filterID)
 	req, err := fs.client.NewRequest(ctx, "GET", apiEndpoint, nil)
 	if err != nil {
@@ -186,15 +176,10 @@ func (fs *FilterService) GetWithContext(ctx context.Context, filterID int) (*Fil
 	return filter, resp, err
 }
 
-// Get wraps GetWithContext using the background context.
-func (fs *FilterService) Get(filterID int) (*Filter, *Response, error) {
-	return fs.GetWithContext(context.Background(), filterID)
-}
-
-// GetMyFiltersWithContext retrieves the my Filters.
+// GetMyFilters retrieves the my Filters.
 //
 // https://developer.atlassian.com/cloud/jira/platform/rest/v3/#api-rest-api-3-filter-my-get
-func (fs *FilterService) GetMyFiltersWithContext(ctx context.Context, opts *GetMyFiltersQueryOptions) ([]*Filter, *Response, error) {
+func (fs *FilterService) GetMyFilters(ctx context.Context, opts *GetMyFiltersQueryOptions) ([]*Filter, *Response, error) {
 	apiEndpoint := "rest/api/3/filter/my"
 	url, err := addOptions(apiEndpoint, opts)
 	if err != nil {
@@ -214,15 +199,10 @@ func (fs *FilterService) GetMyFiltersWithContext(ctx context.Context, opts *GetM
 	return filters, resp, nil
 }
 
-// GetMyFilters wraps GetMyFiltersWithContext using the background context.
-func (fs *FilterService) GetMyFilters(opts *GetMyFiltersQueryOptions) ([]*Filter, *Response, error) {
-	return fs.GetMyFiltersWithContext(context.Background(), opts)
-}
-
-// SearchWithContext will search for filter according to the search options
+// Search will search for filter according to the search options
 //
 // Jira API docs: https://developer.atlassian.com/cloud/jira/platform/rest/v3/#api-rest-api-3-filter-search-get
-func (fs *FilterService) SearchWithContext(ctx context.Context, opt *FilterSearchOptions) (*FiltersList, *Response, error) {
+func (fs *FilterService) Search(ctx context.Context, opt *FilterSearchOptions) (*FiltersList, *Response, error) {
 	apiEndpoint := "rest/api/3/filter/search"
 	url, err := addOptions(apiEndpoint, opt)
 	if err != nil {
@@ -241,9 +221,4 @@ func (fs *FilterService) SearchWithContext(ctx context.Context, opt *FilterSearc
 	}
 
 	return filters, resp, err
-}
-
-// Search wraps SearchWithContext using the background context.
-func (fs *FilterService) Search(opt *FilterSearchOptions) (*FiltersList, *Response, error) {
-	return fs.SearchWithContext(context.Background(), opt)
 }

--- a/cloud/filter_test.go
+++ b/cloud/filter_test.go
@@ -1,6 +1,7 @@
 package cloud
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 	"os"
@@ -21,7 +22,7 @@ func TestFilterService_GetList(t *testing.T) {
 		fmt.Fprint(writer, string(raw))
 	})
 
-	filters, _, err := testClient.Filter.GetList()
+	filters, _, err := testClient.Filter.GetList(context.Background())
 	if filters == nil {
 		t.Error("Expected Filters list. Filters list is nil")
 	}
@@ -44,7 +45,7 @@ func TestFilterService_Get(t *testing.T) {
 		fmt.Fprint(writer, string(raw))
 	})
 
-	filter, _, err := testClient.Filter.Get(10000)
+	filter, _, err := testClient.Filter.Get(context.Background(), 10000)
 	if filter == nil {
 		t.Errorf("Expected Filter, got nil")
 	}
@@ -68,7 +69,7 @@ func TestFilterService_GetFavouriteList(t *testing.T) {
 		fmt.Fprint(writer, string(raw))
 	})
 
-	filters, _, err := testClient.Filter.GetFavouriteList()
+	filters, _, err := testClient.Filter.GetFavouriteList(context.Background())
 	if filters == nil {
 		t.Error("Expected Filters list. Filters list is nil")
 	}
@@ -92,7 +93,7 @@ func TestFilterService_GetMyFilters(t *testing.T) {
 	})
 
 	opts := GetMyFiltersQueryOptions{}
-	filters, _, err := testClient.Filter.GetMyFilters(&opts)
+	filters, _, err := testClient.Filter.GetMyFilters(context.Background(), &opts)
 	if err != nil {
 		t.Errorf("Error given: %s", err)
 	}
@@ -116,7 +117,7 @@ func TestFilterService_Search(t *testing.T) {
 	})
 
 	opt := FilterSearchOptions{}
-	filters, _, err := testClient.Filter.Search(&opt)
+	filters, _, err := testClient.Filter.Search(context.Background(), &opt)
 	if err != nil {
 		t.Errorf("Error given: %s", err)
 	}

--- a/cloud/group.go
+++ b/cloud/group.go
@@ -57,14 +57,14 @@ type GroupSearchOptions struct {
 	IncludeInactiveUsers bool
 }
 
-// GetWithContext returns a paginated list of users who are members of the specified group and its subgroups.
+// Get returns a paginated list of users who are members of the specified group and its subgroups.
 // Users in the page are ordered by user names.
 // User of this resource is required to have sysadmin or admin permissions.
 //
 // Jira API docs: https://docs.atlassian.com/jira/REST/server/#api/2/group-getUsersFromGroup
 //
 // WARNING: This API only returns the first page of group members
-func (s *GroupService) GetWithContext(ctx context.Context, name string) ([]GroupMember, *Response, error) {
+func (s *GroupService) Get(ctx context.Context, name string) ([]GroupMember, *Response, error) {
 	apiEndpoint := fmt.Sprintf("/rest/api/2/group/member?groupname=%s", url.QueryEscape(name))
 	req, err := s.client.NewRequest(ctx, "GET", apiEndpoint, nil)
 	if err != nil {
@@ -80,17 +80,12 @@ func (s *GroupService) GetWithContext(ctx context.Context, name string) ([]Group
 	return group.Members, resp, nil
 }
 
-// Get wraps GetWithContext using the background context.
-func (s *GroupService) Get(name string) ([]GroupMember, *Response, error) {
-	return s.GetWithContext(context.Background(), name)
-}
-
-// GetWithOptionsWithContext returns a paginated list of members of the specified group and its subgroups.
+// GetWithOptions returns a paginated list of members of the specified group and its subgroups.
 // Users in the page are ordered by user names.
 // User of this resource is required to have sysadmin or admin permissions.
 //
 // Jira API docs: https://docs.atlassian.com/jira/REST/server/#api/2/group-getUsersFromGroup
-func (s *GroupService) GetWithOptionsWithContext(ctx context.Context, name string, options *GroupSearchOptions) ([]GroupMember, *Response, error) {
+func (s *GroupService) GetWithOptions(ctx context.Context, name string, options *GroupSearchOptions) ([]GroupMember, *Response, error) {
 	var apiEndpoint string
 	if options == nil {
 		apiEndpoint = fmt.Sprintf("/rest/api/2/group/member?groupname=%s", url.QueryEscape(name))
@@ -116,15 +111,10 @@ func (s *GroupService) GetWithOptionsWithContext(ctx context.Context, name strin
 	return group.Members, resp, nil
 }
 
-// GetWithOptions wraps GetWithOptionsWithContext using the background context.
-func (s *GroupService) GetWithOptions(name string, options *GroupSearchOptions) ([]GroupMember, *Response, error) {
-	return s.GetWithOptionsWithContext(context.Background(), name, options)
-}
-
-// AddWithContext adds user to group
+// Add adds user to group
 //
 // Jira API docs: https://docs.atlassian.com/jira/REST/cloud/#api/2/group-addUserToGroup
-func (s *GroupService) AddWithContext(ctx context.Context, groupname string, username string) (*Group, *Response, error) {
+func (s *GroupService) Add(ctx context.Context, groupname string, username string) (*Group, *Response, error) {
 	apiEndpoint := fmt.Sprintf("/rest/api/2/group/user?groupname=%s", groupname)
 	var user struct {
 		Name string `json:"name"`
@@ -145,16 +135,11 @@ func (s *GroupService) AddWithContext(ctx context.Context, groupname string, use
 	return responseGroup, resp, nil
 }
 
-// Add wraps AddWithContext using the background context.
-func (s *GroupService) Add(groupname string, username string) (*Group, *Response, error) {
-	return s.AddWithContext(context.Background(), groupname, username)
-}
-
-// RemoveWithContext removes user from group
+// Remove removes user from group
 //
 // Jira API docs: https://docs.atlassian.com/jira/REST/cloud/#api/2/group-removeUserFromGroup
 // Caller must close resp.Body
-func (s *GroupService) RemoveWithContext(ctx context.Context, groupname string, username string) (*Response, error) {
+func (s *GroupService) Remove(ctx context.Context, groupname string, username string) (*Response, error) {
 	apiEndpoint := fmt.Sprintf("/rest/api/2/group/user?groupname=%s&username=%s", groupname, username)
 	req, err := s.client.NewRequest(ctx, "DELETE", apiEndpoint, nil)
 	if err != nil {
@@ -168,10 +153,4 @@ func (s *GroupService) RemoveWithContext(ctx context.Context, groupname string, 
 	}
 
 	return resp, nil
-}
-
-// Remove wraps RemoveWithContext using the background context.
-// Caller must close resp.Body
-func (s *GroupService) Remove(groupname string, username string) (*Response, error) {
-	return s.RemoveWithContext(context.Background(), groupname, username)
 }

--- a/cloud/group_test.go
+++ b/cloud/group_test.go
@@ -1,6 +1,7 @@
 package cloud
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 	"testing"
@@ -14,7 +15,7 @@ func TestGroupService_Get(t *testing.T) {
 		testRequestURL(t, r, "/rest/api/2/group/member?groupname=default")
 		fmt.Fprint(w, `{"self":"http://www.example.com/jira/rest/api/2/group/member?includeInactiveUsers=false&maxResults=50&groupname=default&startAt=0","maxResults":50,"startAt":0,"total":2,"isLast":true,"values":[{"self":"http://www.example.com/jira/rest/api/2/user?username=michael","name":"michael","key":"michael","emailAddress":"michael@example.com","displayName":"MichaelScofield","active":true,"timeZone":"Australia/Sydney"},{"self":"http://www.example.com/jira/rest/api/2/user?username=alex","name":"alex","key":"alex","emailAddress":"alex@example.com","displayName":"AlexanderMahone","active":true,"timeZone":"Australia/Sydney"}]}`)
 	})
-	if members, _, err := testClient.Group.Get("default"); err != nil {
+	if members, _, err := testClient.Group.Get(context.Background(), "default"); err != nil {
 		t.Errorf("Error given: %s", err)
 	} else if members == nil {
 		t.Error("Expected members. Group.Members is nil")
@@ -36,7 +37,7 @@ func TestGroupService_GetPage(t *testing.T) {
 			t.Errorf("startAt %s", startAt)
 		}
 	})
-	if page, resp, err := testClient.Group.GetWithOptions("default", &GroupSearchOptions{
+	if page, resp, err := testClient.Group.GetWithOptions(context.Background(), "default", &GroupSearchOptions{
 		StartAt:              0,
 		MaxResults:           2,
 		IncludeInactiveUsers: false,
@@ -54,7 +55,7 @@ func TestGroupService_GetPage(t *testing.T) {
 		if resp.Total != 4 {
 			t.Errorf("Expect Result Total to be 4, but is %d", resp.Total)
 		}
-		if page, resp, err := testClient.Group.GetWithOptions("default", &GroupSearchOptions{
+		if page, resp, err := testClient.Group.GetWithOptions(context.Background(), "default", &GroupSearchOptions{
 			StartAt:              2,
 			MaxResults:           2,
 			IncludeInactiveUsers: false,
@@ -87,7 +88,7 @@ func TestGroupService_Add(t *testing.T) {
 		fmt.Fprint(w, `{"name":"default","self":"http://www.example.com/jira/rest/api/2/group?groupname=default","users":{"size":1,"items":[],"max-results":50,"start-index":0,"end-index":0},"expand":"users"}`)
 	})
 
-	if group, _, err := testClient.Group.Add("default", "theodore"); err != nil {
+	if group, _, err := testClient.Group.Add(context.Background(), "default", "theodore"); err != nil {
 		t.Errorf("Error given: %s", err)
 	} else if group == nil {
 		t.Error("Expected group. Group is nil")
@@ -105,7 +106,7 @@ func TestGroupService_Remove(t *testing.T) {
 		fmt.Fprint(w, `{"name":"default","self":"http://www.example.com/jira/rest/api/2/group?groupname=default","users":{"size":1,"items":[],"max-results":50,"start-index":0,"end-index":0},"expand":"users"}`)
 	})
 
-	if _, err := testClient.Group.Remove("default", "theodore"); err != nil {
+	if _, err := testClient.Group.Remove(context.Background(), "default", "theodore"); err != nil {
 		t.Errorf("Error given: %s", err)
 	}
 }

--- a/cloud/metaissue.go
+++ b/cloud/metaissue.go
@@ -48,18 +48,13 @@ type MetaIssueType struct {
 	Fields      tcontainer.MarshalMap `json:"fields,omitempty"`
 }
 
-// GetCreateMetaWithContext makes the api call to get the meta information required to create a ticket
-func (s *IssueService) GetCreateMetaWithContext(ctx context.Context, projectkeys string) (*CreateMetaInfo, *Response, error) {
-	return s.GetCreateMetaWithOptionsWithContext(ctx, &GetQueryOptions{ProjectKeys: projectkeys, Expand: "projects.issuetypes.fields"})
+// GetCreateMeta makes the api call to get the meta information required to create a ticket
+func (s *IssueService) GetCreateMeta(ctx context.Context, projectkeys string) (*CreateMetaInfo, *Response, error) {
+	return s.GetCreateMetaWithOptions(ctx, &GetQueryOptions{ProjectKeys: projectkeys, Expand: "projects.issuetypes.fields"})
 }
 
-// GetCreateMeta wraps GetCreateMetaWithContext using the background context.
-func (s *IssueService) GetCreateMeta(projectkeys string) (*CreateMetaInfo, *Response, error) {
-	return s.GetCreateMetaWithContext(context.Background(), projectkeys)
-}
-
-// GetCreateMetaWithOptionsWithContext makes the api call to get the meta information without requiring to have a projectKey
-func (s *IssueService) GetCreateMetaWithOptionsWithContext(ctx context.Context, options *GetQueryOptions) (*CreateMetaInfo, *Response, error) {
+// GetCreateMetaWithOptions makes the api call to get the meta information without requiring to have a projectKey
+func (s *IssueService) GetCreateMetaWithOptions(ctx context.Context, options *GetQueryOptions) (*CreateMetaInfo, *Response, error) {
 	apiEndpoint := "rest/api/2/issue/createmeta"
 
 	req, err := s.client.NewRequest(ctx, "GET", apiEndpoint, nil)
@@ -84,13 +79,8 @@ func (s *IssueService) GetCreateMetaWithOptionsWithContext(ctx context.Context, 
 	return meta, resp, nil
 }
 
-// GetCreateMetaWithOptions wraps GetCreateMetaWithOptionsWithContext using the background context.
-func (s *IssueService) GetCreateMetaWithOptions(options *GetQueryOptions) (*CreateMetaInfo, *Response, error) {
-	return s.GetCreateMetaWithOptionsWithContext(context.Background(), options)
-}
-
-// GetEditMetaWithContext makes the api call to get the edit meta information for an issue
-func (s *IssueService) GetEditMetaWithContext(ctx context.Context, issue *Issue) (*EditMetaInfo, *Response, error) {
+// GetEditMeta makes the api call to get the edit meta information for an issue
+func (s *IssueService) GetEditMeta(ctx context.Context, issue *Issue) (*EditMetaInfo, *Response, error) {
 	apiEndpoint := fmt.Sprintf("/rest/api/2/issue/%s/editmeta", issue.Key)
 
 	req, err := s.client.NewRequest(ctx, "GET", apiEndpoint, nil)
@@ -106,11 +96,6 @@ func (s *IssueService) GetEditMetaWithContext(ctx context.Context, issue *Issue)
 	}
 
 	return meta, resp, nil
-}
-
-// GetEditMeta wraps GetEditMetaWithContext using the background context.
-func (s *IssueService) GetEditMeta(issue *Issue) (*EditMetaInfo, *Response, error) {
-	return s.GetEditMetaWithContext(context.Background(), issue)
 }
 
 // GetProjectWithName returns a project with "name" from the meta information received. If not found, this returns nil.

--- a/cloud/metaissue_test.go
+++ b/cloud/metaissue_test.go
@@ -1,6 +1,7 @@
 package cloud
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 	"net/url"
@@ -348,7 +349,7 @@ func TestIssueService_GetCreateMeta_Success(t *testing.T) {
     }`)
 	})
 
-	issue, _, err := testClient.Issue.GetCreateMeta("SPN")
+	issue, _, err := testClient.Issue.GetCreateMeta(context.Background(), "SPN")
 	if err != nil {
 		t.Errorf("Expected nil error but got %s", err)
 	}
@@ -420,7 +421,7 @@ func TestIssueService_GetEditMeta_Success(t *testing.T) {
 	}`)
 	})
 
-	editMeta, _, err := testClient.Issue.GetEditMeta(&Issue{Key: "PROJ-9001"})
+	editMeta, _, err := testClient.Issue.GetEditMeta(context.Background(), &Issue{Key: "PROJ-9001"})
 	if err != nil {
 		t.Errorf("Expected nil error but got %s", err)
 	}
@@ -446,7 +447,7 @@ func TestIssueService_GetEditMeta_Success(t *testing.T) {
 }
 
 func TestIssueService_GetEditMeta_Fail(t *testing.T) {
-	_, _, err := testClient.Issue.GetEditMeta(&Issue{Key: "PROJ-9001"})
+	_, _, err := testClient.Issue.GetEditMeta(context.Background(), &Issue{Key: "PROJ-9001"})
 	if err == nil {
 		t.Error("Expected to receive an error, received nil instead")
 	}
@@ -797,7 +798,7 @@ func TestMetaIssueType_GetCreateMetaWithOptions(t *testing.T) {
     }`)
 	})
 
-	issue, _, err := testClient.Issue.GetCreateMetaWithOptions(&GetQueryOptions{Expand: "projects.issuetypes.fields"})
+	issue, _, err := testClient.Issue.GetCreateMetaWithOptions(context.Background(), &GetQueryOptions{Expand: "projects.issuetypes.fields"})
 	if err != nil {
 		t.Errorf("Expected nil error but got %s", err)
 	}

--- a/cloud/permissionscheme.go
+++ b/cloud/permissionscheme.go
@@ -27,10 +27,10 @@ type Holder struct {
 	Expand    string `json:"expand" structs:"expand"`
 }
 
-// GetListWithContext returns a list of all permission schemes
+// GetList returns a list of all permission schemes
 //
 // Jira API docs: https://developer.atlassian.com/cloud/jira/platform/rest/v3/#api-api-3-permissionscheme-get
-func (s *PermissionSchemeService) GetListWithContext(ctx context.Context) (*PermissionSchemes, *Response, error) {
+func (s *PermissionSchemeService) GetList(ctx context.Context) (*PermissionSchemes, *Response, error) {
 	apiEndpoint := "/rest/api/3/permissionscheme"
 	req, err := s.client.NewRequest(ctx, "GET", apiEndpoint, nil)
 	if err != nil {
@@ -47,15 +47,10 @@ func (s *PermissionSchemeService) GetListWithContext(ctx context.Context) (*Perm
 	return pss, resp, nil
 }
 
-// GetList wraps GetListWithContext using the background context.
-func (s *PermissionSchemeService) GetList() (*PermissionSchemes, *Response, error) {
-	return s.GetListWithContext(context.Background())
-}
-
-// GetWithContext returns a full representation of the permission scheme for the schemeID
+// Get returns a full representation of the permission scheme for the schemeID
 //
 // Jira API docs: https://developer.atlassian.com/cloud/jira/platform/rest/v3/#api-api-3-permissionscheme-schemeId-get
-func (s *PermissionSchemeService) GetWithContext(ctx context.Context, schemeID int) (*PermissionScheme, *Response, error) {
+func (s *PermissionSchemeService) Get(ctx context.Context, schemeID int) (*PermissionScheme, *Response, error) {
 	apiEndpoint := fmt.Sprintf("/rest/api/3/permissionscheme/%d", schemeID)
 	req, err := s.client.NewRequest(ctx, "GET", apiEndpoint, nil)
 	if err != nil {
@@ -73,9 +68,4 @@ func (s *PermissionSchemeService) GetWithContext(ctx context.Context, schemeID i
 	}
 
 	return ps, resp, nil
-}
-
-// Get wraps GetWithContext using the background context.
-func (s *PermissionSchemeService) Get(schemeID int) (*PermissionScheme, *Response, error) {
-	return s.GetWithContext(context.Background(), schemeID)
 }

--- a/cloud/permissionscheme_test.go
+++ b/cloud/permissionscheme_test.go
@@ -1,6 +1,7 @@
 package cloud
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 	"os"
@@ -22,7 +23,7 @@ func TestPermissionSchemeService_GetList(t *testing.T) {
 		fmt.Fprint(w, string(raw))
 	})
 
-	permissionScheme, _, err := testClient.PermissionScheme.GetList()
+	permissionScheme, _, err := testClient.PermissionScheme.GetList(context.Background())
 	if err != nil {
 		t.Errorf("Error given: %v", err)
 	}
@@ -50,7 +51,7 @@ func TestPermissionSchemeService_GetList_NoList(t *testing.T) {
 		fmt.Fprint(w, string(raw))
 	})
 
-	permissionScheme, _, err := testClient.PermissionScheme.GetList()
+	permissionScheme, _, err := testClient.PermissionScheme.GetList(context.Background())
 	if permissionScheme != nil {
 		t.Errorf("Expected permissionScheme list has %d entries but should be nil", len(permissionScheme.PermissionSchemes))
 	}
@@ -73,7 +74,7 @@ func TestPermissionSchemeService_Get(t *testing.T) {
 		fmt.Fprint(writer, string(raw))
 	})
 
-	permissionScheme, _, err := testClient.PermissionScheme.Get(10100)
+	permissionScheme, _, err := testClient.PermissionScheme.Get(context.Background(), 10100)
 	if permissionScheme == nil {
 		t.Errorf("Expected permissionscheme, got nil")
 	}
@@ -96,7 +97,7 @@ func TestPermissionSchemeService_Get_NoScheme(t *testing.T) {
 		fmt.Fprint(writer, string(raw))
 	})
 
-	permissionScheme, _, err := testClient.PermissionScheme.Get(99999)
+	permissionScheme, _, err := testClient.PermissionScheme.Get(context.Background(), 99999)
 	if permissionScheme != nil {
 		t.Errorf("Expected nil, got permissionschme %v", permissionScheme)
 	}

--- a/cloud/priority.go
+++ b/cloud/priority.go
@@ -18,10 +18,10 @@ type Priority struct {
 	Description string `json:"description,omitempty" structs:"description,omitempty"`
 }
 
-// GetListWithContext gets all priorities from Jira
+// GetList gets all priorities from Jira
 //
 // Jira API docs: https://developer.atlassian.com/cloud/jira/platform/rest/#api-api-2-priority-get
-func (s *PriorityService) GetListWithContext(ctx context.Context) ([]Priority, *Response, error) {
+func (s *PriorityService) GetList(ctx context.Context) ([]Priority, *Response, error) {
 	apiEndpoint := "rest/api/2/priority"
 	req, err := s.client.NewRequest(ctx, "GET", apiEndpoint, nil)
 	if err != nil {
@@ -34,9 +34,4 @@ func (s *PriorityService) GetListWithContext(ctx context.Context) ([]Priority, *
 		return nil, resp, NewJiraError(resp, err)
 	}
 	return priorityList, resp, nil
-}
-
-// GetList wraps GetListWithContext using the background context.
-func (s *PriorityService) GetList() ([]Priority, *Response, error) {
-	return s.GetListWithContext(context.Background())
 }

--- a/cloud/priority_test.go
+++ b/cloud/priority_test.go
@@ -1,6 +1,7 @@
 package cloud
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 	"os"
@@ -22,7 +23,7 @@ func TestPriorityService_GetList(t *testing.T) {
 		fmt.Fprint(w, string(raw))
 	})
 
-	priorities, _, err := testClient.Priority.GetList()
+	priorities, _, err := testClient.Priority.GetList(context.Background())
 	if priorities == nil {
 		t.Error("Expected priority list. Priority list is nil")
 	}

--- a/cloud/project.go
+++ b/cloud/project.go
@@ -79,23 +79,18 @@ type PermissionScheme struct {
 	Permissions []Permission `json:"permissions" structs:"permissions,omitempty"`
 }
 
-// GetListWithContext gets all projects form Jira
+// GetList gets all projects form Jira
 //
 // Jira API docs: https://docs.atlassian.com/jira/REST/latest/#api/2/project-getAllProjects
-func (s *ProjectService) GetListWithContext(ctx context.Context) (*ProjectList, *Response, error) {
-	return s.ListWithOptionsWithContext(ctx, &GetQueryOptions{})
+func (s *ProjectService) GetList(ctx context.Context) (*ProjectList, *Response, error) {
+	return s.ListWithOptions(ctx, &GetQueryOptions{})
 }
 
-// GetList wraps GetListWithContext using the background context.
-func (s *ProjectService) GetList() (*ProjectList, *Response, error) {
-	return s.GetListWithContext(context.Background())
-}
-
-// ListWithOptionsWithContext gets all projects form Jira with optional query params, like &GetQueryOptions{Expand: "issueTypes"} to get
+// ListWithOptions gets all projects form Jira with optional query params, like &GetQueryOptions{Expand: "issueTypes"} to get
 // a list of all projects and their supported issuetypes
 //
 // Jira API docs: https://docs.atlassian.com/jira/REST/latest/#api/2/project-getAllProjects
-func (s *ProjectService) ListWithOptionsWithContext(ctx context.Context, options *GetQueryOptions) (*ProjectList, *Response, error) {
+func (s *ProjectService) ListWithOptions(ctx context.Context, options *GetQueryOptions) (*ProjectList, *Response, error) {
 	apiEndpoint := "rest/api/2/project"
 	req, err := s.client.NewRequest(ctx, "GET", apiEndpoint, nil)
 	if err != nil {
@@ -120,17 +115,12 @@ func (s *ProjectService) ListWithOptionsWithContext(ctx context.Context, options
 	return projectList, resp, nil
 }
 
-// ListWithOptions wraps ListWithOptionsWithContext using the background context.
-func (s *ProjectService) ListWithOptions(options *GetQueryOptions) (*ProjectList, *Response, error) {
-	return s.ListWithOptionsWithContext(context.Background(), options)
-}
-
-// GetWithContext returns a full representation of the project for the given issue key.
+// Get returns a full representation of the project for the given issue key.
 // Jira will attempt to identify the project by the projectIdOrKey path parameter.
 // This can be an project id, or an project key.
 //
 // Jira API docs: https://docs.atlassian.com/jira/REST/latest/#api/2/project-getProject
-func (s *ProjectService) GetWithContext(ctx context.Context, projectID string) (*Project, *Response, error) {
+func (s *ProjectService) Get(ctx context.Context, projectID string) (*Project, *Response, error) {
 	apiEndpoint := fmt.Sprintf("rest/api/2/project/%s", projectID)
 	req, err := s.client.NewRequest(ctx, "GET", apiEndpoint, nil)
 	if err != nil {
@@ -147,17 +137,12 @@ func (s *ProjectService) GetWithContext(ctx context.Context, projectID string) (
 	return project, resp, nil
 }
 
-// Get wraps GetWithContext using the background context.
-func (s *ProjectService) Get(projectID string) (*Project, *Response, error) {
-	return s.GetWithContext(context.Background(), projectID)
-}
-
-// GetPermissionSchemeWithContext returns a full representation of the permission scheme for the project
+// GetPermissionScheme returns a full representation of the permission scheme for the project
 // Jira will attempt to identify the project by the projectIdOrKey path parameter.
 // This can be an project id, or an project key.
 //
 // Jira API docs: https://docs.atlassian.com/jira/REST/latest/#api/2/project-getProject
-func (s *ProjectService) GetPermissionSchemeWithContext(ctx context.Context, projectID string) (*PermissionScheme, *Response, error) {
+func (s *ProjectService) GetPermissionScheme(ctx context.Context, projectID string) (*PermissionScheme, *Response, error) {
 	apiEndpoint := fmt.Sprintf("/rest/api/2/project/%s/permissionscheme", projectID)
 	req, err := s.client.NewRequest(ctx, "GET", apiEndpoint, nil)
 	if err != nil {
@@ -172,9 +157,4 @@ func (s *ProjectService) GetPermissionSchemeWithContext(ctx context.Context, pro
 	}
 
 	return ps, resp, nil
-}
-
-// GetPermissionScheme wraps GetPermissionSchemeWithContext using the background context.
-func (s *ProjectService) GetPermissionScheme(projectID string) (*PermissionScheme, *Response, error) {
-	return s.GetPermissionSchemeWithContext(context.Background(), projectID)
 }

--- a/cloud/project_test.go
+++ b/cloud/project_test.go
@@ -1,6 +1,7 @@
 package cloud
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 	"os"
@@ -22,7 +23,7 @@ func TestProjectService_GetList(t *testing.T) {
 		fmt.Fprint(w, string(raw))
 	})
 
-	projects, _, err := testClient.Project.GetList()
+	projects, _, err := testClient.Project.GetList(context.Background())
 	if projects == nil {
 		t.Error("Expected project list. Project list is nil")
 	}
@@ -46,7 +47,7 @@ func TestProjectService_ListWithOptions(t *testing.T) {
 		fmt.Fprint(w, string(raw))
 	})
 
-	projects, _, err := testClient.Project.ListWithOptions(&GetQueryOptions{Expand: "issueTypes"})
+	projects, _, err := testClient.Project.ListWithOptions(context.Background(), &GetQueryOptions{Expand: "issueTypes"})
 	if projects == nil {
 		t.Error("Expected project list. Project list is nil")
 	}
@@ -70,7 +71,7 @@ func TestProjectService_Get(t *testing.T) {
 		fmt.Fprint(w, string(raw))
 	})
 
-	projects, _, err := testClient.Project.Get("12310505")
+	projects, _, err := testClient.Project.Get(context.Background(), "12310505")
 	if err != nil {
 		t.Errorf("Error given: %s", err)
 	}
@@ -94,7 +95,7 @@ func TestProjectService_Get_NoProject(t *testing.T) {
 		fmt.Fprint(w, nil)
 	})
 
-	projects, resp, err := testClient.Project.Get("99999999")
+	projects, resp, err := testClient.Project.Get(context.Background(), "99999999")
 	if projects != nil {
 		t.Errorf("Expected nil. Got %+v", projects)
 	}
@@ -118,7 +119,7 @@ func TestProjectService_GetPermissionScheme_Failure(t *testing.T) {
 		fmt.Fprint(w, nil)
 	})
 
-	permissionScheme, resp, err := testClient.Project.GetPermissionScheme("99999999")
+	permissionScheme, resp, err := testClient.Project.GetPermissionScheme(context.Background(), "99999999")
 	if permissionScheme != nil {
 		t.Errorf("Expected nil. Got %+v", permissionScheme)
 	}
@@ -148,7 +149,7 @@ func TestProjectService_GetPermissionScheme_Success(t *testing.T) {
 		}`)
 	})
 
-	permissionScheme, resp, err := testClient.Project.GetPermissionScheme("99999999")
+	permissionScheme, resp, err := testClient.Project.GetPermissionScheme(context.Background(), "99999999")
 	if permissionScheme.ID != 10201 {
 		t.Errorf("Expected Permission Scheme ID. Got %+v", permissionScheme)
 	}

--- a/cloud/request.go
+++ b/cloud/request.go
@@ -54,10 +54,10 @@ type RequestComment struct {
 	Expands []string     `json:"_expands,omitempty" structs:"_expands,omitempty"`
 }
 
-// CreateWithContext creates a new request.
+// Create creates a new request.
 //
 // https://developer.atlassian.com/cloud/jira/service-desk/rest/api-group-request/#api-rest-servicedeskapi-request-post
-func (r *RequestService) CreateWithContext(ctx context.Context, requester string, participants []string, request *Request) (*Request, *Response, error) {
+func (r *RequestService) Create(ctx context.Context, requester string, participants []string, request *Request) (*Request, *Response, error) {
 	apiEndpoint := "rest/servicedeskapi/request"
 
 	payload := struct {
@@ -90,15 +90,10 @@ func (r *RequestService) CreateWithContext(ctx context.Context, requester string
 	return responseRequest, resp, nil
 }
 
-// Create wraps CreateWithContext using the background context.
-func (r *RequestService) Create(requester string, participants []string, request *Request) (*Request, *Response, error) {
-	return r.CreateWithContext(context.Background(), requester, participants, request)
-}
-
-// CreateCommentWithContext creates a comment on a request.
+// CreateComment creates a comment on a request.
 //
 // https://developer.atlassian.com/cloud/jira/service-desk/rest/api-group-request/#api-rest-servicedeskapi-request-issueidorkey-comment-post
-func (r *RequestService) CreateCommentWithContext(ctx context.Context, issueIDOrKey string, comment *RequestComment) (*RequestComment, *Response, error) {
+func (r *RequestService) CreateComment(ctx context.Context, issueIDOrKey string, comment *RequestComment) (*RequestComment, *Response, error) {
 	apiEndpoint := fmt.Sprintf("rest/servicedeskapi/request/%v/comment", issueIDOrKey)
 
 	req, err := r.client.NewRequest(ctx, "POST", apiEndpoint, comment)
@@ -113,9 +108,4 @@ func (r *RequestService) CreateCommentWithContext(ctx context.Context, issueIDOr
 	}
 
 	return responseComment, resp, nil
-}
-
-// CreateComment wraps CreateCommentWithContext using the background context.
-func (r *RequestService) CreateComment(issueIDOrKey string, comment *RequestComment) (*RequestComment, *Response, error) {
-	return r.CreateCommentWithContext(context.Background(), issueIDOrKey, comment)
 }

--- a/cloud/request_test.go
+++ b/cloud/request_test.go
@@ -1,6 +1,7 @@
 package cloud
 
 import (
+	"context"
 	"encoding/json"
 	"net/http"
 	"reflect"
@@ -126,7 +127,7 @@ func TestRequestService_Create(t *testing.T) {
 		},
 	}
 
-	_, _, err := testClient.Request.Create(wantRequester, wantParticipants, request)
+	_, _, err := testClient.Request.Create(context.Background(), wantRequester, wantParticipants, request)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -192,7 +193,7 @@ func TestRequestService_CreateComment(t *testing.T) {
 		Public: true,
 	}
 
-	_, _, err := testClient.Request.CreateComment("HELPDESK-1", comment)
+	_, _, err := testClient.Request.CreateComment(context.Background(), "HELPDESK-1", comment)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/cloud/resolution.go
+++ b/cloud/resolution.go
@@ -16,10 +16,10 @@ type Resolution struct {
 	Name        string `json:"name" structs:"name"`
 }
 
-// GetListWithContext gets all resolutions from Jira
+// GetList gets all resolutions from Jira
 //
 // Jira API docs: https://developer.atlassian.com/cloud/jira/platform/rest/#api-api-2-resolution-get
-func (s *ResolutionService) GetListWithContext(ctx context.Context) ([]Resolution, *Response, error) {
+func (s *ResolutionService) GetList(ctx context.Context) ([]Resolution, *Response, error) {
 	apiEndpoint := "rest/api/2/resolution"
 	req, err := s.client.NewRequest(ctx, "GET", apiEndpoint, nil)
 	if err != nil {
@@ -32,9 +32,4 @@ func (s *ResolutionService) GetListWithContext(ctx context.Context) ([]Resolutio
 		return nil, resp, NewJiraError(resp, err)
 	}
 	return resolutionList, resp, nil
-}
-
-// GetList wraps GetListWithContext using the background context.
-func (s *ResolutionService) GetList() ([]Resolution, *Response, error) {
-	return s.GetListWithContext(context.Background())
 }

--- a/cloud/resolution_test.go
+++ b/cloud/resolution_test.go
@@ -1,6 +1,7 @@
 package cloud
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 	"os"
@@ -22,7 +23,7 @@ func TestResolutionService_GetList(t *testing.T) {
 		fmt.Fprint(w, string(raw))
 	})
 
-	resolution, _, err := testClient.Resolution.GetList()
+	resolution, _, err := testClient.Resolution.GetList(context.Background())
 	if resolution == nil {
 		t.Error("Expected resolution list. Resolution list is nil")
 	}

--- a/onpremise/component.go
+++ b/onpremise/component.go
@@ -18,8 +18,8 @@ type CreateComponentOptions struct {
 	ProjectID    int    `json:"projectId,omitempty" structs:"projectId,omitempty"`
 }
 
-// CreateWithContext creates a new Jira component based on the given options.
-func (s *ComponentService) CreateWithContext(ctx context.Context, options *CreateComponentOptions) (*ProjectComponent, *Response, error) {
+// Create creates a new Jira component based on the given options.
+func (s *ComponentService) Create(ctx context.Context, options *CreateComponentOptions) (*ProjectComponent, *Response, error) {
 	apiEndpoint := "rest/api/2/component"
 	req, err := s.client.NewRequest(ctx, "POST", apiEndpoint, options)
 	if err != nil {
@@ -34,9 +34,4 @@ func (s *ComponentService) CreateWithContext(ctx context.Context, options *Creat
 	}
 
 	return component, resp, nil
-}
-
-// Create wraps CreateWithContext using the background context.
-func (s *ComponentService) Create(options *CreateComponentOptions) (*ProjectComponent, *Response, error) {
-	return s.CreateWithContext(context.Background(), options)
 }

--- a/onpremise/component_test.go
+++ b/onpremise/component_test.go
@@ -1,6 +1,7 @@
 package onpremise
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 	"testing"
@@ -17,7 +18,7 @@ func TestComponentService_Create_Success(t *testing.T) {
 		fmt.Fprint(w, `{ "self": "http://www.example.com/jira/rest/api/2/component/10000", "id": "10000", "name": "Component 1", "description": "This is a Jira component", "lead": { "self": "http://www.example.com/jira/rest/api/2/user?username=fred", "name": "fred", "avatarUrls": { "48x48": "http://www.example.com/jira/secure/useravatar?size=large&ownerId=fred", "24x24": "http://www.example.com/jira/secure/useravatar?size=small&ownerId=fred", "16x16": "http://www.example.com/jira/secure/useravatar?size=xsmall&ownerId=fred", "32x32": "http://www.example.com/jira/secure/useravatar?size=medium&ownerId=fred" }, "displayName": "Fred F. User", "active": false }, "assigneeType": "PROJECT_LEAD", "assignee": { "self": "http://www.example.com/jira/rest/api/2/user?username=fred", "name": "fred", "avatarUrls": { "48x48": "http://www.example.com/jira/secure/useravatar?size=large&ownerId=fred", "24x24": "http://www.example.com/jira/secure/useravatar?size=small&ownerId=fred", "16x16": "http://www.example.com/jira/secure/useravatar?size=xsmall&ownerId=fred", "32x32": "http://www.example.com/jira/secure/useravatar?size=medium&ownerId=fred" }, "displayName": "Fred F. User", "active": false }, "realAssigneeType": "PROJECT_LEAD", "realAssignee": { "self": "http://www.example.com/jira/rest/api/2/user?username=fred", "name": "fred", "avatarUrls": { "48x48": "http://www.example.com/jira/secure/useravatar?size=large&ownerId=fred", "24x24": "http://www.example.com/jira/secure/useravatar?size=small&ownerId=fred", "16x16": "http://www.example.com/jira/secure/useravatar?size=xsmall&ownerId=fred", "32x32": "http://www.example.com/jira/secure/useravatar?size=medium&ownerId=fred" }, "displayName": "Fred F. User", "active": false }, "isAssigneeTypeValid": false, "project": "HSP", "projectId": 10000 }`)
 	})
 
-	component, _, err := testClient.Component.Create(&CreateComponentOptions{
+	component, _, err := testClient.Component.Create(context.Background(), &CreateComponentOptions{
 		Name: "foo-bar",
 	})
 	if component == nil {

--- a/onpremise/customer.go
+++ b/onpremise/customer.go
@@ -36,10 +36,10 @@ type CustomerList struct {
 	Expands []string   `json:"_expands,omitempty" structs:"_expands,omitempty"`
 }
 
-// CreateWithContext creates a ServiceDesk customer.
+// Create creates a ServiceDesk customer.
 //
 // https://developer.atlassian.com/cloud/jira/service-desk/rest/api-group-customer/#api-rest-servicedeskapi-customer-post
-func (c *CustomerService) CreateWithContext(ctx context.Context, email, displayName string) (*Customer, *Response, error) {
+func (c *CustomerService) Create(ctx context.Context, email, displayName string) (*Customer, *Response, error) {
 	const apiEndpoint = "rest/servicedeskapi/customer"
 
 	payload := struct {
@@ -62,9 +62,4 @@ func (c *CustomerService) CreateWithContext(ctx context.Context, email, displayN
 	}
 
 	return responseCustomer, resp, nil
-}
-
-// Create wraps CreateWithContext using the background context.
-func (c *CustomerService) Create(email, displayName string) (*Customer, *Response, error) {
-	return c.CreateWithContext(context.Background(), email, displayName)
 }

--- a/onpremise/customer_test.go
+++ b/onpremise/customer_test.go
@@ -1,6 +1,7 @@
 package onpremise
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 	"testing"
@@ -41,7 +42,7 @@ func TestCustomerService_Create(t *testing.T) {
 		}`, wantEmailAddress, wantDisplayName)
 	})
 
-	gotCustomer, _, err := testClient.Customer.Create(wantEmailAddress, wantDisplayName)
+	gotCustomer, _, err := testClient.Customer.Create(context.Background(), wantEmailAddress, wantDisplayName)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/onpremise/field.go
+++ b/onpremise/field.go
@@ -29,10 +29,10 @@ type FieldSchema struct {
 	CustomID int64  `json:"customId,omitempty" structs:"customId,omitempty"`
 }
 
-// GetListWithContext gets all fields from Jira
+// GetList gets all fields from Jira
 //
 // Jira API docs: https://developer.atlassian.com/cloud/jira/platform/rest/#api-api-2-field-get
-func (s *FieldService) GetListWithContext(ctx context.Context) ([]Field, *Response, error) {
+func (s *FieldService) GetList(ctx context.Context) ([]Field, *Response, error) {
 	apiEndpoint := "rest/api/2/field"
 	req, err := s.client.NewRequest(ctx, "GET", apiEndpoint, nil)
 	if err != nil {
@@ -45,9 +45,4 @@ func (s *FieldService) GetListWithContext(ctx context.Context) ([]Field, *Respon
 		return nil, resp, NewJiraError(resp, err)
 	}
 	return fieldList, resp, nil
-}
-
-// GetList wraps GetListWithContext using the background context.
-func (s *FieldService) GetList() ([]Field, *Response, error) {
-	return s.GetListWithContext(context.Background())
 }

--- a/onpremise/field_test.go
+++ b/onpremise/field_test.go
@@ -1,6 +1,7 @@
 package onpremise
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 	"os"
@@ -22,7 +23,7 @@ func TestFieldService_GetList(t *testing.T) {
 		fmt.Fprint(w, string(raw))
 	})
 
-	fields, _, err := testClient.Field.GetList()
+	fields, _, err := testClient.Field.GetList(context.Background())
 	if fields == nil {
 		t.Error("Expected field list. Field list is nil")
 	}

--- a/onpremise/filter.go
+++ b/onpremise/filter.go
@@ -118,8 +118,8 @@ type FilterSearchOptions struct {
 	Expand string `url:"expand,omitempty"`
 }
 
-// GetListWithContext retrieves all filters from Jira
-func (fs *FilterService) GetListWithContext(ctx context.Context) ([]*Filter, *Response, error) {
+// GetList retrieves all filters from Jira
+func (fs *FilterService) GetList(ctx context.Context) ([]*Filter, *Response, error) {
 
 	options := &GetQueryOptions{}
 	apiEndpoint := "rest/api/2/filter"
@@ -143,13 +143,8 @@ func (fs *FilterService) GetListWithContext(ctx context.Context) ([]*Filter, *Re
 	return filters, resp, err
 }
 
-// GetList wraps GetListWithContext using the background context.
-func (fs *FilterService) GetList() ([]*Filter, *Response, error) {
-	return fs.GetListWithContext(context.Background())
-}
-
-// GetFavouriteListWithContext retrieves the user's favourited filters from Jira
-func (fs *FilterService) GetFavouriteListWithContext(ctx context.Context) ([]*Filter, *Response, error) {
+// GetFavouriteList retrieves the user's favourited filters from Jira
+func (fs *FilterService) GetFavouriteList(ctx context.Context) ([]*Filter, *Response, error) {
 	apiEndpoint := "rest/api/2/filter/favourite"
 	req, err := fs.client.NewRequest(ctx, "GET", apiEndpoint, nil)
 	if err != nil {
@@ -164,13 +159,8 @@ func (fs *FilterService) GetFavouriteListWithContext(ctx context.Context) ([]*Fi
 	return filters, resp, err
 }
 
-// GetFavouriteList wraps GetFavouriteListWithContext using the background context.
-func (fs *FilterService) GetFavouriteList() ([]*Filter, *Response, error) {
-	return fs.GetFavouriteListWithContext(context.Background())
-}
-
-// GetWithContext retrieves a single Filter from Jira
-func (fs *FilterService) GetWithContext(ctx context.Context, filterID int) (*Filter, *Response, error) {
+// Get retrieves a single Filter from Jira
+func (fs *FilterService) Get(ctx context.Context, filterID int) (*Filter, *Response, error) {
 	apiEndpoint := fmt.Sprintf("rest/api/2/filter/%d", filterID)
 	req, err := fs.client.NewRequest(ctx, "GET", apiEndpoint, nil)
 	if err != nil {
@@ -186,15 +176,10 @@ func (fs *FilterService) GetWithContext(ctx context.Context, filterID int) (*Fil
 	return filter, resp, err
 }
 
-// Get wraps GetWithContext using the background context.
-func (fs *FilterService) Get(filterID int) (*Filter, *Response, error) {
-	return fs.GetWithContext(context.Background(), filterID)
-}
-
-// GetMyFiltersWithContext retrieves the my Filters.
+// GetMyFilters retrieves the my Filters.
 //
 // https://developer.atlassian.com/cloud/jira/platform/rest/v3/#api-rest-api-3-filter-my-get
-func (fs *FilterService) GetMyFiltersWithContext(ctx context.Context, opts *GetMyFiltersQueryOptions) ([]*Filter, *Response, error) {
+func (fs *FilterService) GetMyFilters(ctx context.Context, opts *GetMyFiltersQueryOptions) ([]*Filter, *Response, error) {
 	apiEndpoint := "rest/api/3/filter/my"
 	url, err := addOptions(apiEndpoint, opts)
 	if err != nil {
@@ -214,15 +199,10 @@ func (fs *FilterService) GetMyFiltersWithContext(ctx context.Context, opts *GetM
 	return filters, resp, nil
 }
 
-// GetMyFilters wraps GetMyFiltersWithContext using the background context.
-func (fs *FilterService) GetMyFilters(opts *GetMyFiltersQueryOptions) ([]*Filter, *Response, error) {
-	return fs.GetMyFiltersWithContext(context.Background(), opts)
-}
-
-// SearchWithContext will search for filter according to the search options
+// Search will search for filter according to the search options
 //
 // Jira API docs: https://developer.atlassian.com/cloud/jira/platform/rest/v3/#api-rest-api-3-filter-search-get
-func (fs *FilterService) SearchWithContext(ctx context.Context, opt *FilterSearchOptions) (*FiltersList, *Response, error) {
+func (fs *FilterService) Search(ctx context.Context, opt *FilterSearchOptions) (*FiltersList, *Response, error) {
 	apiEndpoint := "rest/api/3/filter/search"
 	url, err := addOptions(apiEndpoint, opt)
 	if err != nil {
@@ -241,9 +221,4 @@ func (fs *FilterService) SearchWithContext(ctx context.Context, opt *FilterSearc
 	}
 
 	return filters, resp, err
-}
-
-// Search wraps SearchWithContext using the background context.
-func (fs *FilterService) Search(opt *FilterSearchOptions) (*FiltersList, *Response, error) {
-	return fs.SearchWithContext(context.Background(), opt)
 }

--- a/onpremise/filter_test.go
+++ b/onpremise/filter_test.go
@@ -1,6 +1,7 @@
 package onpremise
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 	"os"
@@ -21,7 +22,7 @@ func TestFilterService_GetList(t *testing.T) {
 		fmt.Fprint(writer, string(raw))
 	})
 
-	filters, _, err := testClient.Filter.GetList()
+	filters, _, err := testClient.Filter.GetList(context.Background())
 	if filters == nil {
 		t.Error("Expected Filters list. Filters list is nil")
 	}
@@ -44,7 +45,7 @@ func TestFilterService_Get(t *testing.T) {
 		fmt.Fprint(writer, string(raw))
 	})
 
-	filter, _, err := testClient.Filter.Get(10000)
+	filter, _, err := testClient.Filter.Get(context.Background(), 10000)
 	if filter == nil {
 		t.Errorf("Expected Filter, got nil")
 	}
@@ -68,7 +69,7 @@ func TestFilterService_GetFavouriteList(t *testing.T) {
 		fmt.Fprint(writer, string(raw))
 	})
 
-	filters, _, err := testClient.Filter.GetFavouriteList()
+	filters, _, err := testClient.Filter.GetFavouriteList(context.Background())
 	if filters == nil {
 		t.Error("Expected Filters list. Filters list is nil")
 	}
@@ -92,7 +93,7 @@ func TestFilterService_GetMyFilters(t *testing.T) {
 	})
 
 	opts := GetMyFiltersQueryOptions{}
-	filters, _, err := testClient.Filter.GetMyFilters(&opts)
+	filters, _, err := testClient.Filter.GetMyFilters(context.Background(), &opts)
 	if err != nil {
 		t.Errorf("Error given: %s", err)
 	}
@@ -116,7 +117,7 @@ func TestFilterService_Search(t *testing.T) {
 	})
 
 	opt := FilterSearchOptions{}
-	filters, _, err := testClient.Filter.Search(&opt)
+	filters, _, err := testClient.Filter.Search(context.Background(), &opt)
 	if err != nil {
 		t.Errorf("Error given: %s", err)
 	}

--- a/onpremise/group.go
+++ b/onpremise/group.go
@@ -57,14 +57,14 @@ type GroupSearchOptions struct {
 	IncludeInactiveUsers bool
 }
 
-// GetWithContext returns a paginated list of users who are members of the specified group and its subgroups.
+// Get returns a paginated list of users who are members of the specified group and its subgroups.
 // Users in the page are ordered by user names.
 // User of this resource is required to have sysadmin or admin permissions.
 //
 // Jira API docs: https://docs.atlassian.com/jira/REST/server/#api/2/group-getUsersFromGroup
 //
 // WARNING: This API only returns the first page of group members
-func (s *GroupService) GetWithContext(ctx context.Context, name string) ([]GroupMember, *Response, error) {
+func (s *GroupService) Get(ctx context.Context, name string) ([]GroupMember, *Response, error) {
 	apiEndpoint := fmt.Sprintf("/rest/api/2/group/member?groupname=%s", url.QueryEscape(name))
 	req, err := s.client.NewRequest(ctx, "GET", apiEndpoint, nil)
 	if err != nil {
@@ -80,17 +80,12 @@ func (s *GroupService) GetWithContext(ctx context.Context, name string) ([]Group
 	return group.Members, resp, nil
 }
 
-// Get wraps GetWithContext using the background context.
-func (s *GroupService) Get(name string) ([]GroupMember, *Response, error) {
-	return s.GetWithContext(context.Background(), name)
-}
-
-// GetWithOptionsWithContext returns a paginated list of members of the specified group and its subgroups.
+// GetWithOptions returns a paginated list of members of the specified group and its subgroups.
 // Users in the page are ordered by user names.
 // User of this resource is required to have sysadmin or admin permissions.
 //
 // Jira API docs: https://docs.atlassian.com/jira/REST/server/#api/2/group-getUsersFromGroup
-func (s *GroupService) GetWithOptionsWithContext(ctx context.Context, name string, options *GroupSearchOptions) ([]GroupMember, *Response, error) {
+func (s *GroupService) GetWithOptions(ctx context.Context, name string, options *GroupSearchOptions) ([]GroupMember, *Response, error) {
 	var apiEndpoint string
 	if options == nil {
 		apiEndpoint = fmt.Sprintf("/rest/api/2/group/member?groupname=%s", url.QueryEscape(name))
@@ -116,15 +111,10 @@ func (s *GroupService) GetWithOptionsWithContext(ctx context.Context, name strin
 	return group.Members, resp, nil
 }
 
-// GetWithOptions wraps GetWithOptionsWithContext using the background context.
-func (s *GroupService) GetWithOptions(name string, options *GroupSearchOptions) ([]GroupMember, *Response, error) {
-	return s.GetWithOptionsWithContext(context.Background(), name, options)
-}
-
-// AddWithContext adds user to group
+// Add adds user to group
 //
 // Jira API docs: https://docs.atlassian.com/jira/REST/cloud/#api/2/group-addUserToGroup
-func (s *GroupService) AddWithContext(ctx context.Context, groupname string, username string) (*Group, *Response, error) {
+func (s *GroupService) Add(ctx context.Context, groupname string, username string) (*Group, *Response, error) {
 	apiEndpoint := fmt.Sprintf("/rest/api/2/group/user?groupname=%s", groupname)
 	var user struct {
 		Name string `json:"name"`
@@ -145,16 +135,11 @@ func (s *GroupService) AddWithContext(ctx context.Context, groupname string, use
 	return responseGroup, resp, nil
 }
 
-// Add wraps AddWithContext using the background context.
-func (s *GroupService) Add(groupname string, username string) (*Group, *Response, error) {
-	return s.AddWithContext(context.Background(), groupname, username)
-}
-
-// RemoveWithContext removes user from group
+// Remove removes user from group
 //
 // Jira API docs: https://docs.atlassian.com/jira/REST/cloud/#api/2/group-removeUserFromGroup
 // Caller must close resp.Body
-func (s *GroupService) RemoveWithContext(ctx context.Context, groupname string, username string) (*Response, error) {
+func (s *GroupService) Remove(ctx context.Context, groupname string, username string) (*Response, error) {
 	apiEndpoint := fmt.Sprintf("/rest/api/2/group/user?groupname=%s&username=%s", groupname, username)
 	req, err := s.client.NewRequest(ctx, "DELETE", apiEndpoint, nil)
 	if err != nil {
@@ -168,10 +153,4 @@ func (s *GroupService) RemoveWithContext(ctx context.Context, groupname string, 
 	}
 
 	return resp, nil
-}
-
-// Remove wraps RemoveWithContext using the background context.
-// Caller must close resp.Body
-func (s *GroupService) Remove(groupname string, username string) (*Response, error) {
-	return s.RemoveWithContext(context.Background(), groupname, username)
 }

--- a/onpremise/group_test.go
+++ b/onpremise/group_test.go
@@ -1,6 +1,7 @@
 package onpremise
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 	"testing"
@@ -14,7 +15,7 @@ func TestGroupService_Get(t *testing.T) {
 		testRequestURL(t, r, "/rest/api/2/group/member?groupname=default")
 		fmt.Fprint(w, `{"self":"http://www.example.com/jira/rest/api/2/group/member?includeInactiveUsers=false&maxResults=50&groupname=default&startAt=0","maxResults":50,"startAt":0,"total":2,"isLast":true,"values":[{"self":"http://www.example.com/jira/rest/api/2/user?username=michael","name":"michael","key":"michael","emailAddress":"michael@example.com","displayName":"MichaelScofield","active":true,"timeZone":"Australia/Sydney"},{"self":"http://www.example.com/jira/rest/api/2/user?username=alex","name":"alex","key":"alex","emailAddress":"alex@example.com","displayName":"AlexanderMahone","active":true,"timeZone":"Australia/Sydney"}]}`)
 	})
-	if members, _, err := testClient.Group.Get("default"); err != nil {
+	if members, _, err := testClient.Group.Get(context.Background(), "default"); err != nil {
 		t.Errorf("Error given: %s", err)
 	} else if members == nil {
 		t.Error("Expected members. Group.Members is nil")
@@ -36,7 +37,7 @@ func TestGroupService_GetPage(t *testing.T) {
 			t.Errorf("startAt %s", startAt)
 		}
 	})
-	if page, resp, err := testClient.Group.GetWithOptions("default", &GroupSearchOptions{
+	if page, resp, err := testClient.Group.GetWithOptions(context.Background(), "default", &GroupSearchOptions{
 		StartAt:              0,
 		MaxResults:           2,
 		IncludeInactiveUsers: false,
@@ -54,7 +55,7 @@ func TestGroupService_GetPage(t *testing.T) {
 		if resp.Total != 4 {
 			t.Errorf("Expect Result Total to be 4, but is %d", resp.Total)
 		}
-		if page, resp, err := testClient.Group.GetWithOptions("default", &GroupSearchOptions{
+		if page, resp, err := testClient.Group.GetWithOptions(context.Background(), "default", &GroupSearchOptions{
 			StartAt:              2,
 			MaxResults:           2,
 			IncludeInactiveUsers: false,
@@ -87,7 +88,7 @@ func TestGroupService_Add(t *testing.T) {
 		fmt.Fprint(w, `{"name":"default","self":"http://www.example.com/jira/rest/api/2/group?groupname=default","users":{"size":1,"items":[],"max-results":50,"start-index":0,"end-index":0},"expand":"users"}`)
 	})
 
-	if group, _, err := testClient.Group.Add("default", "theodore"); err != nil {
+	if group, _, err := testClient.Group.Add(context.Background(), "default", "theodore"); err != nil {
 		t.Errorf("Error given: %s", err)
 	} else if group == nil {
 		t.Error("Expected group. Group is nil")
@@ -105,7 +106,7 @@ func TestGroupService_Remove(t *testing.T) {
 		fmt.Fprint(w, `{"name":"default","self":"http://www.example.com/jira/rest/api/2/group?groupname=default","users":{"size":1,"items":[],"max-results":50,"start-index":0,"end-index":0},"expand":"users"}`)
 	})
 
-	if _, err := testClient.Group.Remove("default", "theodore"); err != nil {
+	if _, err := testClient.Group.Remove(context.Background(), "default", "theodore"); err != nil {
 		t.Errorf("Error given: %s", err)
 	}
 }

--- a/onpremise/metaissue.go
+++ b/onpremise/metaissue.go
@@ -48,18 +48,13 @@ type MetaIssueType struct {
 	Fields      tcontainer.MarshalMap `json:"fields,omitempty"`
 }
 
-// GetCreateMetaWithContext makes the api call to get the meta information required to create a ticket
-func (s *IssueService) GetCreateMetaWithContext(ctx context.Context, projectkeys string) (*CreateMetaInfo, *Response, error) {
-	return s.GetCreateMetaWithOptionsWithContext(ctx, &GetQueryOptions{ProjectKeys: projectkeys, Expand: "projects.issuetypes.fields"})
+// GetCreateMeta makes the api call to get the meta information required to create a ticket
+func (s *IssueService) GetCreateMeta(ctx context.Context, projectkeys string) (*CreateMetaInfo, *Response, error) {
+	return s.GetCreateMetaWithOptions(ctx, &GetQueryOptions{ProjectKeys: projectkeys, Expand: "projects.issuetypes.fields"})
 }
 
-// GetCreateMeta wraps GetCreateMetaWithContext using the background context.
-func (s *IssueService) GetCreateMeta(projectkeys string) (*CreateMetaInfo, *Response, error) {
-	return s.GetCreateMetaWithContext(context.Background(), projectkeys)
-}
-
-// GetCreateMetaWithOptionsWithContext makes the api call to get the meta information without requiring to have a projectKey
-func (s *IssueService) GetCreateMetaWithOptionsWithContext(ctx context.Context, options *GetQueryOptions) (*CreateMetaInfo, *Response, error) {
+// GetCreateMetaWithOptions makes the api call to get the meta information without requiring to have a projectKey
+func (s *IssueService) GetCreateMetaWithOptions(ctx context.Context, options *GetQueryOptions) (*CreateMetaInfo, *Response, error) {
 	apiEndpoint := "rest/api/2/issue/createmeta"
 
 	req, err := s.client.NewRequest(ctx, "GET", apiEndpoint, nil)
@@ -84,13 +79,8 @@ func (s *IssueService) GetCreateMetaWithOptionsWithContext(ctx context.Context, 
 	return meta, resp, nil
 }
 
-// GetCreateMetaWithOptions wraps GetCreateMetaWithOptionsWithContext using the background context.
-func (s *IssueService) GetCreateMetaWithOptions(options *GetQueryOptions) (*CreateMetaInfo, *Response, error) {
-	return s.GetCreateMetaWithOptionsWithContext(context.Background(), options)
-}
-
-// GetEditMetaWithContext makes the api call to get the edit meta information for an issue
-func (s *IssueService) GetEditMetaWithContext(ctx context.Context, issue *Issue) (*EditMetaInfo, *Response, error) {
+// GetEditMeta makes the api call to get the edit meta information for an issue
+func (s *IssueService) GetEditMeta(ctx context.Context, issue *Issue) (*EditMetaInfo, *Response, error) {
 	apiEndpoint := fmt.Sprintf("/rest/api/2/issue/%s/editmeta", issue.Key)
 
 	req, err := s.client.NewRequest(ctx, "GET", apiEndpoint, nil)
@@ -106,11 +96,6 @@ func (s *IssueService) GetEditMetaWithContext(ctx context.Context, issue *Issue)
 	}
 
 	return meta, resp, nil
-}
-
-// GetEditMeta wraps GetEditMetaWithContext using the background context.
-func (s *IssueService) GetEditMeta(issue *Issue) (*EditMetaInfo, *Response, error) {
-	return s.GetEditMetaWithContext(context.Background(), issue)
 }
 
 // GetProjectWithName returns a project with "name" from the meta information received. If not found, this returns nil.

--- a/onpremise/metaissue_test.go
+++ b/onpremise/metaissue_test.go
@@ -1,6 +1,7 @@
 package onpremise
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 	"net/url"
@@ -348,7 +349,7 @@ func TestIssueService_GetCreateMeta_Success(t *testing.T) {
     }`)
 	})
 
-	issue, _, err := testClient.Issue.GetCreateMeta("SPN")
+	issue, _, err := testClient.Issue.GetCreateMeta(context.Background(), "SPN")
 	if err != nil {
 		t.Errorf("Expected nil error but got %s", err)
 	}
@@ -420,7 +421,7 @@ func TestIssueService_GetEditMeta_Success(t *testing.T) {
 	}`)
 	})
 
-	editMeta, _, err := testClient.Issue.GetEditMeta(&Issue{Key: "PROJ-9001"})
+	editMeta, _, err := testClient.Issue.GetEditMeta(context.Background(), &Issue{Key: "PROJ-9001"})
 	if err != nil {
 		t.Errorf("Expected nil error but got %s", err)
 	}
@@ -446,7 +447,7 @@ func TestIssueService_GetEditMeta_Success(t *testing.T) {
 }
 
 func TestIssueService_GetEditMeta_Fail(t *testing.T) {
-	_, _, err := testClient.Issue.GetEditMeta(&Issue{Key: "PROJ-9001"})
+	_, _, err := testClient.Issue.GetEditMeta(context.Background(), &Issue{Key: "PROJ-9001"})
 	if err == nil {
 		t.Error("Expected to receive an error, received nil instead")
 	}
@@ -797,7 +798,7 @@ func TestMetaIssueType_GetCreateMetaWithOptions(t *testing.T) {
     }`)
 	})
 
-	issue, _, err := testClient.Issue.GetCreateMetaWithOptions(&GetQueryOptions{Expand: "projects.issuetypes.fields"})
+	issue, _, err := testClient.Issue.GetCreateMetaWithOptions(context.Background(), &GetQueryOptions{Expand: "projects.issuetypes.fields"})
 	if err != nil {
 		t.Errorf("Expected nil error but got %s", err)
 	}

--- a/onpremise/permissionscheme.go
+++ b/onpremise/permissionscheme.go
@@ -27,10 +27,10 @@ type Holder struct {
 	Expand    string `json:"expand" structs:"expand"`
 }
 
-// GetListWithContext returns a list of all permission schemes
+// GetList returns a list of all permission schemes
 //
 // Jira API docs: https://developer.atlassian.com/cloud/jira/platform/rest/v3/#api-api-3-permissionscheme-get
-func (s *PermissionSchemeService) GetListWithContext(ctx context.Context) (*PermissionSchemes, *Response, error) {
+func (s *PermissionSchemeService) GetList(ctx context.Context) (*PermissionSchemes, *Response, error) {
 	apiEndpoint := "/rest/api/3/permissionscheme"
 	req, err := s.client.NewRequest(ctx, "GET", apiEndpoint, nil)
 	if err != nil {
@@ -47,15 +47,10 @@ func (s *PermissionSchemeService) GetListWithContext(ctx context.Context) (*Perm
 	return pss, resp, nil
 }
 
-// GetList wraps GetListWithContext using the background context.
-func (s *PermissionSchemeService) GetList() (*PermissionSchemes, *Response, error) {
-	return s.GetListWithContext(context.Background())
-}
-
-// GetWithContext returns a full representation of the permission scheme for the schemeID
+// Get returns a full representation of the permission scheme for the schemeID
 //
 // Jira API docs: https://developer.atlassian.com/cloud/jira/platform/rest/v3/#api-api-3-permissionscheme-schemeId-get
-func (s *PermissionSchemeService) GetWithContext(ctx context.Context, schemeID int) (*PermissionScheme, *Response, error) {
+func (s *PermissionSchemeService) Get(ctx context.Context, schemeID int) (*PermissionScheme, *Response, error) {
 	apiEndpoint := fmt.Sprintf("/rest/api/3/permissionscheme/%d", schemeID)
 	req, err := s.client.NewRequest(ctx, "GET", apiEndpoint, nil)
 	if err != nil {
@@ -73,9 +68,4 @@ func (s *PermissionSchemeService) GetWithContext(ctx context.Context, schemeID i
 	}
 
 	return ps, resp, nil
-}
-
-// Get wraps GetWithContext using the background context.
-func (s *PermissionSchemeService) Get(schemeID int) (*PermissionScheme, *Response, error) {
-	return s.GetWithContext(context.Background(), schemeID)
 }

--- a/onpremise/permissionscheme_test.go
+++ b/onpremise/permissionscheme_test.go
@@ -1,6 +1,7 @@
 package onpremise
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 	"os"
@@ -22,7 +23,7 @@ func TestPermissionSchemeService_GetList(t *testing.T) {
 		fmt.Fprint(w, string(raw))
 	})
 
-	permissionScheme, _, err := testClient.PermissionScheme.GetList()
+	permissionScheme, _, err := testClient.PermissionScheme.GetList(context.Background())
 	if err != nil {
 		t.Errorf("Error given: %v", err)
 	}
@@ -50,7 +51,7 @@ func TestPermissionSchemeService_GetList_NoList(t *testing.T) {
 		fmt.Fprint(w, string(raw))
 	})
 
-	permissionScheme, _, err := testClient.PermissionScheme.GetList()
+	permissionScheme, _, err := testClient.PermissionScheme.GetList(context.Background())
 	if permissionScheme != nil {
 		t.Errorf("Expected permissionScheme list has %d entries but should be nil", len(permissionScheme.PermissionSchemes))
 	}
@@ -73,7 +74,7 @@ func TestPermissionSchemeService_Get(t *testing.T) {
 		fmt.Fprint(writer, string(raw))
 	})
 
-	permissionScheme, _, err := testClient.PermissionScheme.Get(10100)
+	permissionScheme, _, err := testClient.PermissionScheme.Get(context.Background(), 10100)
 	if permissionScheme == nil {
 		t.Errorf("Expected permissionscheme, got nil")
 	}
@@ -96,7 +97,7 @@ func TestPermissionSchemeService_Get_NoScheme(t *testing.T) {
 		fmt.Fprint(writer, string(raw))
 	})
 
-	permissionScheme, _, err := testClient.PermissionScheme.Get(99999)
+	permissionScheme, _, err := testClient.PermissionScheme.Get(context.Background(), 99999)
 	if permissionScheme != nil {
 		t.Errorf("Expected nil, got permissionschme %v", permissionScheme)
 	}

--- a/onpremise/priority.go
+++ b/onpremise/priority.go
@@ -18,10 +18,10 @@ type Priority struct {
 	Description string `json:"description,omitempty" structs:"description,omitempty"`
 }
 
-// GetListWithContext gets all priorities from Jira
+// GetList gets all priorities from Jira
 //
 // Jira API docs: https://developer.atlassian.com/cloud/jira/platform/rest/#api-api-2-priority-get
-func (s *PriorityService) GetListWithContext(ctx context.Context) ([]Priority, *Response, error) {
+func (s *PriorityService) GetList(ctx context.Context) ([]Priority, *Response, error) {
 	apiEndpoint := "rest/api/2/priority"
 	req, err := s.client.NewRequest(ctx, "GET", apiEndpoint, nil)
 	if err != nil {
@@ -34,9 +34,4 @@ func (s *PriorityService) GetListWithContext(ctx context.Context) ([]Priority, *
 		return nil, resp, NewJiraError(resp, err)
 	}
 	return priorityList, resp, nil
-}
-
-// GetList wraps GetListWithContext using the background context.
-func (s *PriorityService) GetList() ([]Priority, *Response, error) {
-	return s.GetListWithContext(context.Background())
 }

--- a/onpremise/priority_test.go
+++ b/onpremise/priority_test.go
@@ -1,6 +1,7 @@
 package onpremise
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 	"os"
@@ -22,7 +23,7 @@ func TestPriorityService_GetList(t *testing.T) {
 		fmt.Fprint(w, string(raw))
 	})
 
-	priorities, _, err := testClient.Priority.GetList()
+	priorities, _, err := testClient.Priority.GetList(context.Background())
 	if priorities == nil {
 		t.Error("Expected priority list. Priority list is nil")
 	}

--- a/onpremise/project.go
+++ b/onpremise/project.go
@@ -79,23 +79,18 @@ type PermissionScheme struct {
 	Permissions []Permission `json:"permissions" structs:"permissions,omitempty"`
 }
 
-// GetListWithContext gets all projects form Jira
+// GetList gets all projects form Jira
 //
 // Jira API docs: https://docs.atlassian.com/jira/REST/latest/#api/2/project-getAllProjects
-func (s *ProjectService) GetListWithContext(ctx context.Context) (*ProjectList, *Response, error) {
-	return s.ListWithOptionsWithContext(ctx, &GetQueryOptions{})
+func (s *ProjectService) GetList(ctx context.Context) (*ProjectList, *Response, error) {
+	return s.ListWithOptions(ctx, &GetQueryOptions{})
 }
 
-// GetList wraps GetListWithContext using the background context.
-func (s *ProjectService) GetList() (*ProjectList, *Response, error) {
-	return s.GetListWithContext(context.Background())
-}
-
-// ListWithOptionsWithContext gets all projects form Jira with optional query params, like &GetQueryOptions{Expand: "issueTypes"} to get
+// ListWithOptions gets all projects form Jira with optional query params, like &GetQueryOptions{Expand: "issueTypes"} to get
 // a list of all projects and their supported issuetypes
 //
 // Jira API docs: https://docs.atlassian.com/jira/REST/latest/#api/2/project-getAllProjects
-func (s *ProjectService) ListWithOptionsWithContext(ctx context.Context, options *GetQueryOptions) (*ProjectList, *Response, error) {
+func (s *ProjectService) ListWithOptions(ctx context.Context, options *GetQueryOptions) (*ProjectList, *Response, error) {
 	apiEndpoint := "rest/api/2/project"
 	req, err := s.client.NewRequest(ctx, "GET", apiEndpoint, nil)
 	if err != nil {
@@ -120,17 +115,12 @@ func (s *ProjectService) ListWithOptionsWithContext(ctx context.Context, options
 	return projectList, resp, nil
 }
 
-// ListWithOptions wraps ListWithOptionsWithContext using the background context.
-func (s *ProjectService) ListWithOptions(options *GetQueryOptions) (*ProjectList, *Response, error) {
-	return s.ListWithOptionsWithContext(context.Background(), options)
-}
-
-// GetWithContext returns a full representation of the project for the given issue key.
+// Get returns a full representation of the project for the given issue key.
 // Jira will attempt to identify the project by the projectIdOrKey path parameter.
 // This can be an project id, or an project key.
 //
 // Jira API docs: https://docs.atlassian.com/jira/REST/latest/#api/2/project-getProject
-func (s *ProjectService) GetWithContext(ctx context.Context, projectID string) (*Project, *Response, error) {
+func (s *ProjectService) Get(ctx context.Context, projectID string) (*Project, *Response, error) {
 	apiEndpoint := fmt.Sprintf("rest/api/2/project/%s", projectID)
 	req, err := s.client.NewRequest(ctx, "GET", apiEndpoint, nil)
 	if err != nil {
@@ -147,17 +137,12 @@ func (s *ProjectService) GetWithContext(ctx context.Context, projectID string) (
 	return project, resp, nil
 }
 
-// Get wraps GetWithContext using the background context.
-func (s *ProjectService) Get(projectID string) (*Project, *Response, error) {
-	return s.GetWithContext(context.Background(), projectID)
-}
-
-// GetPermissionSchemeWithContext returns a full representation of the permission scheme for the project
+// GetPermissionScheme returns a full representation of the permission scheme for the project
 // Jira will attempt to identify the project by the projectIdOrKey path parameter.
 // This can be an project id, or an project key.
 //
 // Jira API docs: https://docs.atlassian.com/jira/REST/latest/#api/2/project-getProject
-func (s *ProjectService) GetPermissionSchemeWithContext(ctx context.Context, projectID string) (*PermissionScheme, *Response, error) {
+func (s *ProjectService) GetPermissionScheme(ctx context.Context, projectID string) (*PermissionScheme, *Response, error) {
 	apiEndpoint := fmt.Sprintf("/rest/api/2/project/%s/permissionscheme", projectID)
 	req, err := s.client.NewRequest(ctx, "GET", apiEndpoint, nil)
 	if err != nil {
@@ -172,9 +157,4 @@ func (s *ProjectService) GetPermissionSchemeWithContext(ctx context.Context, pro
 	}
 
 	return ps, resp, nil
-}
-
-// GetPermissionScheme wraps GetPermissionSchemeWithContext using the background context.
-func (s *ProjectService) GetPermissionScheme(projectID string) (*PermissionScheme, *Response, error) {
-	return s.GetPermissionSchemeWithContext(context.Background(), projectID)
 }

--- a/onpremise/project_test.go
+++ b/onpremise/project_test.go
@@ -1,6 +1,7 @@
 package onpremise
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 	"os"
@@ -22,7 +23,7 @@ func TestProjectService_GetList(t *testing.T) {
 		fmt.Fprint(w, string(raw))
 	})
 
-	projects, _, err := testClient.Project.GetList()
+	projects, _, err := testClient.Project.GetList(context.Background())
 	if projects == nil {
 		t.Error("Expected project list. Project list is nil")
 	}
@@ -46,7 +47,7 @@ func TestProjectService_ListWithOptions(t *testing.T) {
 		fmt.Fprint(w, string(raw))
 	})
 
-	projects, _, err := testClient.Project.ListWithOptions(&GetQueryOptions{Expand: "issueTypes"})
+	projects, _, err := testClient.Project.ListWithOptions(context.Background(), &GetQueryOptions{Expand: "issueTypes"})
 	if projects == nil {
 		t.Error("Expected project list. Project list is nil")
 	}
@@ -70,7 +71,7 @@ func TestProjectService_Get(t *testing.T) {
 		fmt.Fprint(w, string(raw))
 	})
 
-	projects, _, err := testClient.Project.Get("12310505")
+	projects, _, err := testClient.Project.Get(context.Background(), "12310505")
 	if err != nil {
 		t.Errorf("Error given: %s", err)
 	}
@@ -94,7 +95,7 @@ func TestProjectService_Get_NoProject(t *testing.T) {
 		fmt.Fprint(w, nil)
 	})
 
-	projects, resp, err := testClient.Project.Get("99999999")
+	projects, resp, err := testClient.Project.Get(context.Background(), "99999999")
 	if projects != nil {
 		t.Errorf("Expected nil. Got %+v", projects)
 	}
@@ -118,7 +119,7 @@ func TestProjectService_GetPermissionScheme_Failure(t *testing.T) {
 		fmt.Fprint(w, nil)
 	})
 
-	permissionScheme, resp, err := testClient.Project.GetPermissionScheme("99999999")
+	permissionScheme, resp, err := testClient.Project.GetPermissionScheme(context.Background(), "99999999")
 	if permissionScheme != nil {
 		t.Errorf("Expected nil. Got %+v", permissionScheme)
 	}
@@ -148,7 +149,7 @@ func TestProjectService_GetPermissionScheme_Success(t *testing.T) {
 		}`)
 	})
 
-	permissionScheme, resp, err := testClient.Project.GetPermissionScheme("99999999")
+	permissionScheme, resp, err := testClient.Project.GetPermissionScheme(context.Background(), "99999999")
 	if permissionScheme.ID != 10201 {
 		t.Errorf("Expected Permission Scheme ID. Got %+v", permissionScheme)
 	}

--- a/onpremise/request.go
+++ b/onpremise/request.go
@@ -54,10 +54,10 @@ type RequestComment struct {
 	Expands []string     `json:"_expands,omitempty" structs:"_expands,omitempty"`
 }
 
-// CreateWithContext creates a new request.
+// Create creates a new request.
 //
 // https://developer.atlassian.com/cloud/jira/service-desk/rest/api-group-request/#api-rest-servicedeskapi-request-post
-func (r *RequestService) CreateWithContext(ctx context.Context, requester string, participants []string, request *Request) (*Request, *Response, error) {
+func (r *RequestService) Create(ctx context.Context, requester string, participants []string, request *Request) (*Request, *Response, error) {
 	apiEndpoint := "rest/servicedeskapi/request"
 
 	payload := struct {
@@ -90,15 +90,10 @@ func (r *RequestService) CreateWithContext(ctx context.Context, requester string
 	return responseRequest, resp, nil
 }
 
-// Create wraps CreateWithContext using the background context.
-func (r *RequestService) Create(requester string, participants []string, request *Request) (*Request, *Response, error) {
-	return r.CreateWithContext(context.Background(), requester, participants, request)
-}
-
-// CreateCommentWithContext creates a comment on a request.
+// CreateComment creates a comment on a request.
 //
 // https://developer.atlassian.com/cloud/jira/service-desk/rest/api-group-request/#api-rest-servicedeskapi-request-issueidorkey-comment-post
-func (r *RequestService) CreateCommentWithContext(ctx context.Context, issueIDOrKey string, comment *RequestComment) (*RequestComment, *Response, error) {
+func (r *RequestService) CreateComment(ctx context.Context, issueIDOrKey string, comment *RequestComment) (*RequestComment, *Response, error) {
 	apiEndpoint := fmt.Sprintf("rest/servicedeskapi/request/%v/comment", issueIDOrKey)
 
 	req, err := r.client.NewRequest(ctx, "POST", apiEndpoint, comment)
@@ -113,9 +108,4 @@ func (r *RequestService) CreateCommentWithContext(ctx context.Context, issueIDOr
 	}
 
 	return responseComment, resp, nil
-}
-
-// CreateComment wraps CreateCommentWithContext using the background context.
-func (r *RequestService) CreateComment(issueIDOrKey string, comment *RequestComment) (*RequestComment, *Response, error) {
-	return r.CreateCommentWithContext(context.Background(), issueIDOrKey, comment)
 }

--- a/onpremise/request_test.go
+++ b/onpremise/request_test.go
@@ -1,6 +1,7 @@
 package onpremise
 
 import (
+	"context"
 	"encoding/json"
 	"net/http"
 	"reflect"
@@ -126,7 +127,7 @@ func TestRequestService_Create(t *testing.T) {
 		},
 	}
 
-	_, _, err := testClient.Request.Create(wantRequester, wantParticipants, request)
+	_, _, err := testClient.Request.Create(context.Background(), wantRequester, wantParticipants, request)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -192,7 +193,7 @@ func TestRequestService_CreateComment(t *testing.T) {
 		Public: true,
 	}
 
-	_, _, err := testClient.Request.CreateComment("HELPDESK-1", comment)
+	_, _, err := testClient.Request.CreateComment(context.Background(), "HELPDESK-1", comment)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/onpremise/resolution.go
+++ b/onpremise/resolution.go
@@ -16,10 +16,10 @@ type Resolution struct {
 	Name        string `json:"name" structs:"name"`
 }
 
-// GetListWithContext gets all resolutions from Jira
+// GetList gets all resolutions from Jira
 //
 // Jira API docs: https://developer.atlassian.com/cloud/jira/platform/rest/#api-api-2-resolution-get
-func (s *ResolutionService) GetListWithContext(ctx context.Context) ([]Resolution, *Response, error) {
+func (s *ResolutionService) GetList(ctx context.Context) ([]Resolution, *Response, error) {
 	apiEndpoint := "rest/api/2/resolution"
 	req, err := s.client.NewRequest(ctx, "GET", apiEndpoint, nil)
 	if err != nil {
@@ -32,9 +32,4 @@ func (s *ResolutionService) GetListWithContext(ctx context.Context) ([]Resolutio
 		return nil, resp, NewJiraError(resp, err)
 	}
 	return resolutionList, resp, nil
-}
-
-// GetList wraps GetListWithContext using the background context.
-func (s *ResolutionService) GetList() ([]Resolution, *Response, error) {
-	return s.GetListWithContext(context.Background())
 }

--- a/onpremise/resolution_test.go
+++ b/onpremise/resolution_test.go
@@ -1,6 +1,7 @@
 package onpremise
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 	"os"
@@ -22,7 +23,7 @@ func TestResolutionService_GetList(t *testing.T) {
 		fmt.Fprint(w, string(raw))
 	})
 
-	resolution, _, err := testClient.Resolution.GetList()
+	resolution, _, err := testClient.Resolution.GetList(context.Background())
 	if resolution == nil {
 		t.Error("Expected resolution list. Resolution list is nil")
 	}


### PR DESCRIPTION
Remove "WithContext" API methods for the following services:

* Project Service
* Group Service
* Filter Service
* Field Service
* Customer Service
* Component Service
* Priority Service
* PermissionScheme Service
* Metaissue Service
* Resolution Service
* Request Service

Related: #337