### PR TITLE
Make context first class citizen: Remove "WithContext" API methods (Part 3)

### DIFF
--- a/cloud/auth_transport_jwt_test.go
+++ b/cloud/auth_transport_jwt_test.go
@@ -1,6 +1,7 @@
 package cloud
 
 import (
+	"context"
 	"net/http"
 	"strings"
 	"testing"
@@ -27,5 +28,5 @@ func TestJWTAuthTransport_HeaderContainsJWT(t *testing.T) {
 	})
 
 	jwtClient, _ := NewClient(testServer.URL, jwtTransport.Client())
-	jwtClient.Issue.Get("TEST-1", nil)
+	jwtClient.Issue.Get(context.Background(), "TEST-1", nil)
 }

--- a/cloud/authentication.go
+++ b/cloud/authentication.go
@@ -48,7 +48,7 @@ type Session struct {
 	Cookies []*http.Cookie
 }
 
-// AcquireSessionCookieWithContext creates a new session for a user in Jira.
+// AcquireSessionCookie creates a new session for a user in Jira.
 // Once a session has been successfully created it can be used to access any of Jira's remote APIs and also the web UI by passing the appropriate HTTP Cookie header.
 // The header will by automatically applied to every API request.
 // Note that it is generally preferrable to use HTTP BASIC authentication with the REST API.
@@ -57,7 +57,7 @@ type Session struct {
 // Jira API docs: https://docs.atlassian.com/jira/REST/latest/#auth/1/session
 //
 // Deprecated: Use CookieAuthTransport instead
-func (s *AuthenticationService) AcquireSessionCookieWithContext(ctx context.Context, username, password string) (bool, error) {
+func (s *AuthenticationService) AcquireSessionCookie(ctx context.Context, username, password string) (bool, error) {
 	apiEndpoint := "rest/auth/1/session"
 	body := struct {
 		Username string `json:"username"`
@@ -92,13 +92,6 @@ func (s *AuthenticationService) AcquireSessionCookieWithContext(ctx context.Cont
 	return true, nil
 }
 
-// AcquireSessionCookie wraps AcquireSessionCookieWithContext using the background context.
-//
-// Deprecated: Use CookieAuthTransport instead
-func (s *AuthenticationService) AcquireSessionCookie(username, password string) (bool, error) {
-	return s.AcquireSessionCookieWithContext(context.Background(), username, password)
-}
-
 // SetBasicAuth sets username and password for the basic auth against the Jira instance.
 //
 // Deprecated: Use BasicAuthTransport instead
@@ -121,13 +114,13 @@ func (s *AuthenticationService) Authenticated() bool {
 	return false
 }
 
-// LogoutWithContext logs out the current user that has been authenticated and the session in the client is destroyed.
+// Logout logs out the current user that has been authenticated and the session in the client is destroyed.
 //
 // Jira API docs: https://docs.atlassian.com/jira/REST/latest/#auth/1/session
 //
 // Deprecated: Use CookieAuthTransport to create base client.  Logging out is as simple as not using the
 // client anymore
-func (s *AuthenticationService) LogoutWithContext(ctx context.Context) error {
+func (s *AuthenticationService) Logout(ctx context.Context) error {
 	if s.authType != authTypeSession || s.client.session == nil {
 		return fmt.Errorf("no user is authenticated")
 	}
@@ -154,18 +147,10 @@ func (s *AuthenticationService) LogoutWithContext(ctx context.Context) error {
 
 }
 
-// Logout wraps LogoutWithContext using the background context.
-//
-// Deprecated: Use CookieAuthTransport to create base client.  Logging out is as simple as not using the
-// client anymore
-func (s *AuthenticationService) Logout() error {
-	return s.LogoutWithContext(context.Background())
-}
-
-// GetCurrentUserWithContext gets the details of the current user.
+// GetCurrentUser gets the details of the current user.
 //
 // Jira API docs: https://docs.atlassian.com/jira/REST/latest/#auth/1/session
-func (s *AuthenticationService) GetCurrentUserWithContext(ctx context.Context) (*Session, error) {
+func (s *AuthenticationService) GetCurrentUser(ctx context.Context) (*Session, error) {
 	if s == nil {
 		return nil, fmt.Errorf("authentication Service is not instantiated")
 	}
@@ -200,9 +185,4 @@ func (s *AuthenticationService) GetCurrentUserWithContext(ctx context.Context) (
 	}
 
 	return ret, nil
-}
-
-// GetCurrentUser wraps GetCurrentUserWithContext using the background context.
-func (s *AuthenticationService) GetCurrentUser() (*Session, error) {
-	return s.GetCurrentUserWithContext(context.Background())
 }

--- a/cloud/authentication_test.go
+++ b/cloud/authentication_test.go
@@ -2,6 +2,7 @@ package cloud
 
 import (
 	"bytes"
+	"context"
 	"fmt"
 	"io"
 	"net/http"
@@ -30,7 +31,7 @@ func TestAuthenticationService_AcquireSessionCookie_Failure(t *testing.T) {
 		w.WriteHeader(http.StatusInternalServerError)
 	})
 
-	res, err := testClient.Authentication.AcquireSessionCookie("foo", "bar")
+	res, err := testClient.Authentication.AcquireSessionCookie(context.Background(), "foo", "bar")
 	if err == nil {
 		t.Errorf("Expected error, but no error given")
 	}
@@ -63,7 +64,7 @@ func TestAuthenticationService_AcquireSessionCookie_Success(t *testing.T) {
 		fmt.Fprint(w, `{"session":{"name":"JSESSIONID","value":"12345678901234567890"},"loginInfo":{"failedLoginCount":10,"loginCount":127,"lastFailedLoginTime":"2016-03-16T04:22:35.386+0000","previousLoginTime":"2016-03-16T04:22:35.386+0000"}}`)
 	})
 
-	res, err := testClient.Authentication.AcquireSessionCookie("foo", "bar")
+	res, err := testClient.Authentication.AcquireSessionCookie(context.Background(), "foo", "bar")
 	if err != nil {
 		t.Errorf("No error expected. Got %s", err)
 	}
@@ -162,9 +163,9 @@ func TestAuthenticationService_GetUserInfo_AccessForbidden_Fail(t *testing.T) {
 		}
 	})
 
-	testClient.Authentication.AcquireSessionCookie("foo", "bar")
+	testClient.Authentication.AcquireSessionCookie(context.Background(), "foo", "bar")
 
-	_, err := testClient.Authentication.GetCurrentUser()
+	_, err := testClient.Authentication.GetCurrentUser(context.Background())
 	if err == nil {
 		t.Errorf("Non nil error expect, received nil")
 	}
@@ -200,9 +201,9 @@ func TestAuthenticationService_GetUserInfo_NonOkStatusCode_Fail(t *testing.T) {
 		}
 	})
 
-	testClient.Authentication.AcquireSessionCookie("foo", "bar")
+	testClient.Authentication.AcquireSessionCookie(context.Background(), "foo", "bar")
 
-	_, err := testClient.Authentication.GetCurrentUser()
+	_, err := testClient.Authentication.GetCurrentUser(context.Background())
 	if err == nil {
 		t.Errorf("Non nil error expect, received nil")
 	}
@@ -212,7 +213,7 @@ func TestAuthenticationService_GetUserInfo_FailWithoutLogin(t *testing.T) {
 	// no setup() required here
 	testClient = new(Client)
 
-	_, err := testClient.Authentication.GetCurrentUser()
+	_, err := testClient.Authentication.GetCurrentUser(context.Background())
 	if err == nil {
 		t.Errorf("Expected error, but got %s", err)
 	}
@@ -255,9 +256,9 @@ func TestAuthenticationService_GetUserInfo_Success(t *testing.T) {
 		}
 	})
 
-	testClient.Authentication.AcquireSessionCookie("foo", "bar")
+	testClient.Authentication.AcquireSessionCookie(context.Background(), "foo", "bar")
 
-	userinfo, err := testClient.Authentication.GetCurrentUser()
+	userinfo, err := testClient.Authentication.GetCurrentUser(context.Background())
 	if err != nil {
 		t.Errorf("Nil error expect, received %s", err)
 	}
@@ -296,9 +297,9 @@ func TestAuthenticationService_Logout_Success(t *testing.T) {
 		}
 	})
 
-	testClient.Authentication.AcquireSessionCookie("foo", "bar")
+	testClient.Authentication.AcquireSessionCookie(context.Background(), "foo", "bar")
 
-	err := testClient.Authentication.Logout()
+	err := testClient.Authentication.Logout(context.Background())
 	if err != nil {
 		t.Errorf("Expected nil error, got %s", err)
 	}
@@ -314,7 +315,7 @@ func TestAuthenticationService_Logout_FailWithoutLogin(t *testing.T) {
 			w.WriteHeader(http.StatusUnauthorized)
 		}
 	})
-	err := testClient.Authentication.Logout()
+	err := testClient.Authentication.Logout(context.Background())
 	if err == nil {
 		t.Error("Expected not nil, got nil")
 	}

--- a/cloud/board.go
+++ b/cloud/board.go
@@ -125,10 +125,10 @@ type BoardConfigurationColumnStatus struct {
 	Self string `json:"self"`
 }
 
-// GetAllBoardsWithContext will returns all boards. This only includes boards that the user has permission to view.
+// GetAllBoards will returns all boards. This only includes boards that the user has permission to view.
 //
 // Jira API docs: https://docs.atlassian.com/jira-software/REST/cloud/#agile/1.0/board-getAllBoards
-func (s *BoardService) GetAllBoardsWithContext(ctx context.Context, opt *BoardListOptions) (*BoardsList, *Response, error) {
+func (s *BoardService) GetAllBoards(ctx context.Context, opt *BoardListOptions) (*BoardsList, *Response, error) {
 	apiEndpoint := "rest/agile/1.0/board"
 	url, err := addOptions(apiEndpoint, opt)
 	if err != nil {
@@ -149,16 +149,11 @@ func (s *BoardService) GetAllBoardsWithContext(ctx context.Context, opt *BoardLi
 	return boards, resp, err
 }
 
-// GetAllBoards wraps GetAllBoardsWithContext using the background context.
-func (s *BoardService) GetAllBoards(opt *BoardListOptions) (*BoardsList, *Response, error) {
-	return s.GetAllBoardsWithContext(context.Background(), opt)
-}
-
-// GetBoardWithContext will returns the board for the given boardID.
+// GetBoard will returns the board for the given boardID.
 // This board will only be returned if the user has permission to view it.
 //
 // Jira API docs: https://docs.atlassian.com/jira-software/REST/cloud/#agile/1.0/board-getBoard
-func (s *BoardService) GetBoardWithContext(ctx context.Context, boardID int) (*Board, *Response, error) {
+func (s *BoardService) GetBoard(ctx context.Context, boardID int) (*Board, *Response, error) {
 	apiEndpoint := fmt.Sprintf("rest/agile/1.0/board/%v", boardID)
 	req, err := s.client.NewRequest(ctx, "GET", apiEndpoint, nil)
 	if err != nil {
@@ -175,12 +170,7 @@ func (s *BoardService) GetBoardWithContext(ctx context.Context, boardID int) (*B
 	return board, resp, nil
 }
 
-// GetBoard wraps GetBoardWithContext using the background context.
-func (s *BoardService) GetBoard(boardID int) (*Board, *Response, error) {
-	return s.GetBoardWithContext(context.Background(), boardID)
-}
-
-// CreateBoardWithContext creates a new board. Board name, type and filter Id is required.
+// CreateBoard creates a new board. Board name, type and filter Id is required.
 // name - Must be less than 255 characters.
 // type - Valid values: scrum, kanban
 // filterId - Id of a filter that the user has permissions to view.
@@ -188,7 +178,7 @@ func (s *BoardService) GetBoard(boardID int) (*Board, *Response, error) {
 // board will be created instead (remember that board sharing depends on the filter sharing).
 //
 // Jira API docs: https://docs.atlassian.com/jira-software/REST/cloud/#agile/1.0/board-createBoard
-func (s *BoardService) CreateBoardWithContext(ctx context.Context, board *Board) (*Board, *Response, error) {
+func (s *BoardService) CreateBoard(ctx context.Context, board *Board) (*Board, *Response, error) {
 	apiEndpoint := "rest/agile/1.0/board"
 	req, err := s.client.NewRequest(ctx, "POST", apiEndpoint, board)
 	if err != nil {
@@ -205,16 +195,11 @@ func (s *BoardService) CreateBoardWithContext(ctx context.Context, board *Board)
 	return responseBoard, resp, nil
 }
 
-// CreateBoard wraps CreateBoardWithContext using the background context.
-func (s *BoardService) CreateBoard(board *Board) (*Board, *Response, error) {
-	return s.CreateBoardWithContext(context.Background(), board)
-}
-
-// DeleteBoardWithContext will delete an agile board.
+// DeleteBoard will delete an agile board.
 //
 // Jira API docs: https://docs.atlassian.com/jira-software/REST/cloud/#agile/1.0/board-deleteBoard
 // Caller must close resp.Body
-func (s *BoardService) DeleteBoardWithContext(ctx context.Context, boardID int) (*Board, *Response, error) {
+func (s *BoardService) DeleteBoard(ctx context.Context, boardID int) (*Board, *Response, error) {
 	apiEndpoint := fmt.Sprintf("rest/agile/1.0/board/%v", boardID)
 	req, err := s.client.NewRequest(ctx, "DELETE", apiEndpoint, nil)
 	if err != nil {
@@ -228,23 +213,17 @@ func (s *BoardService) DeleteBoardWithContext(ctx context.Context, boardID int) 
 	return nil, resp, err
 }
 
-// DeleteBoard wraps DeleteBoardWithContext using the background context.
-// Caller must close resp.Body
-func (s *BoardService) DeleteBoard(boardID int) (*Board, *Response, error) {
-	return s.DeleteBoardWithContext(context.Background(), boardID)
-}
-
-// GetAllSprintsWithContext will return all sprints from a board, for a given board Id.
+// GetAllSprints will return all sprints from a board, for a given board Id.
 // This only includes sprints that the user has permission to view.
 //
 // Jira API docs: https://docs.atlassian.com/jira-software/REST/cloud/#agile/1.0/board/{boardId}/sprint
-func (s *BoardService) GetAllSprintsWithContext(ctx context.Context, boardID string) ([]Sprint, *Response, error) {
+func (s *BoardService) GetAllSprints(ctx context.Context, boardID string) ([]Sprint, *Response, error) {
 	id, err := strconv.Atoi(boardID)
 	if err != nil {
 		return nil, nil, err
 	}
 
-	result, response, err := s.GetAllSprintsWithOptions(id, &GetAllSprintsOptions{})
+	result, response, err := s.GetAllSprintsWithOptions(ctx, id, &GetAllSprintsOptions{})
 	if err != nil {
 		return nil, nil, err
 	}
@@ -252,16 +231,11 @@ func (s *BoardService) GetAllSprintsWithContext(ctx context.Context, boardID str
 	return result.Values, response, nil
 }
 
-// GetAllSprints wraps GetAllSprintsWithContext using the background context.
-func (s *BoardService) GetAllSprints(boardID string) ([]Sprint, *Response, error) {
-	return s.GetAllSprintsWithContext(context.Background(), boardID)
-}
-
-// GetAllSprintsWithOptionsWithContext will return sprints from a board, for a given board Id and filtering options
+// GetAllSprintsWithOptions will return sprints from a board, for a given board Id and filtering options
 // This only includes sprints that the user has permission to view.
 //
 // Jira API docs: https://docs.atlassian.com/jira-software/REST/cloud/#agile/1.0/board/{boardId}/sprint
-func (s *BoardService) GetAllSprintsWithOptionsWithContext(ctx context.Context, boardID int, options *GetAllSprintsOptions) (*SprintsList, *Response, error) {
+func (s *BoardService) GetAllSprintsWithOptions(ctx context.Context, boardID int, options *GetAllSprintsOptions) (*SprintsList, *Response, error) {
 	apiEndpoint := fmt.Sprintf("rest/agile/1.0/board/%d/sprint", boardID)
 	url, err := addOptions(apiEndpoint, options)
 	if err != nil {
@@ -281,14 +255,9 @@ func (s *BoardService) GetAllSprintsWithOptionsWithContext(ctx context.Context, 
 	return result, resp, err
 }
 
-// GetAllSprintsWithOptions wraps GetAllSprintsWithOptionsWithContext using the background context.
-func (s *BoardService) GetAllSprintsWithOptions(boardID int, options *GetAllSprintsOptions) (*SprintsList, *Response, error) {
-	return s.GetAllSprintsWithOptionsWithContext(context.Background(), boardID, options)
-}
-
-// GetBoardConfigurationWithContext will return a board configuration for a given board Id
+// GetBoardConfiguration will return a board configuration for a given board Id
 // Jira API docs:https://developer.atlassian.com/cloud/jira/software/rest/#api-rest-agile-1-0-board-boardId-configuration-get
-func (s *BoardService) GetBoardConfigurationWithContext(ctx context.Context, boardID int) (*BoardConfiguration, *Response, error) {
+func (s *BoardService) GetBoardConfiguration(ctx context.Context, boardID int) (*BoardConfiguration, *Response, error) {
 	apiEndpoint := fmt.Sprintf("rest/agile/1.0/board/%d/configuration", boardID)
 
 	req, err := s.client.NewRequest(ctx, "GET", apiEndpoint, nil)
@@ -305,9 +274,4 @@ func (s *BoardService) GetBoardConfigurationWithContext(ctx context.Context, boa
 
 	return result, resp, err
 
-}
-
-// GetBoardConfiguration wraps GetBoardConfigurationWithContext using the background context.
-func (s *BoardService) GetBoardConfiguration(boardID int) (*BoardConfiguration, *Response, error) {
-	return s.GetBoardConfigurationWithContext(context.Background(), boardID)
 }

--- a/cloud/board_test.go
+++ b/cloud/board_test.go
@@ -1,6 +1,7 @@
 package cloud
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 	"os"
@@ -22,7 +23,7 @@ func TestBoardService_GetAllBoards(t *testing.T) {
 		fmt.Fprint(w, string(raw))
 	})
 
-	projects, _, err := testClient.Board.GetAllBoards(nil)
+	projects, _, err := testClient.Board.GetAllBoards(context.Background(), nil)
 	if projects == nil {
 		t.Error("Expected boards list. Boards list is nil")
 	}
@@ -56,7 +57,7 @@ func TestBoardService_GetAllBoards_WithFilter(t *testing.T) {
 	boardsListOptions.StartAt = 1
 	boardsListOptions.MaxResults = 10
 
-	projects, _, err := testClient.Board.GetAllBoards(boardsListOptions)
+	projects, _, err := testClient.Board.GetAllBoards(context.Background(), boardsListOptions)
 	if projects == nil {
 		t.Error("Expected boards list. Boards list is nil")
 	}
@@ -76,7 +77,7 @@ func TestBoardService_GetBoard(t *testing.T) {
 		fmt.Fprint(w, `{"id":4,"self":"https://test.jira.org/rest/agile/1.0/board/1","name":"Test Weekly","type":"scrum"}`)
 	})
 
-	board, _, err := testClient.Board.GetBoard(1)
+	board, _, err := testClient.Board.GetBoard(context.Background(), 1)
 	if board == nil {
 		t.Error("Expected board list. Board list is nil")
 	}
@@ -96,7 +97,7 @@ func TestBoardService_GetBoard_WrongID(t *testing.T) {
 		fmt.Fprint(w, nil)
 	})
 
-	board, resp, err := testClient.Board.GetBoard(99999999)
+	board, resp, err := testClient.Board.GetBoard(context.Background(), 99999999)
 	if board != nil {
 		t.Errorf("Expected nil. Got %s", err)
 	}
@@ -125,7 +126,7 @@ func TestBoardService_CreateBoard(t *testing.T) {
 		Type:     "kanban",
 		FilterID: 17,
 	}
-	issue, _, err := testClient.Board.CreateBoard(b)
+	issue, _, err := testClient.Board.CreateBoard(context.Background(), b)
 	if issue == nil {
 		t.Error("Expected board. Board is nil")
 	}
@@ -145,7 +146,7 @@ func TestBoardService_DeleteBoard(t *testing.T) {
 		fmt.Fprint(w, `{}`)
 	})
 
-	_, resp, err := testClient.Board.DeleteBoard(1)
+	_, resp, err := testClient.Board.DeleteBoard(context.Background(), 1)
 	if resp.StatusCode != 204 {
 		t.Error("Expected board not deleted.")
 	}
@@ -171,7 +172,7 @@ func TestBoardService_GetAllSprints(t *testing.T) {
 		fmt.Fprint(w, string(raw))
 	})
 
-	sprints, _, err := testClient.Board.GetAllSprints("123")
+	sprints, _, err := testClient.Board.GetAllSprints(context.Background(), "123")
 
 	if err != nil {
 		t.Errorf("Got error: %v", err)
@@ -203,7 +204,7 @@ func TestBoardService_GetAllSprintsWithOptions(t *testing.T) {
 		fmt.Fprint(w, string(raw))
 	})
 
-	sprints, _, err := testClient.Board.GetAllSprintsWithOptions(123, &GetAllSprintsOptions{State: "active,future"})
+	sprints, _, err := testClient.Board.GetAllSprintsWithOptions(context.Background(), 123, &GetAllSprintsOptions{State: "active,future"})
 	if err != nil {
 		t.Errorf("Got error: %v", err)
 	}
@@ -234,7 +235,7 @@ func TestBoardService_GetBoardConfigoration(t *testing.T) {
 		fmt.Fprint(w, string(raw))
 	})
 
-	boardConfiguration, _, err := testClient.Board.GetBoardConfiguration(35)
+	boardConfiguration, _, err := testClient.Board.GetBoardConfiguration(context.Background(), 35)
 	if err != nil {
 		t.Errorf("Got error: %v", err)
 	}

--- a/cloud/examples/addlabel/main.go
+++ b/cloud/examples/addlabel/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"bufio"
+	"context"
 	"fmt"
 	"io"
 	"os"
@@ -62,7 +63,7 @@ func main() {
 		},
 	}
 
-	resp, err := client.Issue.UpdateIssue(issueId, c)
+	resp, err := client.Issue.UpdateIssue(context.Background(), issueId, c)
 
 	if err != nil {
 		fmt.Println(err)
@@ -70,7 +71,7 @@ func main() {
 	body, _ := io.ReadAll(resp.Body)
 	fmt.Println(string(body))
 
-	issue, _, _ := client.Issue.Get(issueId, nil)
+	issue, _, _ := client.Issue.Get(context.Background(), issueId, nil)
 
 	fmt.Printf("Issue: %s:%s\n", issue.Key, issue.Fields.Summary)
 	fmt.Printf("\tLabels: %+v\n", issue.Fields.Labels)

--- a/cloud/examples/create/main.go
+++ b/cloud/examples/create/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"bufio"
+	"context"
 	"fmt"
 	"os"
 	"strings"
@@ -54,7 +55,7 @@ func main() {
 		},
 	}
 
-	issue, _, err := client.Issue.Create(&i)
+	issue, _, err := client.Issue.Create(context.Background(), &i)
 	if err != nil {
 		panic(err)
 	}

--- a/cloud/examples/createwithcustomfields/main.go
+++ b/cloud/examples/createwithcustomfields/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"bufio"
+	"context"
 	"fmt"
 	"os"
 	"strings"
@@ -65,7 +66,7 @@ func main() {
 		},
 	}
 
-	issue, _, err := client.Issue.Create(&i)
+	issue, _, err := client.Issue.Create(context.Background(), &i)
 	if err != nil {
 		panic(err)
 	}

--- a/cloud/examples/ignorecerts/main.go
+++ b/cloud/examples/ignorecerts/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"crypto/tls"
 	"fmt"
 	"net/http"
@@ -15,7 +16,7 @@ func main() {
 	client := &http.Client{Transport: tr}
 
 	jiraClient, _ := jira.NewClient("https://issues.apache.org/jira/", client)
-	issue, _, _ := jiraClient.Issue.Get("MESOS-3325", nil)
+	issue, _, _ := jiraClient.Issue.Get(context.Background(), "MESOS-3325", nil)
 
 	fmt.Printf("%s: %+v\n", issue.Key, issue.Fields.Summary)
 	fmt.Printf("Type: %s\n", issue.Fields.Type.Name)

--- a/cloud/examples/jql/main.go
+++ b/cloud/examples/jql/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"fmt"
 
 	jira "github.com/andygrunwald/go-jira/cloud"
@@ -13,7 +14,7 @@ func main() {
 
 	jql := "project = Mesos and type = Bug and Status NOT IN (Resolved)"
 	fmt.Printf("Usecase: Running a JQL query '%s'\n", jql)
-	issues, resp, err := jiraClient.Issue.Search(jql, nil)
+	issues, resp, err := jiraClient.Issue.Search(context.Background(), jql, nil)
 	if err != nil {
 		panic(err)
 	}
@@ -25,7 +26,7 @@ func main() {
 	// Running an empty JQL query to get all tickets
 	jql = ""
 	fmt.Printf("Usecase: Running an empty JQL query to get all tickets\n")
-	issues, resp, err = jiraClient.Issue.Search(jql, nil)
+	issues, resp, err = jiraClient.Issue.Search(context.Background(), jql, nil)
 	if err != nil {
 		panic(err)
 	}

--- a/cloud/examples/newclient/main.go
+++ b/cloud/examples/newclient/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"fmt"
 
 	jira "github.com/andygrunwald/go-jira/cloud"
@@ -8,7 +9,7 @@ import (
 
 func main() {
 	jiraClient, _ := jira.NewClient("https://issues.apache.org/jira/", nil)
-	issue, _, _ := jiraClient.Issue.Get("MESOS-3325", nil)
+	issue, _, _ := jiraClient.Issue.Get(context.Background(), "MESOS-3325", nil)
 
 	fmt.Printf("%s: %+v\n", issue.Key, issue.Fields.Summary)
 	fmt.Printf("Type: %s\n", issue.Fields.Type.Name)

--- a/cloud/examples/pagination/main.go
+++ b/cloud/examples/pagination/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"fmt"
 
 	jira "github.com/andygrunwald/go-jira/cloud"
@@ -19,7 +20,7 @@ func GetAllIssues(client *jira.Client, searchString string) ([]jira.Issue, error
 			StartAt:    last,
 		}
 
-		chunk, resp, err := client.Issue.Search(searchString, opt)
+		chunk, resp, err := client.Issue.Search(context.Background(), searchString, opt)
 		if err != nil {
 			return nil, err
 		}

--- a/cloud/examples/renderedfields/main.go
+++ b/cloud/examples/renderedfields/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"bufio"
+	"context"
 	"fmt"
 	"net/http"
 	"os"
@@ -52,7 +53,7 @@ func main() {
 	fmt.Printf("Targeting %s for issue %s\n", strings.TrimSpace(jiraURL), key)
 
 	options := &jira.GetQueryOptions{Expand: "renderedFields"}
-	u, _, err := client.Issue.Get(key, options)
+	u, _, err := client.Issue.Get(context.Background(), key, options)
 
 	if err != nil {
 		fmt.Printf("\n==> error: %v\n", err)

--- a/cloud/examples/searchpages/main.go
+++ b/cloud/examples/searchpages/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"bufio"
+	"context"
 	"fmt"
 	"log"
 	"os"
@@ -49,7 +50,7 @@ func main() {
 
 	// SearchPages will page through results and pass each issue to appendFunc
 	// In this example, we'll search for all the issues in the target project
-	err = client.Issue.SearchPages(fmt.Sprintf(`project=%s`, strings.TrimSpace(jiraPK)), nil, appendFunc)
+	err = client.Issue.SearchPages(context.Background(), fmt.Sprintf(`project=%s`, strings.TrimSpace(jiraPK)), nil, appendFunc)
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/cloud/issue.go
+++ b/cloud/issue.go
@@ -605,7 +605,7 @@ type RemoteLinkStatus struct {
 	Icon     *RemoteLinkIcon `json:"icon,omitempty" structs:"icon,omitempty"`
 }
 
-// GetWithContext returns a full representation of the issue for the given issue key.
+// Get returns a full representation of the issue for the given issue key.
 // Jira will attempt to identify the issue by the issueIdOrKey path parameter.
 // This can be an issue id, or an issue key.
 // If the issue cannot be found via an exact match, Jira will also look for the issue in a case-insensitive way, or by looking to see if the issue was moved.
@@ -613,7 +613,7 @@ type RemoteLinkStatus struct {
 // # The given options will be appended to the query string
 //
 // Jira API docs: https://docs.atlassian.com/jira/REST/latest/#api/2/issue-getIssue
-func (s *IssueService) GetWithContext(ctx context.Context, issueID string, options *GetQueryOptions) (*Issue, *Response, error) {
+func (s *IssueService) Get(ctx context.Context, issueID string, options *GetQueryOptions) (*Issue, *Response, error) {
 	apiEndpoint := fmt.Sprintf("rest/api/2/issue/%s", issueID)
 	req, err := s.client.NewRequest(ctx, "GET", apiEndpoint, nil)
 	if err != nil {
@@ -638,16 +638,11 @@ func (s *IssueService) GetWithContext(ctx context.Context, issueID string, optio
 	return issue, resp, nil
 }
 
-// Get wraps GetWithContext using the background context.
-func (s *IssueService) Get(issueID string, options *GetQueryOptions) (*Issue, *Response, error) {
-	return s.GetWithContext(context.Background(), issueID, options)
-}
-
-// DownloadAttachmentWithContext returns a Response of an attachment for a given attachmentID.
+// DownloadAttachment returns a Response of an attachment for a given attachmentID.
 // The attachment is in the Response.Body of the response.
 // This is an io.ReadCloser.
 // Caller must close resp.Body.
-func (s *IssueService) DownloadAttachmentWithContext(ctx context.Context, attachmentID string) (*Response, error) {
+func (s *IssueService) DownloadAttachment(ctx context.Context, attachmentID string) (*Response, error) {
 	apiEndpoint := fmt.Sprintf("secure/attachment/%s/", attachmentID)
 	req, err := s.client.NewRequest(ctx, "GET", apiEndpoint, nil)
 	if err != nil {
@@ -663,14 +658,8 @@ func (s *IssueService) DownloadAttachmentWithContext(ctx context.Context, attach
 	return resp, nil
 }
 
-// DownloadAttachment wraps DownloadAttachmentWithContext using the background context.
-// Caller must close resp.Body
-func (s *IssueService) DownloadAttachment(attachmentID string) (*Response, error) {
-	return s.DownloadAttachmentWithContext(context.Background(), attachmentID)
-}
-
-// PostAttachmentWithContext uploads r (io.Reader) as an attachment to a given issueID
-func (s *IssueService) PostAttachmentWithContext(ctx context.Context, issueID string, r io.Reader, attachmentName string) (*[]Attachment, *Response, error) {
+// PostAttachment uploads r (io.Reader) as an attachment to a given issueID
+func (s *IssueService) PostAttachment(ctx context.Context, issueID string, r io.Reader, attachmentName string) (*[]Attachment, *Response, error) {
 	apiEndpoint := fmt.Sprintf("rest/api/2/issue/%s/attachments", issueID)
 
 	b := new(bytes.Buffer)
@@ -707,14 +696,9 @@ func (s *IssueService) PostAttachmentWithContext(ctx context.Context, issueID st
 	return attachment, resp, nil
 }
 
-// PostAttachment wraps PostAttachmentWithContext using the background context.
-func (s *IssueService) PostAttachment(issueID string, r io.Reader, attachmentName string) (*[]Attachment, *Response, error) {
-	return s.PostAttachmentWithContext(context.Background(), issueID, r, attachmentName)
-}
-
-// DeleteAttachmentWithContext deletes an attachment of a given attachmentID
+// DeleteAttachment deletes an attachment of a given attachmentID
 // Caller must close resp.Body
-func (s *IssueService) DeleteAttachmentWithContext(ctx context.Context, attachmentID string) (*Response, error) {
+func (s *IssueService) DeleteAttachment(ctx context.Context, attachmentID string) (*Response, error) {
 	apiEndpoint := fmt.Sprintf("rest/api/2/attachment/%s", attachmentID)
 
 	req, err := s.client.NewRequest(ctx, "DELETE", apiEndpoint, nil)
@@ -731,15 +715,9 @@ func (s *IssueService) DeleteAttachmentWithContext(ctx context.Context, attachme
 	return resp, nil
 }
 
-// DeleteAttachment wraps DeleteAttachmentWithContext using the background context.
+// DeleteLink deletes a link of a given linkID
 // Caller must close resp.Body
-func (s *IssueService) DeleteAttachment(attachmentID string) (*Response, error) {
-	return s.DeleteAttachmentWithContext(context.Background(), attachmentID)
-}
-
-// DeleteLinkWithContext deletes a link of a given linkID
-// Caller must close resp.Body
-func (s *IssueService) DeleteLinkWithContext(ctx context.Context, linkID string) (*Response, error) {
+func (s *IssueService) DeleteLink(ctx context.Context, linkID string) (*Response, error) {
 	apiEndpoint := fmt.Sprintf("rest/api/2/issueLink/%s", linkID)
 
 	req, err := s.client.NewRequest(ctx, "DELETE", apiEndpoint, nil)
@@ -756,17 +734,11 @@ func (s *IssueService) DeleteLinkWithContext(ctx context.Context, linkID string)
 	return resp, nil
 }
 
-// DeleteLink wraps DeleteLinkWithContext using the background context.
-// Caller must close resp.Body
-func (s *IssueService) DeleteLink(linkID string) (*Response, error) {
-	return s.DeleteLinkWithContext(context.Background(), linkID)
-}
-
-// GetWorklogsWithContext gets all the worklogs for an issue.
+// GetWorklogs gets all the worklogs for an issue.
 // This method is especially important if you need to read all the worklogs, not just the first page.
 //
 // https://docs.atlassian.com/jira/REST/cloud/#api/2/issue/{issueIdOrKey}/worklog-getIssueWorklog
-func (s *IssueService) GetWorklogsWithContext(ctx context.Context, issueID string, options ...func(*http.Request) error) (*Worklog, *Response, error) {
+func (s *IssueService) GetWorklogs(ctx context.Context, issueID string, options ...func(*http.Request) error) (*Worklog, *Response, error) {
 	apiEndpoint := fmt.Sprintf("rest/api/2/issue/%s/worklog", issueID)
 
 	req, err := s.client.NewRequest(ctx, "GET", apiEndpoint, nil)
@@ -786,11 +758,6 @@ func (s *IssueService) GetWorklogsWithContext(ctx context.Context, issueID strin
 	return v, resp, err
 }
 
-// GetWorklogs wraps GetWorklogsWithContext using the background context.
-func (s *IssueService) GetWorklogs(issueID string, options ...func(*http.Request) error) (*Worklog, *Response, error) {
-	return s.GetWorklogsWithContext(context.Background(), issueID, options...)
-}
-
 // Applies query options to http request.
 // This helper is meant to be used with all "QueryOptions" structs.
 func WithQueryOptions(options interface{}) func(*http.Request) error {
@@ -807,12 +774,12 @@ func WithQueryOptions(options interface{}) func(*http.Request) error {
 	}
 }
 
-// CreateWithContext creates an issue or a sub-task from a JSON representation.
+// Create creates an issue or a sub-task from a JSON representation.
 // Creating a sub-task is similar to creating a regular issue, with two important differences:
 // The issueType field must correspond to a sub-task issue type and you must provide a parent field in the issue create request containing the id or key of the parent issue.
 //
 // Jira API docs: https://docs.atlassian.com/jira/REST/latest/#api/2/issue-createIssues
-func (s *IssueService) CreateWithContext(ctx context.Context, issue *Issue) (*Issue, *Response, error) {
+func (s *IssueService) Create(ctx context.Context, issue *Issue) (*Issue, *Response, error) {
 	apiEndpoint := "rest/api/2/issue"
 	req, err := s.client.NewRequest(ctx, "POST", apiEndpoint, issue)
 	if err != nil {
@@ -837,17 +804,12 @@ func (s *IssueService) CreateWithContext(ctx context.Context, issue *Issue) (*Is
 	return responseIssue, resp, nil
 }
 
-// Create wraps CreateWithContext using the background context.
-func (s *IssueService) Create(issue *Issue) (*Issue, *Response, error) {
-	return s.CreateWithContext(context.Background(), issue)
-}
-
-// UpdateWithOptionsWithContext updates an issue from a JSON representation,
+// UpdateWithOptions updates an issue from a JSON representation,
 // while also specifying query params. The issue is found by key.
 //
 // Jira API docs: https://docs.atlassian.com/jira/REST/cloud/#api/2/issue-editIssue
 // Caller must close resp.Body
-func (s *IssueService) UpdateWithOptionsWithContext(ctx context.Context, issue *Issue, opts *UpdateQueryOptions) (*Issue, *Response, error) {
+func (s *IssueService) UpdateWithOptions(ctx context.Context, issue *Issue, opts *UpdateQueryOptions) (*Issue, *Response, error) {
 	apiEndpoint := fmt.Sprintf("rest/api/2/issue/%v", issue.Key)
 	url, err := addOptions(apiEndpoint, opts)
 	if err != nil {
@@ -869,29 +831,18 @@ func (s *IssueService) UpdateWithOptionsWithContext(ctx context.Context, issue *
 	return &ret, resp, nil
 }
 
-// UpdateWithOptions wraps UpdateWithOptionsWithContext using the background context.
-// Caller must close resp.Body
-func (s *IssueService) UpdateWithOptions(issue *Issue, opts *UpdateQueryOptions) (*Issue, *Response, error) {
-	return s.UpdateWithOptionsWithContext(context.Background(), issue, opts)
-}
-
-// UpdateWithContext updates an issue from a JSON representation. The issue is found by key.
+// Update updates an issue from a JSON representation. The issue is found by key.
 //
 // Jira API docs: https://docs.atlassian.com/jira/REST/cloud/#api/2/issue-editIssue
-func (s *IssueService) UpdateWithContext(ctx context.Context, issue *Issue) (*Issue, *Response, error) {
-	return s.UpdateWithOptionsWithContext(ctx, issue, nil)
+func (s *IssueService) Update(ctx context.Context, issue *Issue) (*Issue, *Response, error) {
+	return s.UpdateWithOptions(ctx, issue, nil)
 }
 
-// Update wraps UpdateWithContext using the background context.
-func (s *IssueService) Update(issue *Issue) (*Issue, *Response, error) {
-	return s.UpdateWithContext(context.Background(), issue)
-}
-
-// UpdateIssueWithContext updates an issue from a JSON representation. The issue is found by key.
+// UpdateIssue updates an issue from a JSON representation. The issue is found by key.
 //
 // https://docs.atlassian.com/jira/REST/7.4.0/#api/2/issue-editIssue
 // Caller must close resp.Body
-func (s *IssueService) UpdateIssueWithContext(ctx context.Context, jiraID string, data map[string]interface{}) (*Response, error) {
+func (s *IssueService) UpdateIssue(ctx context.Context, jiraID string, data map[string]interface{}) (*Response, error) {
 	apiEndpoint := fmt.Sprintf("rest/api/2/issue/%v", jiraID)
 	req, err := s.client.NewRequest(ctx, "PUT", apiEndpoint, data)
 	if err != nil {
@@ -907,16 +858,10 @@ func (s *IssueService) UpdateIssueWithContext(ctx context.Context, jiraID string
 	return resp, nil
 }
 
-// UpdateIssue wraps UpdateIssueWithContext using the background context.
-// Caller must close resp.Body
-func (s *IssueService) UpdateIssue(jiraID string, data map[string]interface{}) (*Response, error) {
-	return s.UpdateIssueWithContext(context.Background(), jiraID, data)
-}
-
-// AddCommentWithContext adds a new comment to issueID.
+// AddComment adds a new comment to issueID.
 //
 // Jira API docs: https://docs.atlassian.com/jira/REST/latest/#api/2/issue-addComment
-func (s *IssueService) AddCommentWithContext(ctx context.Context, issueID string, comment *Comment) (*Comment, *Response, error) {
+func (s *IssueService) AddComment(ctx context.Context, issueID string, comment *Comment) (*Comment, *Response, error) {
 	apiEndpoint := fmt.Sprintf("rest/api/2/issue/%s/comment", issueID)
 	req, err := s.client.NewRequest(ctx, "POST", apiEndpoint, comment)
 	if err != nil {
@@ -933,15 +878,10 @@ func (s *IssueService) AddCommentWithContext(ctx context.Context, issueID string
 	return responseComment, resp, nil
 }
 
-// AddComment wraps AddCommentWithContext using the background context.
-func (s *IssueService) AddComment(issueID string, comment *Comment) (*Comment, *Response, error) {
-	return s.AddCommentWithContext(context.Background(), issueID, comment)
-}
-
-// UpdateCommentWithContext updates the body of a comment, identified by comment.ID, on the issueID.
+// UpdateComment updates the body of a comment, identified by comment.ID, on the issueID.
 //
 // Jira API docs: https://docs.atlassian.com/jira/REST/cloud/#api/2/issue/{issueIdOrKey}/comment-updateComment
-func (s *IssueService) UpdateCommentWithContext(ctx context.Context, issueID string, comment *Comment) (*Comment, *Response, error) {
+func (s *IssueService) UpdateComment(ctx context.Context, issueID string, comment *Comment) (*Comment, *Response, error) {
 	reqBody := struct {
 		Body string `json:"body"`
 	}{
@@ -962,15 +902,10 @@ func (s *IssueService) UpdateCommentWithContext(ctx context.Context, issueID str
 	return responseComment, resp, nil
 }
 
-// UpdateComment wraps UpdateCommentWithContext using the background context.
-func (s *IssueService) UpdateComment(issueID string, comment *Comment) (*Comment, *Response, error) {
-	return s.UpdateCommentWithContext(context.Background(), issueID, comment)
-}
-
-// DeleteCommentWithContext Deletes a comment from an issueID.
+// DeleteComment Deletes a comment from an issueID.
 //
 // Jira API docs: https://developer.atlassian.com/cloud/jira/platform/rest/v3/#api-api-3-issue-issueIdOrKey-comment-id-delete
-func (s *IssueService) DeleteCommentWithContext(ctx context.Context, issueID, commentID string) error {
+func (s *IssueService) DeleteComment(ctx context.Context, issueID, commentID string) error {
 	apiEndpoint := fmt.Sprintf("rest/api/2/issue/%s/comment/%s", issueID, commentID)
 	req, err := s.client.NewRequest(ctx, "DELETE", apiEndpoint, nil)
 	if err != nil {
@@ -987,15 +922,10 @@ func (s *IssueService) DeleteCommentWithContext(ctx context.Context, issueID, co
 	return nil
 }
 
-// DeleteComment wraps DeleteCommentWithContext using the background context.
-func (s *IssueService) DeleteComment(issueID, commentID string) error {
-	return s.DeleteCommentWithContext(context.Background(), issueID, commentID)
-}
-
-// AddWorklogRecordWithContext adds a new worklog record to issueID.
+// AddWorklogRecord adds a new worklog record to issueID.
 //
 // https://developer.atlassian.com/cloud/jira/platform/rest/#api-api-2-issue-issueIdOrKey-worklog-post
-func (s *IssueService) AddWorklogRecordWithContext(ctx context.Context, issueID string, record *WorklogRecord, options ...func(*http.Request) error) (*WorklogRecord, *Response, error) {
+func (s *IssueService) AddWorklogRecord(ctx context.Context, issueID string, record *WorklogRecord, options ...func(*http.Request) error) (*WorklogRecord, *Response, error) {
 	apiEndpoint := fmt.Sprintf("rest/api/2/issue/%s/worklog", issueID)
 	req, err := s.client.NewRequest(ctx, "POST", apiEndpoint, record)
 	if err != nil {
@@ -1019,15 +949,10 @@ func (s *IssueService) AddWorklogRecordWithContext(ctx context.Context, issueID 
 	return responseRecord, resp, nil
 }
 
-// AddWorklogRecord wraps AddWorklogRecordWithContext using the background context.
-func (s *IssueService) AddWorklogRecord(issueID string, record *WorklogRecord, options ...func(*http.Request) error) (*WorklogRecord, *Response, error) {
-	return s.AddWorklogRecordWithContext(context.Background(), issueID, record, options...)
-}
-
-// UpdateWorklogRecordWithContext updates a worklog record.
+// UpdateWorklogRecord updates a worklog record.
 //
 // https://docs.atlassian.com/software/jira/docs/api/REST/7.1.2/#api/2/issue-updateWorklog
-func (s *IssueService) UpdateWorklogRecordWithContext(ctx context.Context, issueID, worklogID string, record *WorklogRecord, options ...func(*http.Request) error) (*WorklogRecord, *Response, error) {
+func (s *IssueService) UpdateWorklogRecord(ctx context.Context, issueID, worklogID string, record *WorklogRecord, options ...func(*http.Request) error) (*WorklogRecord, *Response, error) {
 	apiEndpoint := fmt.Sprintf("rest/api/2/issue/%s/worklog/%s", issueID, worklogID)
 	req, err := s.client.NewRequest(ctx, "PUT", apiEndpoint, record)
 	if err != nil {
@@ -1051,16 +976,11 @@ func (s *IssueService) UpdateWorklogRecordWithContext(ctx context.Context, issue
 	return responseRecord, resp, nil
 }
 
-// UpdateWorklogRecord wraps UpdateWorklogRecordWithContext using the background context.
-func (s *IssueService) UpdateWorklogRecord(issueID, worklogID string, record *WorklogRecord, options ...func(*http.Request) error) (*WorklogRecord, *Response, error) {
-	return s.UpdateWorklogRecordWithContext(context.Background(), issueID, worklogID, record, options...)
-}
-
-// AddLinkWithContext adds a link between two issues.
+// AddLink adds a link between two issues.
 //
 // Jira API docs: https://docs.atlassian.com/jira/REST/latest/#api/2/issueLink
 // Caller must close resp.Body
-func (s *IssueService) AddLinkWithContext(ctx context.Context, issueLink *IssueLink) (*Response, error) {
+func (s *IssueService) AddLink(ctx context.Context, issueLink *IssueLink) (*Response, error) {
 	apiEndpoint := "rest/api/2/issueLink"
 	req, err := s.client.NewRequest(ctx, "POST", apiEndpoint, issueLink)
 	if err != nil {
@@ -1075,16 +995,10 @@ func (s *IssueService) AddLinkWithContext(ctx context.Context, issueLink *IssueL
 	return resp, err
 }
 
-// AddLink wraps AddLinkWithContext using the background context.
-// Caller must close resp.Body
-func (s *IssueService) AddLink(issueLink *IssueLink) (*Response, error) {
-	return s.AddLinkWithContext(context.Background(), issueLink)
-}
-
-// SearchWithContext will search for tickets according to the jql
+// Search will search for tickets according to the jql
 //
 // Jira API docs: https://developer.atlassian.com/jiradev/jira-apis/jira-rest-apis/jira-rest-api-tutorials/jira-rest-api-example-query-issues
-func (s *IssueService) SearchWithContext(ctx context.Context, jql string, options *SearchOptions) ([]Issue, *Response, error) {
+func (s *IssueService) Search(ctx context.Context, jql string, options *SearchOptions) ([]Issue, *Response, error) {
 	u := url.URL{
 		Path: "rest/api/2/search",
 	}
@@ -1126,15 +1040,10 @@ func (s *IssueService) SearchWithContext(ctx context.Context, jql string, option
 	return v.Issues, resp, err
 }
 
-// Search wraps SearchWithContext using the background context.
-func (s *IssueService) Search(jql string, options *SearchOptions) ([]Issue, *Response, error) {
-	return s.SearchWithContext(context.Background(), jql, options)
-}
-
-// SearchPagesWithContext will get issues from all pages in a search
+// SearchPages will get issues from all pages in a search
 //
 // Jira API docs: https://developer.atlassian.com/jiradev/jira-apis/jira-rest-apis/jira-rest-api-tutorials/jira-rest-api-example-query-issues
-func (s *IssueService) SearchPagesWithContext(ctx context.Context, jql string, options *SearchOptions, f func(Issue) error) error {
+func (s *IssueService) SearchPages(ctx context.Context, jql string, options *SearchOptions, f func(Issue) error) error {
 	if options == nil {
 		options = &SearchOptions{
 			StartAt:    0,
@@ -1146,7 +1055,7 @@ func (s *IssueService) SearchPagesWithContext(ctx context.Context, jql string, o
 		options.MaxResults = 50
 	}
 
-	issues, resp, err := s.SearchWithContext(ctx, jql, options)
+	issues, resp, err := s.Search(ctx, jql, options)
 	if err != nil {
 		return err
 	}
@@ -1168,20 +1077,15 @@ func (s *IssueService) SearchPagesWithContext(ctx context.Context, jql string, o
 		}
 
 		options.StartAt += resp.MaxResults
-		issues, resp, err = s.SearchWithContext(ctx, jql, options)
+		issues, resp, err = s.Search(ctx, jql, options)
 		if err != nil {
 			return err
 		}
 	}
 }
 
-// SearchPages wraps SearchPagesWithContext using the background context.
-func (s *IssueService) SearchPages(jql string, options *SearchOptions, f func(Issue) error) error {
-	return s.SearchPagesWithContext(context.Background(), jql, options, f)
-}
-
-// GetCustomFieldsWithContext returns a map of customfield_* keys with string values
-func (s *IssueService) GetCustomFieldsWithContext(ctx context.Context, issueID string) (CustomFields, *Response, error) {
+// GetCustomFields returns a map of customfield_* keys with string values
+func (s *IssueService) GetCustomFields(ctx context.Context, issueID string) (CustomFields, *Response, error) {
 	apiEndpoint := fmt.Sprintf("rest/api/2/issue/%s", issueID)
 	req, err := s.client.NewRequest(ctx, "GET", apiEndpoint, nil)
 	if err != nil {
@@ -1217,16 +1121,11 @@ func (s *IssueService) GetCustomFieldsWithContext(ctx context.Context, issueID s
 	return cf, resp, nil
 }
 
-// GetCustomFields wraps GetCustomFieldsWithContext using the background context.
-func (s *IssueService) GetCustomFields(issueID string) (CustomFields, *Response, error) {
-	return s.GetCustomFieldsWithContext(context.Background(), issueID)
-}
-
-// GetTransitionsWithContext gets a list of the transitions possible for this issue by the current user,
+// GetTransitions gets a list of the transitions possible for this issue by the current user,
 // along with fields that are required and their types.
 //
 // Jira API docs: https://docs.atlassian.com/jira/REST/latest/#api/2/issue-getTransitions
-func (s *IssueService) GetTransitionsWithContext(ctx context.Context, id string) ([]Transition, *Response, error) {
+func (s *IssueService) GetTransitions(ctx context.Context, id string) ([]Transition, *Response, error) {
 	apiEndpoint := fmt.Sprintf("rest/api/2/issue/%s/transitions?expand=transitions.fields", id)
 	req, err := s.client.NewRequest(ctx, "GET", apiEndpoint, nil)
 	if err != nil {
@@ -1241,35 +1140,25 @@ func (s *IssueService) GetTransitionsWithContext(ctx context.Context, id string)
 	return result.Transitions, resp, err
 }
 
-// GetTransitions wraps GetTransitionsWithContext using the background context.
-func (s *IssueService) GetTransitions(id string) ([]Transition, *Response, error) {
-	return s.GetTransitionsWithContext(context.Background(), id)
-}
-
-// DoTransitionWithContext performs a transition on an issue.
+// DoTransition performs a transition on an issue.
 // When performing the transition you can update or set other issue fields.
 //
 // Jira API docs: https://docs.atlassian.com/jira/REST/latest/#api/2/issue-doTransition
-func (s *IssueService) DoTransitionWithContext(ctx context.Context, ticketID, transitionID string) (*Response, error) {
+func (s *IssueService) DoTransition(ctx context.Context, ticketID, transitionID string) (*Response, error) {
 	payload := CreateTransitionPayload{
 		Transition: TransitionPayload{
 			ID: transitionID,
 		},
 	}
-	return s.DoTransitionWithPayloadWithContext(ctx, ticketID, payload)
+	return s.DoTransitionWithPayload(ctx, ticketID, payload)
 }
 
-// DoTransition wraps DoTransitionWithContext using the background context.
-func (s *IssueService) DoTransition(ticketID, transitionID string) (*Response, error) {
-	return s.DoTransitionWithContext(context.Background(), ticketID, transitionID)
-}
-
-// DoTransitionWithPayloadWithContext performs a transition on an issue using any payload.
+// DoTransitionWithPayload performs a transition on an issue using any payload.
 // When performing the transition you can update or set other issue fields.
 //
 // Jira API docs: https://docs.atlassian.com/jira/REST/latest/#api/2/issue-doTransition
 // Caller must close resp.Body
-func (s *IssueService) DoTransitionWithPayloadWithContext(ctx context.Context, ticketID, payload interface{}) (*Response, error) {
+func (s *IssueService) DoTransitionWithPayload(ctx context.Context, ticketID, payload interface{}) (*Response, error) {
 	apiEndpoint := fmt.Sprintf("rest/api/2/issue/%s/transitions", ticketID)
 
 	req, err := s.client.NewRequest(ctx, "POST", apiEndpoint, payload)
@@ -1283,12 +1172,6 @@ func (s *IssueService) DoTransitionWithPayloadWithContext(ctx context.Context, t
 	}
 
 	return resp, err
-}
-
-// DoTransitionWithPayload wraps DoTransitionWithPayloadWithContext using the background context.
-// Caller must close resp.Body
-func (s *IssueService) DoTransitionWithPayload(ticketID, payload interface{}) (*Response, error) {
-	return s.DoTransitionWithPayloadWithContext(context.Background(), ticketID, payload)
 }
 
 // InitIssueWithMetaAndFields returns Issue with with values from fieldsConfig properly set.
@@ -1372,9 +1255,9 @@ func InitIssueWithMetaAndFields(metaProject *MetaProject, metaIssuetype *MetaIss
 	return issue, nil
 }
 
-// DeleteWithContext will delete a specified issue.
+// Delete will delete a specified issue.
 // Caller must close resp.Body
-func (s *IssueService) DeleteWithContext(ctx context.Context, issueID string) (*Response, error) {
+func (s *IssueService) Delete(ctx context.Context, issueID string) (*Response, error) {
 	apiEndpoint := fmt.Sprintf("rest/api/2/issue/%s", issueID)
 
 	// to enable deletion of subtasks; without this, the request will fail if the issue has subtasks
@@ -1391,16 +1274,10 @@ func (s *IssueService) DeleteWithContext(ctx context.Context, issueID string) (*
 	return resp, err
 }
 
-// Delete wraps DeleteWithContext using the background context.
-// Caller must close resp.Body
-func (s *IssueService) Delete(issueID string) (*Response, error) {
-	return s.DeleteWithContext(context.Background(), issueID)
-}
-
-// GetWatchersWithContext wil return all the users watching/observing the given issue
+// GetWatchers wil return all the users watching/observing the given issue
 //
 // Jira API docs: https://docs.atlassian.com/software/jira/docs/api/REST/latest/#api/2/issue-getIssueWatchers
-func (s *IssueService) GetWatchersWithContext(ctx context.Context, issueID string) (*[]User, *Response, error) {
+func (s *IssueService) GetWatchers(ctx context.Context, issueID string) (*[]User, *Response, error) {
 	watchesAPIEndpoint := fmt.Sprintf("rest/api/2/issue/%s/watchers", issueID)
 
 	req, err := s.client.NewRequest(ctx, "GET", watchesAPIEndpoint, nil)
@@ -1429,16 +1306,11 @@ func (s *IssueService) GetWatchersWithContext(ctx context.Context, issueID strin
 	return &result, resp, nil
 }
 
-// GetWatchers wraps GetWatchersWithContext using the background context.
-func (s *IssueService) GetWatchers(issueID string) (*[]User, *Response, error) {
-	return s.GetWatchersWithContext(context.Background(), issueID)
-}
-
-// AddWatcherWithContext adds watcher to the given issue
+// AddWatcher adds watcher to the given issue
 //
 // Jira API docs: https://docs.atlassian.com/software/jira/docs/api/REST/latest/#api/2/issue-addWatcher
 // Caller must close resp.Body
-func (s *IssueService) AddWatcherWithContext(ctx context.Context, issueID string, userName string) (*Response, error) {
+func (s *IssueService) AddWatcher(ctx context.Context, issueID string, userName string) (*Response, error) {
 	apiEndPoint := fmt.Sprintf("rest/api/2/issue/%s/watchers", issueID)
 
 	req, err := s.client.NewRequest(ctx, "POST", apiEndPoint, userName)
@@ -1454,17 +1326,11 @@ func (s *IssueService) AddWatcherWithContext(ctx context.Context, issueID string
 	return resp, err
 }
 
-// AddWatcher wraps AddWatcherWithContext using the background context.
-// Caller must close resp.Body
-func (s *IssueService) AddWatcher(issueID string, userName string) (*Response, error) {
-	return s.AddWatcherWithContext(context.Background(), issueID, userName)
-}
-
-// RemoveWatcherWithContext removes given user from given issue
+// RemoveWatcher removes given user from given issue
 //
 // Jira API docs: https://docs.atlassian.com/software/jira/docs/api/REST/latest/#api/2/issue-removeWatcher
 // Caller must close resp.Body
-func (s *IssueService) RemoveWatcherWithContext(ctx context.Context, issueID string, userName string) (*Response, error) {
+func (s *IssueService) RemoveWatcher(ctx context.Context, issueID string, userName string) (*Response, error) {
 	apiEndPoint := fmt.Sprintf("rest/api/2/issue/%s/watchers", issueID)
 
 	req, err := s.client.NewRequest(ctx, "DELETE", apiEndPoint, userName)
@@ -1480,17 +1346,11 @@ func (s *IssueService) RemoveWatcherWithContext(ctx context.Context, issueID str
 	return resp, err
 }
 
-// RemoveWatcher wraps RemoveWatcherWithContext using the background context.
-// Caller must close resp.Body
-func (s *IssueService) RemoveWatcher(issueID string, userName string) (*Response, error) {
-	return s.RemoveWatcherWithContext(context.Background(), issueID, userName)
-}
-
-// UpdateAssigneeWithContext updates the user assigned to work on the given issue
+// UpdateAssignee updates the user assigned to work on the given issue
 //
 // Jira API docs: https://docs.atlassian.com/software/jira/docs/api/REST/7.10.2/#api/2/issue-assign
 // Caller must close resp.Body
-func (s *IssueService) UpdateAssigneeWithContext(ctx context.Context, issueID string, assignee *User) (*Response, error) {
+func (s *IssueService) UpdateAssignee(ctx context.Context, issueID string, assignee *User) (*Response, error) {
 	apiEndPoint := fmt.Sprintf("rest/api/2/issue/%s/assignee", issueID)
 
 	req, err := s.client.NewRequest(ctx, "PUT", apiEndPoint, assignee)
@@ -1506,12 +1366,6 @@ func (s *IssueService) UpdateAssigneeWithContext(ctx context.Context, issueID st
 	return resp, err
 }
 
-// UpdateAssignee wraps UpdateAssigneeWithContext using the background context.
-// Caller must close resp.Body
-func (s *IssueService) UpdateAssignee(issueID string, assignee *User) (*Response, error) {
-	return s.UpdateAssigneeWithContext(context.Background(), issueID, assignee)
-}
-
 func (c ChangelogHistory) CreatedTime() (time.Time, error) {
 	var t time.Time
 	// Ignore null
@@ -1522,10 +1376,10 @@ func (c ChangelogHistory) CreatedTime() (time.Time, error) {
 	return t, err
 }
 
-// GetRemoteLinksWithContext gets remote issue links on the issue.
+// GetRemoteLinks gets remote issue links on the issue.
 //
 // Jira API docs: https://docs.atlassian.com/jira/REST/latest/#api/2/issue-getRemoteIssueLinks
-func (s *IssueService) GetRemoteLinksWithContext(ctx context.Context, id string) (*[]RemoteLink, *Response, error) {
+func (s *IssueService) GetRemoteLinks(ctx context.Context, id string) (*[]RemoteLink, *Response, error) {
 	apiEndpoint := fmt.Sprintf("rest/api/2/issue/%s/remotelink", id)
 	req, err := s.client.NewRequest(ctx, "GET", apiEndpoint, nil)
 	if err != nil {
@@ -1540,16 +1394,10 @@ func (s *IssueService) GetRemoteLinksWithContext(ctx context.Context, id string)
 	return result, resp, err
 }
 
-// GetRemoteLinks wraps GetRemoteLinksWithContext using the background context.
-// Caller must close resp.Body
-func (s *IssueService) GetRemoteLinks(id string) (*[]RemoteLink, *Response, error) {
-	return s.GetRemoteLinksWithContext(context.Background(), id)
-}
-
-// AddRemoteLinkWithContext adds a remote link to issueID.
+// AddRemoteLink adds a remote link to issueID.
 //
 // Jira API docs: https://developer.atlassian.com/cloud/jira/platform/rest/v2/#api-rest-api-2-issue-issueIdOrKey-remotelink-post
-func (s *IssueService) AddRemoteLinkWithContext(ctx context.Context, issueID string, remotelink *RemoteLink) (*RemoteLink, *Response, error) {
+func (s *IssueService) AddRemoteLink(ctx context.Context, issueID string, remotelink *RemoteLink) (*RemoteLink, *Response, error) {
 	apiEndpoint := fmt.Sprintf("rest/api/2/issue/%s/remotelink", issueID)
 	req, err := s.client.NewRequest(ctx, "POST", apiEndpoint, remotelink)
 	if err != nil {
@@ -1566,15 +1414,10 @@ func (s *IssueService) AddRemoteLinkWithContext(ctx context.Context, issueID str
 	return responseRemotelink, resp, nil
 }
 
-// AddRemoteLink wraps AddRemoteLinkWithContext using the background context.
-func (s *IssueService) AddRemoteLink(issueID string, remotelink *RemoteLink) (*RemoteLink, *Response, error) {
-	return s.AddRemoteLinkWithContext(context.Background(), issueID, remotelink)
-}
-
-// UpdateRemoteLinkWithContext updates a remote issue link by linkID.
+// UpdateRemoteLink updates a remote issue link by linkID.
 //
 // Jira API docs: https://developer.atlassian.com/cloud/jira/platform/rest/v2/api-group-issue-remote-links/#api-rest-api-2-issue-issueidorkey-remotelink-linkid-put
-func (s *IssueService) UpdateRemoteLinkWithContext(ctx context.Context, issueID string, linkID int, remotelink *RemoteLink) (*Response, error) {
+func (s *IssueService) UpdateRemoteLink(ctx context.Context, issueID string, linkID int, remotelink *RemoteLink) (*Response, error) {
 	apiEndpoint := fmt.Sprintf("rest/api/2/issue/%s/remotelink/%d", issueID, linkID)
 	req, err := s.client.NewRequest(ctx, "PUT", apiEndpoint, remotelink)
 	if err != nil {
@@ -1588,9 +1431,4 @@ func (s *IssueService) UpdateRemoteLinkWithContext(ctx context.Context, issueID 
 	}
 
 	return resp, nil
-}
-
-// UpdateRemoteLink wraps UpdateRemoteLinkWithContext using the background context.
-func (s *IssueService) UpdateRemoteLink(issueID string, linkID int, remotelink *RemoteLink) (*Response, error) {
-	return s.UpdateRemoteLinkWithContext(context.Background(), issueID, linkID, remotelink)
 }

--- a/cloud/issue_test.go
+++ b/cloud/issue_test.go
@@ -1,6 +1,7 @@
 package cloud
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -25,7 +26,7 @@ func TestIssueService_Get_Success(t *testing.T) {
 		fmt.Fprint(w, `{"expand":"renderedFields,names,schema,transitions,operations,editmeta,changelog,versionedRepresentations","id":"10002","self":"http://www.example.com/jira/rest/api/2/issue/10002","key":"EX-1","fields":{"watcher":{"self":"http://www.example.com/jira/rest/api/2/issue/EX-1/watchers","isWatching":false,"watchCount":1,"watchers":[{"self":"http://www.example.com/jira/rest/api/2/user?username=fred","name":"fred","displayName":"Fred F. User","active":false}]},"attachment":[{"self":"http://www.example.com/jira/rest/api/2.0/attachments/10000","filename":"picture.jpg","author":{"self":"http://www.example.com/jira/rest/api/2/user?username=fred","name":"fred","avatarUrls":{"48x48":"http://www.example.com/jira/secure/useravatar?size=large&ownerId=fred","24x24":"http://www.example.com/jira/secure/useravatar?size=small&ownerId=fred","16x16":"http://www.example.com/jira/secure/useravatar?size=xsmall&ownerId=fred","32x32":"http://www.example.com/jira/secure/useravatar?size=medium&ownerId=fred"},"displayName":"Fred F. User","active":false},"created":"2016-03-16T04:22:37.461+0000","size":23123,"mimeType":"image/jpeg","content":"http://www.example.com/jira/attachments/10000","thumbnail":"http://www.example.com/jira/secure/thumbnail/10000"}],"sub-tasks":[{"id":"10000","type":{"id":"10000","name":"","inward":"Parent","outward":"Sub-task"},"outwardIssue":{"id":"10003","key":"EX-2","self":"http://www.example.com/jira/rest/api/2/issue/EX-2","fields":{"status":{"iconUrl":"http://www.example.com/jira//images/icons/statuses/open.png","name":"Open"}}}}],"description":"example bug report","project":{"self":"http://www.example.com/jira/rest/api/2/project/EX","id":"10000","key":"EX","name":"Example","avatarUrls":{"48x48":"http://www.example.com/jira/secure/projectavatar?size=large&pid=10000","24x24":"http://www.example.com/jira/secure/projectavatar?size=small&pid=10000","16x16":"http://www.example.com/jira/secure/projectavatar?size=xsmall&pid=10000","32x32":"http://www.example.com/jira/secure/projectavatar?size=medium&pid=10000"},"projectCategory":{"self":"http://www.example.com/jira/rest/api/2/projectCategory/10000","id":"10000","name":"FIRST","description":"First Project Category"}},"comment":{"comments":[{"self":"http://www.example.com/jira/rest/api/2/issue/10010/comment/10000","id":"10000","author":{"self":"http://www.example.com/jira/rest/api/2/user?username=fred","name":"fred","displayName":"Fred F. User","active":false},"body":"Lorem ipsum dolor sit amet, consectetur adipiscing elit. Pellentesque eget venenatis elit. Duis eu justo eget augue iaculis fermentum. Sed semper quam laoreet nisi egestas at posuere augue semper.","updateAuthor":{"self":"http://www.example.com/jira/rest/api/2/user?username=fred","name":"fred","displayName":"Fred F. User","active":false},"created":"2016-03-16T04:22:37.356+0000","updated":"2016-03-16T04:22:37.356+0000","visibility":{"type":"role","value":"Administrators"}}]},"issuelinks":[{"id":"10001","type":{"id":"10000","name":"Dependent","inward":"depends on","outward":"is depended by"},"outwardIssue":{"id":"10004L","key":"PRJ-2","self":"http://www.example.com/jira/rest/api/2/issue/PRJ-2","fields":{"status":{"iconUrl":"http://www.example.com/jira//images/icons/statuses/open.png","name":"Open"}}}},{"id":"10002","type":{"id":"10000","name":"Dependent","inward":"depends on","outward":"is depended by"},"inwardIssue":{"id":"10004","key":"PRJ-3","self":"http://www.example.com/jira/rest/api/2/issue/PRJ-3","fields":{"status":{"iconUrl":"http://www.example.com/jira//images/icons/statuses/open.png","name":"Open"}}}}],"worklog":{"worklogs":[{"self":"http://www.example.com/jira/rest/api/2/issue/10010/worklog/10000","author":{"self":"http://www.example.com/jira/rest/api/2/user?username=fred","name":"fred","displayName":"Fred F. User","active":false},"updateAuthor":{"self":"http://www.example.com/jira/rest/api/2/user?username=fred","name":"fred","displayName":"Fred F. User","active":false},"comment":"I did some work here.","updated":"2016-03-16T04:22:37.471+0000","visibility":{"type":"group","value":"jira-developers"},"started":"2016-03-16T04:22:37.471+0000","timeSpent":"3h 20m","timeSpentSeconds":12000,"id":"100028","issueId":"10002"}]},"updated":"2016-04-06T02:36:53.594-0700","duedate":"2018-01-19","timetracking":{"originalEstimate":"10m","remainingEstimate":"3m","timeSpent":"6m","originalEstimateSeconds":600,"remainingEstimateSeconds":200,"timeSpentSeconds":400}},"names":{"watcher":"watcher","attachment":"attachment","sub-tasks":"sub-tasks","description":"description","project":"project","comment":"comment","issuelinks":"issuelinks","worklog":"worklog","updated":"updated","timetracking":"timetracking"},"schema":{}}`)
 	})
 
-	issue, _, err := testClient.Issue.Get("10002", nil)
+	issue, _, err := testClient.Issue.Get(context.Background(), "10002", nil)
 	if issue == nil {
 		t.Error("Expected issue. Issue is nil")
 	}
@@ -47,7 +48,7 @@ func TestIssueService_Get_WithQuerySuccess(t *testing.T) {
 	opt := &GetQueryOptions{
 		Expand: "foo",
 	}
-	issue, _, err := testClient.Issue.Get("10002", opt)
+	issue, _, err := testClient.Issue.Get(context.Background(), "10002", opt)
 	if issue == nil {
 		t.Error("Expected issue. Issue is nil")
 	}
@@ -72,7 +73,7 @@ func TestIssueService_Create(t *testing.T) {
 			Description: "example bug report",
 		},
 	}
-	issue, _, err := testClient.Issue.Create(i)
+	issue, _, err := testClient.Issue.Create(context.Background(), i)
 	if issue == nil {
 		t.Error("Expected issue. Issue is nil")
 	}
@@ -98,7 +99,7 @@ func TestIssueService_CreateThenGet(t *testing.T) {
 			Created:     Time(time.Now()),
 		},
 	}
-	issue, _, err := testClient.Issue.Create(i)
+	issue, _, err := testClient.Issue.Create(context.Background(), i)
 	if issue == nil {
 		t.Error("Expected issue. Issue is nil")
 	}
@@ -120,7 +121,7 @@ func TestIssueService_CreateThenGet(t *testing.T) {
 		}
 	})
 
-	issue2, _, err := testClient.Issue.Get("10002", nil)
+	issue2, _, err := testClient.Issue.Get(context.Background(), "10002", nil)
 	if issue2 == nil {
 		t.Error("Expected issue. Issue is nil")
 	}
@@ -145,7 +146,7 @@ func TestIssueService_Update(t *testing.T) {
 			Description: "example bug report",
 		},
 	}
-	issue, _, err := testClient.Issue.Update(i)
+	issue, _, err := testClient.Issue.Update(context.Background(), i)
 	if issue == nil {
 		t.Error("Expected issue. Issue is nil")
 	}
@@ -167,7 +168,7 @@ func TestIssueService_UpdateIssue(t *testing.T) {
 	i := make(map[string]interface{})
 	fields := make(map[string]interface{})
 	i["fields"] = fields
-	resp, err := testClient.Issue.UpdateIssue(jID, i)
+	resp, err := testClient.Issue.UpdateIssue(context.Background(), jID, i)
 	if resp == nil {
 		t.Error("Expected resp. resp is nil")
 	}
@@ -195,7 +196,7 @@ func TestIssueService_AddComment(t *testing.T) {
 			Value: "Administrators",
 		},
 	}
-	comment, _, err := testClient.Issue.AddComment("10000", c)
+	comment, _, err := testClient.Issue.AddComment(context.Background(), "10000", c)
 	if comment == nil {
 		t.Error("Expected Comment. Comment is nil")
 	}
@@ -223,7 +224,7 @@ func TestIssueService_UpdateComment(t *testing.T) {
 			Value: "Administrators",
 		},
 	}
-	comment, _, err := testClient.Issue.UpdateComment("10000", c)
+	comment, _, err := testClient.Issue.UpdateComment(context.Background(), "10000", c)
 	if comment == nil {
 		t.Error("Expected Comment. Comment is nil")
 	}
@@ -243,7 +244,7 @@ func TestIssueService_DeleteComment(t *testing.T) {
 		fmt.Fprint(w, `{}`)
 	})
 
-	err := testClient.Issue.DeleteComment("10000", "10001")
+	err := testClient.Issue.DeleteComment(context.Background(), "10000", "10001")
 	if err != nil {
 		t.Errorf("Error given: %s", err)
 	}
@@ -262,7 +263,7 @@ func TestIssueService_AddWorklogRecord(t *testing.T) {
 	r := &WorklogRecord{
 		TimeSpent: "1h",
 	}
-	record, _, err := testClient.Issue.AddWorklogRecord("10000", r)
+	record, _, err := testClient.Issue.AddWorklogRecord(context.Background(), "10000", r)
 	if record == nil {
 		t.Error("Expected Record. Record is nil")
 	}
@@ -284,7 +285,7 @@ func TestIssueService_UpdateWorklogRecord(t *testing.T) {
 	r := &WorklogRecord{
 		TimeSpent: "1h",
 	}
-	record, _, err := testClient.Issue.UpdateWorklogRecord("10000", "1", r)
+	record, _, err := testClient.Issue.UpdateWorklogRecord(context.Background(), "10000", "1", r)
 	if record == nil {
 		t.Error("Expected Record. Record is nil")
 	}
@@ -321,7 +322,7 @@ func TestIssueService_AddLink(t *testing.T) {
 			},
 		},
 	}
-	resp, err := testClient.Issue.AddLink(il)
+	resp, err := testClient.Issue.AddLink(context.Background(), il)
 	if err != nil {
 		t.Errorf("Error given: %s", err)
 	}
@@ -344,7 +345,7 @@ func TestIssueService_Get_Fields(t *testing.T) {
 		fmt.Fprint(w, `{"expand":"renderedFields,names,schema,transitions,operations,editmeta,changelog,versionedRepresentations","id":"10002","self":"http://www.example.com/jira/rest/api/2/issue/10002","key":"EX-1","fields":{"labels":["test"],"watcher":{"self":"http://www.example.com/jira/rest/api/2/issue/EX-1/watchers","isWatching":false,"watchCount":1,"watchers":[{"self":"http://www.example.com/jira/rest/api/2/user?username=fred","name":"fred","displayName":"Fred F. User","active":false}]},"epic": {"id": 19415,"key": "EPIC-77","self": "https://example.atlassian.net/rest/agile/1.0/epic/19415","name": "Epic Name","summary": "Do it","color": {"key": "color_11"},"done": false},"attachment":[{"self":"http://www.example.com/jira/rest/api/2.0/attachments/10000","filename":"picture.jpg","author":{"self":"http://www.example.com/jira/rest/api/2/user?username=fred","name":"fred","avatarUrls":{"48x48":"http://www.example.com/jira/secure/useravatar?size=large&ownerId=fred","24x24":"http://www.example.com/jira/secure/useravatar?size=small&ownerId=fred","16x16":"http://www.example.com/jira/secure/useravatar?size=xsmall&ownerId=fred","32x32":"http://www.example.com/jira/secure/useravatar?size=medium&ownerId=fred"},"displayName":"Fred F. User","active":false},"created":"2016-03-16T04:22:37.461+0000","size":23123,"mimeType":"image/jpeg","content":"http://www.example.com/jira/attachments/10000","thumbnail":"http://www.example.com/jira/secure/thumbnail/10000"}],"sub-tasks":[{"id":"10000","type":{"id":"10000","name":"","inward":"Parent","outward":"Sub-task"},"outwardIssue":{"id":"10003","key":"EX-2","self":"http://www.example.com/jira/rest/api/2/issue/EX-2","fields":{"status":{"iconUrl":"http://www.example.com/jira//images/icons/statuses/open.png","name":"Open"}}}}],"description":"example bug report","project":{"self":"http://www.example.com/jira/rest/api/2/project/EX","id":"10000","key":"EX","name":"Example","avatarUrls":{"48x48":"http://www.example.com/jira/secure/projectavatar?size=large&pid=10000","24x24":"http://www.example.com/jira/secure/projectavatar?size=small&pid=10000","16x16":"http://www.example.com/jira/secure/projectavatar?size=xsmall&pid=10000","32x32":"http://www.example.com/jira/secure/projectavatar?size=medium&pid=10000"},"projectCategory":{"self":"http://www.example.com/jira/rest/api/2/projectCategory/10000","id":"10000","name":"FIRST","description":"First Project Category"}},"comment":{"comments":[{"self":"http://www.example.com/jira/rest/api/2/issue/10010/comment/10000","id":"10000","author":{"self":"http://www.example.com/jira/rest/api/2/user?username=fred","name":"fred","displayName":"Fred F. User","active":false},"body":"Lorem ipsum dolor sit amet, consectetur adipiscing elit. Pellentesque eget venenatis elit. Duis eu justo eget augue iaculis fermentum. Sed semper quam laoreet nisi egestas at posuere augue semper.","updateAuthor":{"self":"http://www.example.com/jira/rest/api/2/user?username=fred","name":"fred","displayName":"Fred F. User","active":false},"created":"2016-03-16T04:22:37.356+0000","updated":"2016-03-16T04:22:37.356+0000","visibility":{"type":"role","value":"Administrators"}}]},"issuelinks":[{"id":"10001","type":{"id":"10000","name":"Dependent","inward":"depends on","outward":"is depended by"},"outwardIssue":{"id":"10004L","key":"PRJ-2","self":"http://www.example.com/jira/rest/api/2/issue/PRJ-2","fields":{"status":{"iconUrl":"http://www.example.com/jira//images/icons/statuses/open.png","name":"Open"}}}},{"id":"10002","type":{"id":"10000","name":"Dependent","inward":"depends on","outward":"is depended by"},"inwardIssue":{"id":"10004","key":"PRJ-3","self":"http://www.example.com/jira/rest/api/2/issue/PRJ-3","fields":{"status":{"iconUrl":"http://www.example.com/jira//images/icons/statuses/open.png","name":"Open"}}}}],"worklog":{"worklogs":[{"self":"http://www.example.com/jira/rest/api/2/issue/10010/worklog/10000","author":{"self":"http://www.example.com/jira/rest/api/2/user?username=fred","name":"fred","displayName":"Fred F. User","active":false},"updateAuthor":{"self":"http://www.example.com/jira/rest/api/2/user?username=fred","name":"fred","displayName":"Fred F. User","active":false},"comment":"I did some work here.","updated":"2016-03-16T04:22:37.471+0000","visibility":{"type":"group","value":"jira-developers"},"started":"2016-03-16T04:22:37.471+0000","timeSpent":"3h 20m","timeSpentSeconds":12000,"id":"100028","issueId":"10002"}]},"updated":"2016-04-06T02:36:53.594-0700","duedate":"2018-01-19","timetracking":{"originalEstimate":"10m","remainingEstimate":"3m","timeSpent":"6m","originalEstimateSeconds":600,"remainingEstimateSeconds":200,"timeSpentSeconds":400}},"names":{"watcher":"watcher","attachment":"attachment","sub-tasks":"sub-tasks","description":"description","project":"project","comment":"comment","issuelinks":"issuelinks","worklog":"worklog","updated":"updated","timetracking":"timetracking"},"schema":{}}`)
 	})
 
-	issue, _, err := testClient.Issue.Get("10002", nil)
+	issue, _, err := testClient.Issue.Get(context.Background(), "10002", nil)
 	if err != nil {
 		t.Errorf("Error given: %s", err)
 	}
@@ -374,7 +375,7 @@ func TestIssueService_Get_RenderedFields(t *testing.T) {
 		fmt.Fprint(w, `{"expand":"renderedFields,names,schema,transitions,operations,editmeta,changelog,versionedRepresentations","id":"10002","self":"http://www.example.com/jira/rest/api/2/issue/10002","key":"EX-1","fields":{"labels":["test"],"watcher":{"self":"http://www.example.com/jira/rest/api/2/issue/EX-1/watchers","isWatching":false,"watchCount":1,"watchers":[{"self":"http://www.example.com/jira/rest/api/2/user?username=fred","name":"fred","displayName":"Fred F. User","active":false}]},"epic": {"id": 19415,"key": "EPIC-77","self": "https://example.atlassian.net/rest/agile/1.0/epic/19415","name": "Epic Name","summary": "Do it","color": {"key": "color_11"},"done": false},"attachment":[{"self":"http://www.example.com/jira/rest/api/2.0/attachments/10000","filename":"picture.jpg","author":{"self":"http://www.example.com/jira/rest/api/2/user?username=fred","name":"fred","avatarUrls":{"48x48":"http://www.example.com/jira/secure/useravatar?size=large&ownerId=fred","24x24":"http://www.example.com/jira/secure/useravatar?size=small&ownerId=fred","16x16":"http://www.example.com/jira/secure/useravatar?size=xsmall&ownerId=fred","32x32":"http://www.example.com/jira/secure/useravatar?size=medium&ownerId=fred"},"displayName":"Fred F. User","active":false},"created":"2016-03-16T04:22:37.461+0000","size":23123,"mimeType":"image/jpeg","content":"http://www.example.com/jira/attachments/10000","thumbnail":"http://www.example.com/jira/secure/thumbnail/10000"}],"sub-tasks":[{"id":"10000","type":{"id":"10000","name":"","inward":"Parent","outward":"Sub-task"},"outwardIssue":{"id":"10003","key":"EX-2","self":"http://www.example.com/jira/rest/api/2/issue/EX-2","fields":{"status":{"iconUrl":"http://www.example.com/jira//images/icons/statuses/open.png","name":"Open"}}}}],"description":"example bug report","project":{"self":"http://www.example.com/jira/rest/api/2/project/EX","id":"10000","key":"EX","name":"Example","avatarUrls":{"48x48":"http://www.example.com/jira/secure/projectavatar?size=large&pid=10000","24x24":"http://www.example.com/jira/secure/projectavatar?size=small&pid=10000","16x16":"http://www.example.com/jira/secure/projectavatar?size=xsmall&pid=10000","32x32":"http://www.example.com/jira/secure/projectavatar?size=medium&pid=10000"},"projectCategory":{"self":"http://www.example.com/jira/rest/api/2/projectCategory/10000","id":"10000","name":"FIRST","description":"First Project Category"}},"comment":{"comments":[{"self":"http://www.example.com/jira/rest/api/2/issue/10010/comment/10000","id":"10000","author":{"self":"http://www.example.com/jira/rest/api/2/user?username=fred","name":"fred","displayName":"Fred F. User","active":false},"body":"Lorem ipsum dolor sit amet, consectetur adipiscing elit. Pellentesque eget venenatis elit. Duis eu justo eget augue iaculis fermentum. Sed semper quam laoreet nisi egestas at posuere augue semper.","updateAuthor":{"self":"http://www.example.com/jira/rest/api/2/user?username=fred","name":"fred","displayName":"Fred F. User","active":false},"created":"2016-03-16T04:22:37.356+0000","updated":"2016-03-16T04:22:37.356+0000","visibility":{"type":"role","value":"Administrators"}}]},"issuelinks":[{"id":"10001","type":{"id":"10000","name":"Dependent","inward":"depends on","outward":"is depended by"},"outwardIssue":{"id":"10004L","key":"PRJ-2","self":"http://www.example.com/jira/rest/api/2/issue/PRJ-2","fields":{"status":{"iconUrl":"http://www.example.com/jira//images/icons/statuses/open.png","name":"Open"}}}},{"id":"10002","type":{"id":"10000","name":"Dependent","inward":"depends on","outward":"is depended by"},"inwardIssue":{"id":"10004","key":"PRJ-3","self":"http://www.example.com/jira/rest/api/2/issue/PRJ-3","fields":{"status":{"iconUrl":"http://www.example.com/jira//images/icons/statuses/open.png","name":"Open"}}}}],"worklog":{"worklogs":[{"self":"http://www.example.com/jira/rest/api/2/issue/10010/worklog/10000","author":{"self":"http://www.example.com/jira/rest/api/2/user?username=fred","name":"fred","displayName":"Fred F. User","active":false},"updateAuthor":{"self":"http://www.example.com/jira/rest/api/2/user?username=fred","name":"fred","displayName":"Fred F. User","active":false},"comment":"I did some work here.","updated":"2016-03-16T04:22:37.471+0000","visibility":{"type":"group","value":"jira-developers"},"started":"2016-03-16T04:22:37.471+0000","timeSpent":"3h 20m","timeSpentSeconds":12000,"id":"100028","issueId":"10002"}]},"updated":"2016-04-06T02:36:53.594-0700","duedate":"2018-01-19","timetracking":{"originalEstimate":"10m","remainingEstimate":"3m","timeSpent":"6m","originalEstimateSeconds":600,"remainingEstimateSeconds":200,"timeSpentSeconds":400}},"names":{"watcher":"watcher","attachment":"attachment","sub-tasks":"sub-tasks","description":"description","project":"project","comment":"comment","issuelinks":"issuelinks","worklog":"worklog","updated":"updated","timetracking":"timetracking"},"schema":{},"renderedFields":{"resolutiondate":"In 1 week","updated":"2 hours ago","comment":{"comments":[{"body":"This <strong>is</strong> HTML"}]}}}`)
 	})
 
-	issue, _, err := testClient.Issue.Get("10002", nil)
+	issue, _, err := testClient.Issue.Get(context.Background(), "10002", nil)
 	if err != nil {
 		t.Errorf("Error given: %s", err)
 	}
@@ -408,7 +409,7 @@ func TestIssueService_DownloadAttachment(t *testing.T) {
 		w.Write([]byte(testAttachment))
 	})
 
-	resp, err := testClient.Issue.DownloadAttachment("10000")
+	resp, err := testClient.Issue.DownloadAttachment(context.Background(), "10000")
 	if err != nil {
 		t.Errorf("Error given: %s", err)
 	}
@@ -442,7 +443,7 @@ func TestIssueService_DownloadAttachment_BadStatus(t *testing.T) {
 		w.WriteHeader(http.StatusForbidden)
 	})
 
-	resp, err := testClient.Issue.DownloadAttachment("10000")
+	resp, err := testClient.Issue.DownloadAttachment(context.Background(), "10000")
 	if resp == nil {
 		t.Error("Expected response. Response is nil")
 		return
@@ -491,7 +492,7 @@ func TestIssueService_PostAttachment(t *testing.T) {
 
 	reader := strings.NewReader(testAttachment)
 
-	issue, resp, err := testClient.Issue.PostAttachment("10000", reader, "attachment")
+	issue, resp, err := testClient.Issue.PostAttachment(context.Background(), "10000", reader, "attachment")
 
 	if issue == nil {
 		t.Error("Expected response. Response is nil")
@@ -518,7 +519,7 @@ func TestIssueService_PostAttachment_NoResponse(t *testing.T) {
 	})
 	reader := strings.NewReader(testAttachment)
 
-	_, _, err := testClient.Issue.PostAttachment("10000", reader, "attachment")
+	_, _, err := testClient.Issue.PostAttachment(context.Background(), "10000", reader, "attachment")
 
 	if err == nil {
 		t.Errorf("Error expected: %s", err)
@@ -538,7 +539,7 @@ func TestIssueService_PostAttachment_NoFilename(t *testing.T) {
 	})
 	reader := strings.NewReader(testAttachment)
 
-	_, _, err := testClient.Issue.PostAttachment("10000", reader, "")
+	_, _, err := testClient.Issue.PostAttachment(context.Background(), "10000", reader, "")
 
 	if err != nil {
 		t.Errorf("Error expected: %s", err)
@@ -555,7 +556,7 @@ func TestIssueService_PostAttachment_NoAttachment(t *testing.T) {
 		fmt.Fprint(w, `[{"self":"http://jira/jira/rest/api/2/attachment/228924","id":"228924","filename":"example.jpg","author":{"self":"http://jira/jira/rest/api/2/user?username=test","name":"test","emailAddress":"test@test.com","avatarUrls":{"16x16":"http://jira/jira/secure/useravatar?size=small&avatarId=10082","48x48":"http://jira/jira/secure/useravatar?avatarId=10082"},"displayName":"Tester","active":true},"created":"2016-05-24T00:25:17.000-0700","size":32280,"mimeType":"image/jpeg","content":"http://jira/jira/secure/attachment/228924/example.jpg","thumbnail":"http://jira/jira/secure/thumbnail/228924/_thumb_228924.png"}]`)
 	})
 
-	_, _, err := testClient.Issue.PostAttachment("10000", nil, "attachment")
+	_, _, err := testClient.Issue.PostAttachment(context.Background(), "10000", nil, "attachment")
 
 	if err != nil {
 		t.Errorf("Error given: %s", err)
@@ -573,7 +574,7 @@ func TestIssueService_DeleteAttachment(t *testing.T) {
 		fmt.Fprint(w, `{}`)
 	})
 
-	resp, err := testClient.Issue.DeleteAttachment("10054")
+	resp, err := testClient.Issue.DeleteAttachment(context.Background(), "10054")
 	if resp.StatusCode != 204 {
 		t.Error("Expected attachment not deleted.")
 		if resp.StatusCode == 403 {
@@ -600,7 +601,7 @@ func TestIssueService_DeleteLink(t *testing.T) {
 		fmt.Fprint(w, `{}`)
 	})
 
-	resp, err := testClient.Issue.DeleteLink("10054")
+	resp, err := testClient.Issue.DeleteLink(context.Background(), "10054")
 	if resp.StatusCode != 204 {
 		t.Error("Expected link not deleted.")
 		if resp.StatusCode == 403 {
@@ -627,7 +628,7 @@ func TestIssueService_Search(t *testing.T) {
 	})
 
 	opt := &SearchOptions{StartAt: 1, MaxResults: 40, Expand: "foo"}
-	_, resp, err := testClient.Issue.Search("type = Bug and Status NOT IN (Resolved)", opt)
+	_, resp, err := testClient.Issue.Search(context.Background(), "type = Bug and Status NOT IN (Resolved)", opt)
 
 	if resp == nil {
 		t.Errorf("Response given: %+v", resp)
@@ -658,7 +659,7 @@ func TestIssueService_SearchEmptyJQL(t *testing.T) {
 	})
 
 	opt := &SearchOptions{StartAt: 1, MaxResults: 40, Expand: "foo"}
-	_, resp, err := testClient.Issue.Search("", opt)
+	_, resp, err := testClient.Issue.Search(context.Background(), "", opt)
 
 	if resp == nil {
 		t.Errorf("Response given: %+v", resp)
@@ -687,7 +688,7 @@ func TestIssueService_Search_WithoutPaging(t *testing.T) {
 		w.WriteHeader(http.StatusOK)
 		fmt.Fprint(w, `{"expand": "schema,names","startAt": 0,"maxResults": 50,"total": 6,"issues": [{"expand": "html","id": "10230","self": "http://kelpie9:8081/rest/api/2/issue/BULK-62","key": "BULK-62","fields": {"summary": "testing","timetracking": null,"issuetype": {"self": "http://kelpie9:8081/rest/api/2/issuetype/5","id": "5","description": "The sub-task of the issue","iconUrl": "http://kelpie9:8081/images/icons/issue_subtask.gif","name": "Sub-task","subtask": true},"customfield_10071": null}},{"expand": "html","id": "10004","self": "http://kelpie9:8081/rest/api/2/issue/BULK-47","key": "BULK-47","fields": {"summary": "Cheese v1 2.0 issue","timetracking": null,"issuetype": {"self": "http://kelpie9:8081/rest/api/2/issuetype/3","id": "3","description": "A task that needs to be done.","iconUrl": "http://kelpie9:8081/images/icons/task.gif","name": "Task","subtask": false}}}]}`)
 	})
-	_, resp, err := testClient.Issue.Search("something", nil)
+	_, resp, err := testClient.Issue.Search(context.Background(), "something", nil)
 
 	if resp == nil {
 		t.Errorf("Response given: %+v", resp)
@@ -731,7 +732,7 @@ func TestIssueService_SearchPages(t *testing.T) {
 
 	opt := &SearchOptions{StartAt: 1, MaxResults: 2, Expand: "foo", ValidateQuery: "warn"}
 	issues := make([]Issue, 0)
-	err := testClient.Issue.SearchPages("something", opt, func(issue Issue) error {
+	err := testClient.Issue.SearchPages(context.Background(), "something", opt, func(issue Issue) error {
 		issues = append(issues, issue)
 		return nil
 	})
@@ -762,7 +763,7 @@ func TestIssueService_SearchPages_EmptyResult(t *testing.T) {
 
 	opt := &SearchOptions{StartAt: 1, MaxResults: 50, Expand: "foo", ValidateQuery: "warn"}
 	issues := make([]Issue, 0)
-	err := testClient.Issue.SearchPages("something", opt, func(issue Issue) error {
+	err := testClient.Issue.SearchPages(context.Background(), "something", opt, func(issue Issue) error {
 		issues = append(issues, issue)
 		return nil
 	})
@@ -782,7 +783,7 @@ func TestIssueService_GetCustomFields(t *testing.T) {
 		fmt.Fprint(w, `{"expand":"renderedFields,names,schema,transitions,operations,editmeta,changelog,versionedRepresentations","id":"10002","self":"http://www.example.com/jira/rest/api/2/issue/10002","key":"EX-1","fields":{"customfield_123":"test","watcher":{"self":"http://www.example.com/jira/rest/api/2/issue/EX-1/watchers","isWatching":false,"watchCount":1,"watchers":[{"self":"http://www.example.com/jira/rest/api/2/user?username=fred","name":"fred","displayName":"Fred F. User","active":false}]},"attachment":[{"self":"http://www.example.com/jira/rest/api/2.0/attachments/10000","filename":"picture.jpg","author":{"self":"http://www.example.com/jira/rest/api/2/user?username=fred","name":"fred","avatarUrls":{"48x48":"http://www.example.com/jira/secure/useravatar?size=large&ownerId=fred","24x24":"http://www.example.com/jira/secure/useravatar?size=small&ownerId=fred","16x16":"http://www.example.com/jira/secure/useravatar?size=xsmall&ownerId=fred","32x32":"http://www.example.com/jira/secure/useravatar?size=medium&ownerId=fred"},"displayName":"Fred F. User","active":false},"created":"2016-03-16T04:22:37.461+0000","size":23123,"mimeType":"image/jpeg","content":"http://www.example.com/jira/attachments/10000","thumbnail":"http://www.example.com/jira/secure/thumbnail/10000"}],"sub-tasks":[{"id":"10000","type":{"id":"10000","name":"","inward":"Parent","outward":"Sub-task"},"outwardIssue":{"id":"10003","key":"EX-2","self":"http://www.example.com/jira/rest/api/2/issue/EX-2","fields":{"status":{"iconUrl":"http://www.example.com/jira//images/icons/statuses/open.png","name":"Open"}}}}],"description":"example bug report","project":{"self":"http://www.example.com/jira/rest/api/2/project/EX","id":"10000","key":"EX","name":"Example","avatarUrls":{"48x48":"http://www.example.com/jira/secure/projectavatar?size=large&pid=10000","24x24":"http://www.example.com/jira/secure/projectavatar?size=small&pid=10000","16x16":"http://www.example.com/jira/secure/projectavatar?size=xsmall&pid=10000","32x32":"http://www.example.com/jira/secure/projectavatar?size=medium&pid=10000"},"projectCategory":{"self":"http://www.example.com/jira/rest/api/2/projectCategory/10000","id":"10000","name":"FIRST","description":"First Project Category"}},"comment":{"comments":[{"self":"http://www.example.com/jira/rest/api/2/issue/10010/comment/10000","id":"10000","author":{"self":"http://www.example.com/jira/rest/api/2/user?username=fred","name":"fred","displayName":"Fred F. User","active":false},"body":"Lorem ipsum dolor sit amet, consectetur adipiscing elit. Pellentesque eget venenatis elit. Duis eu justo eget augue iaculis fermentum. Sed semper quam laoreet nisi egestas at posuere augue semper.","updateAuthor":{"self":"http://www.example.com/jira/rest/api/2/user?username=fred","name":"fred","displayName":"Fred F. User","active":false},"created":"2016-03-16T04:22:37.356+0000","updated":"2016-03-16T04:22:37.356+0000","visibility":{"type":"role","value":"Administrators"}}]},"issuelinks":[{"id":"10001","type":{"id":"10000","name":"Dependent","inward":"depends on","outward":"is depended by"},"outwardIssue":{"id":"10004L","key":"PRJ-2","self":"http://www.example.com/jira/rest/api/2/issue/PRJ-2","fields":{"status":{"iconUrl":"http://www.example.com/jira//images/icons/statuses/open.png","name":"Open"}}}},{"id":"10002","type":{"id":"10000","name":"Dependent","inward":"depends on","outward":"is depended by"},"inwardIssue":{"id":"10004","key":"PRJ-3","self":"http://www.example.com/jira/rest/api/2/issue/PRJ-3","fields":{"status":{"iconUrl":"http://www.example.com/jira//images/icons/statuses/open.png","name":"Open"}}}}],"worklog":{"worklogs":[{"self":"http://www.example.com/jira/rest/api/2/issue/10010/worklog/10000","author":{"self":"http://www.example.com/jira/rest/api/2/user?username=fred","name":"fred","displayName":"Fred F. User","active":false},"updateAuthor":{"self":"http://www.example.com/jira/rest/api/2/user?username=fred","name":"fred","displayName":"Fred F. User","active":false},"comment":"I did some work here.","updated":"2016-03-16T04:22:37.471+0000","visibility":{"type":"group","value":"jira-developers"},"started":"2016-03-16T04:22:37.471+0000","timeSpent":"3h 20m","timeSpentSeconds":12000,"id":"100028","issueId":"10002"}]},"updated":"2016-04-06T02:36:53.594-0700","duedate":"2018-01-19","timetracking":{"originalEstimate":"10m","remainingEstimate":"3m","timeSpent":"6m","originalEstimateSeconds":600,"remainingEstimateSeconds":200,"timeSpentSeconds":400}},"names":{"watcher":"watcher","attachment":"attachment","sub-tasks":"sub-tasks","description":"description","project":"project","comment":"comment","issuelinks":"issuelinks","worklog":"worklog","updated":"updated","timetracking":"timetracking"},"schema":{}}`)
 	})
 
-	issue, _, err := testClient.Issue.GetCustomFields("10002")
+	issue, _, err := testClient.Issue.GetCustomFields(context.Background(), "10002")
 	if err != nil {
 		t.Errorf("Error given: %s", err)
 	}
@@ -804,7 +805,7 @@ func TestIssueService_GetComplexCustomFields(t *testing.T) {
 		fmt.Fprint(w, `{"expand":"renderedFields,names,schema,transitions,operations,editmeta,changelog,versionedRepresentations","id":"10002","self":"http://www.example.com/jira/rest/api/2/issue/10002","key":"EX-1","fields":{"customfield_123":{"self":"http://www.example.com/jira/rest/api/2/customFieldOption/123","value":"test","id":"123"},"watcher":{"self":"http://www.example.com/jira/rest/api/2/issue/EX-1/watchers","isWatching":false,"watchCount":1,"watchers":[{"self":"http://www.example.com/jira/rest/api/2/user?username=fred","name":"fred","displayName":"Fred F. User","active":false}]},"attachment":[{"self":"http://www.example.com/jira/rest/api/2.0/attachments/10000","filename":"picture.jpg","author":{"self":"http://www.example.com/jira/rest/api/2/user?username=fred","name":"fred","avatarUrls":{"48x48":"http://www.example.com/jira/secure/useravatar?size=large&ownerId=fred","24x24":"http://www.example.com/jira/secure/useravatar?size=small&ownerId=fred","16x16":"http://www.example.com/jira/secure/useravatar?size=xsmall&ownerId=fred","32x32":"http://www.example.com/jira/secure/useravatar?size=medium&ownerId=fred"},"displayName":"Fred F. User","active":false},"created":"2016-03-16T04:22:37.461+0000","size":23123,"mimeType":"image/jpeg","content":"http://www.example.com/jira/attachments/10000","thumbnail":"http://www.example.com/jira/secure/thumbnail/10000"}],"sub-tasks":[{"id":"10000","type":{"id":"10000","name":"","inward":"Parent","outward":"Sub-task"},"outwardIssue":{"id":"10003","key":"EX-2","self":"http://www.example.com/jira/rest/api/2/issue/EX-2","fields":{"status":{"iconUrl":"http://www.example.com/jira//images/icons/statuses/open.png","name":"Open"}}}}],"description":"example bug report","project":{"self":"http://www.example.com/jira/rest/api/2/project/EX","id":"10000","key":"EX","name":"Example","avatarUrls":{"48x48":"http://www.example.com/jira/secure/projectavatar?size=large&pid=10000","24x24":"http://www.example.com/jira/secure/projectavatar?size=small&pid=10000","16x16":"http://www.example.com/jira/secure/projectavatar?size=xsmall&pid=10000","32x32":"http://www.example.com/jira/secure/projectavatar?size=medium&pid=10000"},"projectCategory":{"self":"http://www.example.com/jira/rest/api/2/projectCategory/10000","id":"10000","name":"FIRST","description":"First Project Category"}},"comment":{"comments":[{"self":"http://www.example.com/jira/rest/api/2/issue/10010/comment/10000","id":"10000","author":{"self":"http://www.example.com/jira/rest/api/2/user?username=fred","name":"fred","displayName":"Fred F. User","active":false},"body":"Lorem ipsum dolor sit amet, consectetur adipiscing elit. Pellentesque eget venenatis elit. Duis eu justo eget augue iaculis fermentum. Sed semper quam laoreet nisi egestas at posuere augue semper.","updateAuthor":{"self":"http://www.example.com/jira/rest/api/2/user?username=fred","name":"fred","displayName":"Fred F. User","active":false},"created":"2016-03-16T04:22:37.356+0000","updated":"2016-03-16T04:22:37.356+0000","visibility":{"type":"role","value":"Administrators"}}]},"issuelinks":[{"id":"10001","type":{"id":"10000","name":"Dependent","inward":"depends on","outward":"is depended by"},"outwardIssue":{"id":"10004L","key":"PRJ-2","self":"http://www.example.com/jira/rest/api/2/issue/PRJ-2","fields":{"status":{"iconUrl":"http://www.example.com/jira//images/icons/statuses/open.png","name":"Open"}}}},{"id":"10002","type":{"id":"10000","name":"Dependent","inward":"depends on","outward":"is depended by"},"inwardIssue":{"id":"10004","key":"PRJ-3","self":"http://www.example.com/jira/rest/api/2/issue/PRJ-3","fields":{"status":{"iconUrl":"http://www.example.com/jira//images/icons/statuses/open.png","name":"Open"}}}}],"worklog":{"worklogs":[{"self":"http://www.example.com/jira/rest/api/2/issue/10010/worklog/10000","author":{"self":"http://www.example.com/jira/rest/api/2/user?username=fred","name":"fred","displayName":"Fred F. User","active":false},"updateAuthor":{"self":"http://www.example.com/jira/rest/api/2/user?username=fred","name":"fred","displayName":"Fred F. User","active":false},"comment":"I did some work here.","updated":"2016-03-16T04:22:37.471+0000","visibility":{"type":"group","value":"jira-developers"},"started":"2016-03-16T04:22:37.471+0000","timeSpent":"3h 20m","timeSpentSeconds":12000,"id":"100028","issueId":"10002"}]},"updated":"2016-04-06T02:36:53.594-0700","duedate":"2018-01-19","timetracking":{"originalEstimate":"10m","remainingEstimate":"3m","timeSpent":"6m","originalEstimateSeconds":600,"remainingEstimateSeconds":200,"timeSpentSeconds":400}},"names":{"watcher":"watcher","attachment":"attachment","sub-tasks":"sub-tasks","description":"description","project":"project","comment":"comment","issuelinks":"issuelinks","worklog":"worklog","updated":"updated","timetracking":"timetracking"},"schema":{}}`)
 	})
 
-	issue, _, err := testClient.Issue.GetCustomFields("10002")
+	issue, _, err := testClient.Issue.GetCustomFields(context.Background(), "10002")
 	if err != nil {
 		t.Errorf("Error given: %s", err)
 	}
@@ -834,7 +835,7 @@ func TestIssueService_GetTransitions(t *testing.T) {
 		fmt.Fprint(w, string(raw))
 	})
 
-	transitions, _, err := testClient.Issue.GetTransitions("123")
+	transitions, _, err := testClient.Issue.GetTransitions(context.Background(), "123")
 
 	if err != nil {
 		t.Errorf("Got error: %v", err)
@@ -876,7 +877,7 @@ func TestIssueService_DoTransition(t *testing.T) {
 			t.Errorf("Expected %s to be in payload, got %s instead", transitionID, payload.Transition.ID)
 		}
 	})
-	_, err := testClient.Issue.DoTransition("123", transitionID)
+	_, err := testClient.Issue.DoTransition(context.Background(), "123", transitionID)
 
 	if err != nil {
 		t.Errorf("Got error: %v", err)
@@ -935,7 +936,7 @@ func TestIssueService_DoTransitionWithPayload(t *testing.T) {
 			t.Errorf("Expected %s to be in payload, got %s instead", transitionID, transition["id"])
 		}
 	})
-	_, err := testClient.Issue.DoTransitionWithPayload("123", customPayload)
+	_, err := testClient.Issue.DoTransitionWithPayload(context.Background(), "123", customPayload)
 
 	if err != nil {
 		t.Errorf("Got error: %v", err)
@@ -1449,7 +1450,7 @@ func TestIssueService_Delete(t *testing.T) {
 		fmt.Fprint(w, `{}`)
 	})
 
-	resp, err := testClient.Issue.Delete("10002")
+	resp, err := testClient.Issue.Delete(context.Background(), "10002")
 	if resp.StatusCode != 204 {
 		t.Error("Expected issue not deleted.")
 	}
@@ -1567,9 +1568,9 @@ func TestIssueService_GetWorklogs(t *testing.T) {
 			var err error
 
 			if tc.option != nil {
-				worklog, _, err = testClient.Issue.GetWorklogs(tc.issueId, WithQueryOptions(tc.option))
+				worklog, _, err = testClient.Issue.GetWorklogs(context.Background(), tc.issueId, WithQueryOptions(tc.option))
 			} else {
-				worklog, _, err = testClient.Issue.GetWorklogs(tc.issueId)
+				worklog, _, err = testClient.Issue.GetWorklogs(context.Background(), tc.issueId)
 			}
 
 			if err != nil && !cmp.Equal(err, tc.err) {
@@ -1606,7 +1607,7 @@ func TestIssueService_GetWatchers(t *testing.T) {
         }]},"applicationRoles":{"size":1,"items":[]},"expand":"groups,applicationRoles"}`)
 	})
 
-	watchers, _, err := testClient.Issue.GetWatchers("10002")
+	watchers, _, err := testClient.Issue.GetWatchers(context.Background(), "10002")
 	if err != nil {
 		t.Errorf("Error given: %s", err)
 		return
@@ -1646,7 +1647,7 @@ func TestIssueService_DeprecatedGetWatchers(t *testing.T) {
         }]},"applicationRoles":{"size":1,"items":[]},"expand":"groups,applicationRoles"}`)
 	})
 
-	watchers, _, err := testClient.Issue.GetWatchers("10002")
+	watchers, _, err := testClient.Issue.GetWatchers(context.Background(), "10002")
 	if err != nil {
 		t.Errorf("Error given: %s", err)
 		return
@@ -1674,7 +1675,7 @@ func TestIssueService_UpdateAssignee(t *testing.T) {
 		w.WriteHeader(http.StatusNoContent)
 	})
 
-	resp, err := testClient.Issue.UpdateAssignee("10002", &User{
+	resp, err := testClient.Issue.UpdateAssignee(context.Background(), "10002", &User{
 		Name: "test-username",
 	})
 
@@ -1696,7 +1697,7 @@ func TestIssueService_Get_Fields_Changelog(t *testing.T) {
 		fmt.Fprint(w, `{"expand":"changelog","id":"10002","self":"http://www.example.com/jira/rest/api/2/issue/10002","key":"EX-1","changelog":{"startAt": 0,"maxResults": 1, "total": 1, "histories": [{"id": "10002", "author": {"self": "http://www.example.com/jira/rest/api/2/user?username=fred", "name": "fred", "key": "fred", "emailAddress": "fred@example.com", "avatarUrls": {"48x48": "http://www.example.com/secure/useravatar?ownerId=fred&avatarId=33072", "24x24": "http://www.example.com/secure/useravatar?size=small&ownerId=fred&avatarId=33072", "16x16": "http://www.example.com/secure/useravatar?size=xsmall&ownerId=fred&avatarId=33072", "32x32": "http://www.example.com/secure/useravatar?size=medium&ownerId=fred&avatarId=33072"},"displayName":"Fred","active": true,"timeZone":"Australia/Sydney"},"created":"2018-06-20T16:50:35.000+0300","items":[{"field":"Rank","fieldtype":"custom","from":"","fromString":"","to":"","toString":"Ranked higher"}]}]}}`)
 	})
 
-	issue, _, _ := testClient.Issue.Get("10002", &GetQueryOptions{Expand: "changelog"})
+	issue, _, _ := testClient.Issue.Get(context.Background(), "10002", &GetQueryOptions{Expand: "changelog"})
 	if issue == nil {
 		t.Error("Expected issue. Issue is nil")
 		return
@@ -1727,7 +1728,7 @@ func TestIssueService_Get_Transitions(t *testing.T) {
 		fmt.Fprint(w, `{"expand":"renderedFields,names,schema,transitions,operations,editmeta,changelog,versionedRepresentations","id":"10002","self":"http://www.example.com/jira/api/latest/issue/10002","key":"EX-1","transitions":[{"id":"121","name":"Start","to":{"self":"http://www.example.com/rest/api/2/status/10444","description":"","iconUrl":"http://www.example.com/images/icons/statuses/inprogress.png","name":"In progress","id":"10444","statusCategory":{"self":"http://www.example.com/rest/api/2/statuscategory/4","id":4,"key":"indeterminate","colorName":"yellow","name":"In Progress"}}}]}`)
 	})
 
-	issue, _, _ := testClient.Issue.Get("10002", &GetQueryOptions{Expand: "transitions"})
+	issue, _, _ := testClient.Issue.Get(context.Background(), "10002", &GetQueryOptions{Expand: "transitions"})
 	if issue == nil {
 		t.Error("Expected issue. Issue is nil")
 		return
@@ -1758,7 +1759,7 @@ func TestIssueService_Get_Fields_AffectsVersions(t *testing.T) {
 		fmt.Fprint(w, `{"fields":{"versions":[{"self":"http://www.example.com/jira/rest/api/2/version/10705","id":"10705","description":"test description","name":"2.1.0-rc3","archived":false,"released":false,"releaseDate":"2018-09-30"}]}}`)
 	})
 
-	issue, _, err := testClient.Issue.Get("10002", nil)
+	issue, _, err := testClient.Issue.Get(context.Background(), "10002", nil)
 	if err != nil {
 		t.Errorf("Error given: %s", err)
 	}
@@ -1798,7 +1799,7 @@ func TestIssueService_GetRemoteLinks(t *testing.T) {
 		fmt.Fprint(w, string(raw))
 	})
 
-	remoteLinks, _, err := testClient.Issue.GetRemoteLinks("123")
+	remoteLinks, _, err := testClient.Issue.GetRemoteLinks(context.Background(), "123")
 	if err != nil {
 		t.Errorf("Got error: %v", err)
 	}
@@ -1852,7 +1853,7 @@ func TestIssueService_AddRemoteLink(t *testing.T) {
 			},
 		},
 	}
-	record, _, err := testClient.Issue.AddRemoteLink("10000", r)
+	record, _, err := testClient.Issue.AddRemoteLink(context.Background(), "10000", r)
 	if record == nil {
 		t.Error("Expected Record. Record is nil")
 	}
@@ -1895,7 +1896,7 @@ func TestIssueService_UpdateRemoteLink(t *testing.T) {
 			},
 		},
 	}
-	_, err := testClient.Issue.UpdateRemoteLink("100", 200, r)
+	_, err := testClient.Issue.UpdateRemoteLink(context.Background(), "100", 200, r)
 	if err != nil {
 		t.Errorf("Error given: %s", err)
 	}

--- a/cloud/issuelinktype.go
+++ b/cloud/issuelinktype.go
@@ -12,10 +12,10 @@ import (
 // Jira API docs: https://developer.atlassian.com/cloud/jira/platform/rest/v2/#api-group-Issue-link-types
 type IssueLinkTypeService service
 
-// GetListWithContext gets all of the issue link types from Jira.
+// GetList gets all of the issue link types from Jira.
 //
 // Jira API docs: https://developer.atlassian.com/cloud/jira/platform/rest/v2/#api-rest-api-2-issueLinkType-get
-func (s *IssueLinkTypeService) GetListWithContext(ctx context.Context) ([]IssueLinkType, *Response, error) {
+func (s *IssueLinkTypeService) GetList(ctx context.Context) ([]IssueLinkType, *Response, error) {
 	apiEndpoint := "rest/api/2/issueLinkType"
 	req, err := s.client.NewRequest(ctx, "GET", apiEndpoint, nil)
 	if err != nil {
@@ -30,15 +30,10 @@ func (s *IssueLinkTypeService) GetListWithContext(ctx context.Context) ([]IssueL
 	return linkTypeList, resp, nil
 }
 
-// GetList wraps GetListWithContext using the background context.
-func (s *IssueLinkTypeService) GetList() ([]IssueLinkType, *Response, error) {
-	return s.GetListWithContext(context.Background())
-}
-
-// GetWithContext gets info of a specific issue link type from Jira.
+// Get gets info of a specific issue link type from Jira.
 //
 // Jira API docs: https://developer.atlassian.com/cloud/jira/platform/rest/v2/#api-rest-api-2-issueLinkType-issueLinkTypeId-get
-func (s *IssueLinkTypeService) GetWithContext(ctx context.Context, ID string) (*IssueLinkType, *Response, error) {
+func (s *IssueLinkTypeService) Get(ctx context.Context, ID string) (*IssueLinkType, *Response, error) {
 	apiEndPoint := fmt.Sprintf("rest/api/2/issueLinkType/%s", ID)
 	req, err := s.client.NewRequest(ctx, "GET", apiEndPoint, nil)
 	if err != nil {
@@ -53,15 +48,10 @@ func (s *IssueLinkTypeService) GetWithContext(ctx context.Context, ID string) (*
 	return linkType, resp, nil
 }
 
-// Get wraps GetWithContext using the background context.
-func (s *IssueLinkTypeService) Get(ID string) (*IssueLinkType, *Response, error) {
-	return s.GetWithContext(context.Background(), ID)
-}
-
-// CreateWithContext creates an issue link type in Jira.
+// Create creates an issue link type in Jira.
 //
 // Jira API docs: https://developer.atlassian.com/cloud/jira/platform/rest/v2/#api-rest-api-2-issueLinkType-post
-func (s *IssueLinkTypeService) CreateWithContext(ctx context.Context, linkType *IssueLinkType) (*IssueLinkType, *Response, error) {
+func (s *IssueLinkTypeService) Create(ctx context.Context, linkType *IssueLinkType) (*IssueLinkType, *Response, error) {
 	apiEndpoint := "/rest/api/2/issueLinkType"
 	req, err := s.client.NewRequest(ctx, "POST", apiEndpoint, linkType)
 	if err != nil {
@@ -88,16 +78,11 @@ func (s *IssueLinkTypeService) CreateWithContext(ctx context.Context, linkType *
 	return linkType, resp, nil
 }
 
-// Create wraps CreateWithContext using the background context.
-func (s *IssueLinkTypeService) Create(linkType *IssueLinkType) (*IssueLinkType, *Response, error) {
-	return s.CreateWithContext(context.Background(), linkType)
-}
-
-// UpdateWithContext updates an issue link type.  The issue is found by key.
+// Update updates an issue link type.  The issue is found by key.
 //
 // Jira API docs: https://developer.atlassian.com/cloud/jira/platform/rest/v2/#api-rest-api-2-issueLinkType-issueLinkTypeId-put
 // Caller must close resp.Body
-func (s *IssueLinkTypeService) UpdateWithContext(ctx context.Context, linkType *IssueLinkType) (*IssueLinkType, *Response, error) {
+func (s *IssueLinkTypeService) Update(ctx context.Context, linkType *IssueLinkType) (*IssueLinkType, *Response, error) {
 	apiEndpoint := fmt.Sprintf("rest/api/2/issueLinkType/%s", linkType.ID)
 	req, err := s.client.NewRequest(ctx, "PUT", apiEndpoint, linkType)
 	if err != nil {
@@ -111,17 +96,11 @@ func (s *IssueLinkTypeService) UpdateWithContext(ctx context.Context, linkType *
 	return &ret, resp, nil
 }
 
-// Update wraps UpdateWithContext using the background context.
-// Caller must close resp.Body
-func (s *IssueLinkTypeService) Update(linkType *IssueLinkType) (*IssueLinkType, *Response, error) {
-	return s.UpdateWithContext(context.Background(), linkType)
-}
-
-// DeleteWithContext deletes an issue link type based on provided ID.
+// Delete deletes an issue link type based on provided ID.
 //
 // Jira API docs: https://developer.atlassian.com/cloud/jira/platform/rest/v2/#api-rest-api-2-issueLinkType-issueLinkTypeId-delete
 // Caller must close resp.Body
-func (s *IssueLinkTypeService) DeleteWithContext(ctx context.Context, ID string) (*Response, error) {
+func (s *IssueLinkTypeService) Delete(ctx context.Context, ID string) (*Response, error) {
 	apiEndpoint := fmt.Sprintf("rest/api/2/issueLinkType/%s", ID)
 	req, err := s.client.NewRequest(ctx, "DELETE", apiEndpoint, nil)
 	if err != nil {
@@ -130,10 +109,4 @@ func (s *IssueLinkTypeService) DeleteWithContext(ctx context.Context, ID string)
 
 	resp, err := s.client.Do(req, nil)
 	return resp, err
-}
-
-// Delete wraps DeleteWithContext using the background context.
-// Caller must close resp.Body
-func (s *IssueLinkTypeService) Delete(ID string) (*Response, error) {
-	return s.DeleteWithContext(context.Background(), ID)
 }

--- a/cloud/issuelinktype_test.go
+++ b/cloud/issuelinktype_test.go
@@ -1,6 +1,7 @@
 package cloud
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 	"os"
@@ -22,7 +23,7 @@ func TestIssueLinkTypeService_GetList(t *testing.T) {
 		fmt.Fprint(w, string(raw))
 	})
 
-	linkTypes, _, err := testClient.IssueLinkType.GetList()
+	linkTypes, _, err := testClient.IssueLinkType.GetList(context.Background())
 	if linkTypes == nil {
 		t.Error("Expected issueLinkType list. LinkTypes is nil")
 	}
@@ -42,7 +43,7 @@ func TestIssueLinkTypeService_Get(t *testing.T) {
 		"self": "https://www.example.com/jira/rest/api/2/issueLinkType/123"}`)
 	})
 
-	if linkType, _, err := testClient.IssueLinkType.Get("123"); err != nil {
+	if linkType, _, err := testClient.IssueLinkType.Get(context.Background(), "123"); err != nil {
 		t.Errorf("Error given: %s", err)
 	} else if linkType == nil {
 		t.Error("Expected linkType. LinkType is nil")
@@ -67,7 +68,7 @@ func TestIssueLinkTypeService_Create(t *testing.T) {
 		Outward: "causes",
 	}
 
-	if linkType, _, err := testClient.IssueLinkType.Create(lt); err != nil {
+	if linkType, _, err := testClient.IssueLinkType.Create(context.Background(), lt); err != nil {
 		t.Errorf("Error given: %s", err)
 	} else if linkType == nil {
 		t.Error("Expected linkType. LinkType is nil")
@@ -91,7 +92,7 @@ func TestIssueLinkTypeService_Update(t *testing.T) {
 		Outward: "causes",
 	}
 
-	if linkType, _, err := testClient.IssueLinkType.Update(lt); err != nil {
+	if linkType, _, err := testClient.IssueLinkType.Update(context.Background(), lt); err != nil {
 		t.Errorf("Error given: %s", err)
 	} else if linkType == nil {
 		t.Error("Expected linkType. LinkType is nil")
@@ -108,7 +109,7 @@ func TestIssueLinkTypeService_Delete(t *testing.T) {
 		w.WriteHeader(http.StatusNoContent)
 	})
 
-	resp, err := testClient.IssueLinkType.Delete("100")
+	resp, err := testClient.IssueLinkType.Delete(context.Background(), "100")
 	if resp.StatusCode != http.StatusNoContent {
 		t.Error("Expected issue not deleted.")
 	}

--- a/cloud/organization.go
+++ b/cloud/organization.go
@@ -53,14 +53,14 @@ type PropertyKeys struct {
 	Keys []PropertyKey `json:"keys,omitempty" structs:"keys,omitempty"`
 }
 
-// GetAllOrganizationsWithContext returns a list of organizations in
+// GetAllOrganizations returns a list of organizations in
 // the Jira Service Management instance.
 // Use this method when you want to present a list
 // of organizations or want to locate an organization
 // by name.
 //
 // Jira API docs: https://developer.atlassian.com/cloud/jira/service-desk/rest/api-group-organization/#api-group-organization
-func (s *OrganizationService) GetAllOrganizationsWithContext(ctx context.Context, start int, limit int, accountID string) (*PagedDTO, *Response, error) {
+func (s *OrganizationService) GetAllOrganizations(ctx context.Context, start int, limit int, accountID string) (*PagedDTO, *Response, error) {
 	apiEndPoint := fmt.Sprintf("rest/servicedeskapi/organization?start=%d&limit=%d", start, limit)
 	if accountID != "" {
 		apiEndPoint += fmt.Sprintf("&accountId=%s", accountID)
@@ -83,16 +83,11 @@ func (s *OrganizationService) GetAllOrganizationsWithContext(ctx context.Context
 	return v, resp, nil
 }
 
-// GetAllOrganizations wraps GetAllOrganizationsWithContext using the background context.
-func (s *OrganizationService) GetAllOrganizations(start int, limit int, accountID string) (*PagedDTO, *Response, error) {
-	return s.GetAllOrganizationsWithContext(context.Background(), start, limit, accountID)
-}
-
-// CreateOrganizationWithContext creates an organization by
+// CreateOrganization creates an organization by
 // passing the name of the organization.
 //
 // Jira API docs: https://developer.atlassian.com/cloud/jira/service-desk/rest/api-group-organization/#api-rest-servicedeskapi-organization-post
-func (s *OrganizationService) CreateOrganizationWithContext(ctx context.Context, name string) (*Organization, *Response, error) {
+func (s *OrganizationService) CreateOrganization(ctx context.Context, name string) (*Organization, *Response, error) {
 	apiEndPoint := "rest/servicedeskapi/organization"
 
 	organization := OrganizationCreationDTO{
@@ -116,19 +111,14 @@ func (s *OrganizationService) CreateOrganizationWithContext(ctx context.Context,
 	return o, resp, nil
 }
 
-// CreateOrganization wraps CreateOrganizationWithContext using the background context.
-func (s *OrganizationService) CreateOrganization(name string) (*Organization, *Response, error) {
-	return s.CreateOrganizationWithContext(context.Background(), name)
-}
-
-// GetOrganizationWithContext returns details of an
+// GetOrganization returns details of an
 // organization. Use this method to get organization
 // details whenever your application component is
 // passed an organization ID but needs to display
 // other organization details.
 //
 // Jira API docs: https://developer.atlassian.com/cloud/jira/service-desk/rest/api-group-organization/#api-rest-servicedeskapi-organization-organizationid-get
-func (s *OrganizationService) GetOrganizationWithContext(ctx context.Context, organizationID int) (*Organization, *Response, error) {
+func (s *OrganizationService) GetOrganization(ctx context.Context, organizationID int) (*Organization, *Response, error) {
 	apiEndPoint := fmt.Sprintf("rest/servicedeskapi/organization/%d", organizationID)
 
 	req, err := s.client.NewRequest(ctx, "GET", apiEndPoint, nil)
@@ -148,19 +138,14 @@ func (s *OrganizationService) GetOrganizationWithContext(ctx context.Context, or
 	return o, resp, nil
 }
 
-// GetOrganization wraps GetOrganizationWithContext using the background context.
-func (s *OrganizationService) GetOrganization(organizationID int) (*Organization, *Response, error) {
-	return s.GetOrganizationWithContext(context.Background(), organizationID)
-}
-
-// DeleteOrganizationWithContext deletes an organization. Note that
+// DeleteOrganization deletes an organization. Note that
 // the organization is deleted regardless
 // of other associations it may have.
 // For example, associations with service desks.
 //
 // Jira API docs: https://developer.atlassian.com/cloud/jira/service-desk/rest/api-group-organization/#api-rest-servicedeskapi-organization-organizationid-delete
 // Caller must close resp.Body
-func (s *OrganizationService) DeleteOrganizationWithContext(ctx context.Context, organizationID int) (*Response, error) {
+func (s *OrganizationService) DeleteOrganization(ctx context.Context, organizationID int) (*Response, error) {
 	apiEndPoint := fmt.Sprintf("rest/servicedeskapi/organization/%d", organizationID)
 
 	req, err := s.client.NewRequest(ctx, "DELETE", apiEndPoint, nil)
@@ -178,19 +163,13 @@ func (s *OrganizationService) DeleteOrganizationWithContext(ctx context.Context,
 	return resp, nil
 }
 
-// DeleteOrganization wraps DeleteOrganizationWithContext using the background context.
-// Caller must close resp.Body
-func (s *OrganizationService) DeleteOrganization(organizationID int) (*Response, error) {
-	return s.DeleteOrganizationWithContext(context.Background(), organizationID)
-}
-
-// GetPropertiesKeysWithContext returns the keys of
+// GetPropertiesKeys returns the keys of
 // all properties for an organization. Use this resource
 // when you need to find out what additional properties
 // items have been added to an organization.
 //
 // https://developer.atlassian.com/cloud/jira/service-desk/rest/api-group-organization/#api-rest-servicedeskapi-organization-organizationid-property-get
-func (s *OrganizationService) GetPropertiesKeysWithContext(ctx context.Context, organizationID int) (*PropertyKeys, *Response, error) {
+func (s *OrganizationService) GetPropertiesKeys(ctx context.Context, organizationID int) (*PropertyKeys, *Response, error) {
 	apiEndPoint := fmt.Sprintf("rest/servicedeskapi/organization/%d/property", organizationID)
 
 	req, err := s.client.NewRequest(ctx, "GET", apiEndPoint, nil)
@@ -210,17 +189,12 @@ func (s *OrganizationService) GetPropertiesKeysWithContext(ctx context.Context, 
 	return pk, resp, nil
 }
 
-// GetPropertiesKeys wraps GetPropertiesKeysWithContext using the background context.
-func (s *OrganizationService) GetPropertiesKeys(organizationID int) (*PropertyKeys, *Response, error) {
-	return s.GetPropertiesKeysWithContext(context.Background(), organizationID)
-}
-
-// GetPropertyWithContext returns the value of a property
+// GetProperty returns the value of a property
 // from an organization. Use this method to obtain the JSON
 // content for an organization's property.
 //
 // https://developer.atlassian.com/cloud/jira/service-desk/rest/api-group-organization/#api-rest-servicedeskapi-organization-organizationid-property-propertykey-get
-func (s *OrganizationService) GetPropertyWithContext(ctx context.Context, organizationID int, propertyKey string) (*EntityProperty, *Response, error) {
+func (s *OrganizationService) GetProperty(ctx context.Context, organizationID int, propertyKey string) (*EntityProperty, *Response, error) {
 	apiEndPoint := fmt.Sprintf("rest/servicedeskapi/organization/%d/property/%s", organizationID, propertyKey)
 
 	req, err := s.client.NewRequest(ctx, "GET", apiEndPoint, nil)
@@ -240,18 +214,13 @@ func (s *OrganizationService) GetPropertyWithContext(ctx context.Context, organi
 	return ep, resp, nil
 }
 
-// GetProperty wraps GetPropertyWithContext using the background context.
-func (s *OrganizationService) GetProperty(organizationID int, propertyKey string) (*EntityProperty, *Response, error) {
-	return s.GetPropertyWithContext(context.Background(), organizationID, propertyKey)
-}
-
-// SetPropertyWithContext sets the value of a
+// SetProperty sets the value of a
 // property for an organization. Use this
 // resource to store custom data against an organization.
 //
 // https://developer.atlassian.com/cloud/jira/service-desk/rest/api-group-organization/#api-rest-servicedeskapi-organization-organizationid-property-propertykey-put
 // Caller must close resp.Body
-func (s *OrganizationService) SetPropertyWithContext(ctx context.Context, organizationID int, propertyKey string) (*Response, error) {
+func (s *OrganizationService) SetProperty(ctx context.Context, organizationID int, propertyKey string) (*Response, error) {
 	apiEndPoint := fmt.Sprintf("rest/servicedeskapi/organization/%d/property/%s", organizationID, propertyKey)
 
 	req, err := s.client.NewRequest(ctx, "PUT", apiEndPoint, nil)
@@ -270,17 +239,11 @@ func (s *OrganizationService) SetPropertyWithContext(ctx context.Context, organi
 	return resp, nil
 }
 
-// SetProperty wraps SetPropertyWithContext using the background context.
-// Caller must close resp.Body
-func (s *OrganizationService) SetProperty(organizationID int, propertyKey string) (*Response, error) {
-	return s.SetPropertyWithContext(context.Background(), organizationID, propertyKey)
-}
-
-// DeletePropertyWithContext removes a property from an organization.
+// DeleteProperty removes a property from an organization.
 //
 // https://developer.atlassian.com/cloud/jira/service-desk/rest/api-group-organization/#api-rest-servicedeskapi-organization-organizationid-property-propertykey-delete
 // Caller must close resp.Body
-func (s *OrganizationService) DeletePropertyWithContext(ctx context.Context, organizationID int, propertyKey string) (*Response, error) {
+func (s *OrganizationService) DeleteProperty(ctx context.Context, organizationID int, propertyKey string) (*Response, error) {
 	apiEndPoint := fmt.Sprintf("rest/servicedeskapi/organization/%d/property/%s", organizationID, propertyKey)
 
 	req, err := s.client.NewRequest(ctx, "DELETE", apiEndPoint, nil)
@@ -299,20 +262,14 @@ func (s *OrganizationService) DeletePropertyWithContext(ctx context.Context, org
 	return resp, nil
 }
 
-// DeleteProperty wraps DeletePropertyWithContext using the background context.
-// Caller must close resp.Body
-func (s *OrganizationService) DeleteProperty(organizationID int, propertyKey string) (*Response, error) {
-	return s.DeletePropertyWithContext(context.Background(), organizationID, propertyKey)
-}
-
-// GetUsersWithContext returns all the users
+// GetUsers returns all the users
 // associated with an organization. Use this
 // method where you want to provide a list of
 // users for an organization or determine if
 // a user is associated with an organization.
 //
 // https://developer.atlassian.com/cloud/jira/service-desk/rest/api-group-organization/#api-rest-servicedeskapi-organization-organizationid-user-get
-func (s *OrganizationService) GetUsersWithContext(ctx context.Context, organizationID int, start int, limit int) (*PagedDTO, *Response, error) {
+func (s *OrganizationService) GetUsers(ctx context.Context, organizationID int, start int, limit int) (*PagedDTO, *Response, error) {
 	apiEndPoint := fmt.Sprintf("rest/servicedeskapi/organization/%d/user?start=%d&limit=%d", organizationID, start, limit)
 
 	req, err := s.client.NewRequest(ctx, "GET", apiEndPoint, nil)
@@ -332,16 +289,11 @@ func (s *OrganizationService) GetUsersWithContext(ctx context.Context, organizat
 	return users, resp, nil
 }
 
-// GetUsers wraps GetUsersWithContext using the background context.
-func (s *OrganizationService) GetUsers(organizationID int, start int, limit int) (*PagedDTO, *Response, error) {
-	return s.GetUsersWithContext(context.Background(), organizationID, start, limit)
-}
-
-// AddUsersWithContext adds users to an organization.
+// AddUsers adds users to an organization.
 //
 // https://developer.atlassian.com/cloud/jira/service-desk/rest/api-group-organization/#api-rest-servicedeskapi-organization-organizationid-user-post
 // Caller must close resp.Body
-func (s *OrganizationService) AddUsersWithContext(ctx context.Context, organizationID int, users OrganizationUsersDTO) (*Response, error) {
+func (s *OrganizationService) AddUsers(ctx context.Context, organizationID int, users OrganizationUsersDTO) (*Response, error) {
 	apiEndPoint := fmt.Sprintf("rest/servicedeskapi/organization/%d/user", organizationID)
 
 	req, err := s.client.NewRequest(ctx, "POST", apiEndPoint, users)
@@ -359,17 +311,11 @@ func (s *OrganizationService) AddUsersWithContext(ctx context.Context, organizat
 	return resp, nil
 }
 
-// AddUsers wraps AddUsersWithContext using the background context.
-// Caller must close resp.Body
-func (s *OrganizationService) AddUsers(organizationID int, users OrganizationUsersDTO) (*Response, error) {
-	return s.AddUsersWithContext(context.Background(), organizationID, users)
-}
-
-// RemoveUsersWithContext removes users from an organization.
+// RemoveUsers removes users from an organization.
 //
 // https://developer.atlassian.com/cloud/jira/service-desk/rest/api-group-organization/#api-rest-servicedeskapi-organization-organizationid-user-delete
 // Caller must close resp.Body
-func (s *OrganizationService) RemoveUsersWithContext(ctx context.Context, organizationID int, users OrganizationUsersDTO) (*Response, error) {
+func (s *OrganizationService) RemoveUsers(ctx context.Context, organizationID int, users OrganizationUsersDTO) (*Response, error) {
 	apiEndPoint := fmt.Sprintf("rest/servicedeskapi/organization/%d/user", organizationID)
 
 	req, err := s.client.NewRequest(ctx, "DELETE", apiEndPoint, nil)
@@ -386,10 +332,4 @@ func (s *OrganizationService) RemoveUsersWithContext(ctx context.Context, organi
 	}
 
 	return resp, nil
-}
-
-// RemoveUsers wraps RemoveUsersWithContext using the background context.
-// Caller must close resp.Body
-func (s *OrganizationService) RemoveUsers(organizationID int, users OrganizationUsersDTO) (*Response, error) {
-	return s.RemoveUsersWithContext(context.Background(), organizationID, users)
 }

--- a/cloud/organization_test.go
+++ b/cloud/organization_test.go
@@ -1,13 +1,14 @@
 package cloud
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"net/http"
 	"testing"
 )
 
-func TestOrganizationService_GetAllOrganizationsWithContext(t *testing.T) {
+func TestOrganizationService_GetAllOrganizations(t *testing.T) {
 	setup()
 	defer teardown()
 	testMux.HandleFunc("/rest/servicedeskapi/organization", func(w http.ResponseWriter, r *http.Request) {
@@ -18,7 +19,7 @@ func TestOrganizationService_GetAllOrganizationsWithContext(t *testing.T) {
 		fmt.Fprint(w, `{ "_expands": [], "size": 1, "start": 1, "limit": 1, "isLastPage": false, "_links": { "base": "https://your-domain.atlassian.net/rest/servicedeskapi", "context": "context", "next": "https://your-domain.atlassian.net/rest/servicedeskapi/organization?start=2&limit=1", "prev": "https://your-domain.atlassian.net/rest/servicedeskapi/organization?start=0&limit=1" }, "values": [ { "id": "1", "name": "Charlie Cakes Franchises", "_links": { "self": "https://your-domain.atlassian.net/rest/servicedeskapi/organization/1" } } ] }`)
 	})
 
-	result, _, err := testClient.Organization.GetAllOrganizations(0, 50, "")
+	result, _, err := testClient.Organization.GetAllOrganizations(context.Background(), 0, 50, "")
 
 	if result == nil {
 		t.Error("Expected Organizations. Result is nil")
@@ -45,7 +46,7 @@ func TestOrganizationService_CreateOrganization(t *testing.T) {
 	})
 
 	name := "MyOrg"
-	o, _, err := testClient.Organization.CreateOrganization(name)
+	o, _, err := testClient.Organization.CreateOrganization(context.Background(), name)
 
 	if o == nil {
 		t.Error("Expected Organization. Result is nil")
@@ -70,7 +71,7 @@ func TestOrganizationService_GetOrganization(t *testing.T) {
 	})
 
 	id := 1
-	o, _, err := testClient.Organization.GetOrganization(id)
+	o, _, err := testClient.Organization.GetOrganization(context.Background(), id)
 
 	if err != nil {
 		t.Errorf("Error given: %s", err)
@@ -93,7 +94,7 @@ func TestOrganizationService_DeleteOrganization(t *testing.T) {
 		w.WriteHeader(http.StatusNoContent)
 	})
 
-	_, err := testClient.Organization.DeleteOrganization(1)
+	_, err := testClient.Organization.DeleteOrganization(context.Background(), 1)
 
 	if err != nil {
 		t.Errorf("Error given: %s", err)
@@ -118,7 +119,7 @@ func TestOrganizationService_GetPropertiesKeys(t *testing.T) {
 		  }`)
 	})
 
-	pk, _, err := testClient.Organization.GetPropertiesKeys(1)
+	pk, _, err := testClient.Organization.GetPropertiesKeys(context.Background(), 1)
 
 	if err != nil {
 		t.Errorf("Error given: %s", err)
@@ -149,7 +150,7 @@ func TestOrganizationService_GetProperty(t *testing.T) {
 	})
 
 	key := "organization.attributes"
-	ep, _, err := testClient.Organization.GetProperty(1, key)
+	ep, _, err := testClient.Organization.GetProperty(context.Background(), 1, key)
 
 	if err != nil {
 		t.Errorf("Error given: %s", err)
@@ -173,7 +174,7 @@ func TestOrganizationService_SetProperty(t *testing.T) {
 	})
 
 	key := "organization.attributes"
-	_, err := testClient.Organization.SetProperty(1, key)
+	_, err := testClient.Organization.SetProperty(context.Background(), 1, key)
 
 	if err != nil {
 		t.Errorf("Error given: %s", err)
@@ -191,7 +192,7 @@ func TestOrganizationService_DeleteProperty(t *testing.T) {
 	})
 
 	key := "organization.attributes"
-	_, err := testClient.Organization.DeleteProperty(1, key)
+	_, err := testClient.Organization.DeleteProperty(context.Background(), 1, key)
 
 	if err != nil {
 		t.Errorf("Error given: %s", err)
@@ -261,7 +262,7 @@ func TestOrganizationService_GetUsers(t *testing.T) {
 		  }`)
 	})
 
-	users, _, err := testClient.Organization.GetUsers(1, 0, 50)
+	users, _, err := testClient.Organization.GetUsers(context.Background(), 1, 0, 50)
 
 	if err != nil {
 		t.Errorf("Error given: %s", err)
@@ -294,7 +295,7 @@ func TestOrganizationService_AddUsers(t *testing.T) {
 			"qm:a713c8ea-1075-4e30-9d96-891a7d181739:5ad6d3a01db05e2a66fa80bd",
 		},
 	}
-	_, err := testClient.Organization.AddUsers(1, users)
+	_, err := testClient.Organization.AddUsers(context.Background(), 1, users)
 
 	if err != nil {
 		t.Errorf("Error given: %s", err)
@@ -317,7 +318,7 @@ func TestOrganizationService_RemoveUsers(t *testing.T) {
 			"qm:a713c8ea-1075-4e30-9d96-891a7d181739:5ad6d3a01db05e2a66fa80bd",
 		},
 	}
-	_, err := testClient.Organization.RemoveUsers(1, users)
+	_, err := testClient.Organization.RemoveUsers(context.Background(), 1, users)
 
 	if err != nil {
 		t.Errorf("Error given: %s", err)

--- a/onpremise/auth_transport_jwt_test.go
+++ b/onpremise/auth_transport_jwt_test.go
@@ -1,6 +1,7 @@
 package onpremise
 
 import (
+	"context"
 	"net/http"
 	"strings"
 	"testing"
@@ -27,5 +28,5 @@ func TestJWTAuthTransport_HeaderContainsJWT(t *testing.T) {
 	})
 
 	jwtClient, _ := NewClient(testServer.URL, jwtTransport.Client())
-	jwtClient.Issue.Get("TEST-1", nil)
+	jwtClient.Issue.Get(context.Background(), "TEST-1", nil)
 }

--- a/onpremise/authentication.go
+++ b/onpremise/authentication.go
@@ -48,7 +48,7 @@ type Session struct {
 	Cookies []*http.Cookie
 }
 
-// AcquireSessionCookieWithContext creates a new session for a user in Jira.
+// AcquireSessionCookie creates a new session for a user in Jira.
 // Once a session has been successfully created it can be used to access any of Jira's remote APIs and also the web UI by passing the appropriate HTTP Cookie header.
 // The header will by automatically applied to every API request.
 // Note that it is generally preferrable to use HTTP BASIC authentication with the REST API.
@@ -57,7 +57,7 @@ type Session struct {
 // Jira API docs: https://docs.atlassian.com/jira/REST/latest/#auth/1/session
 //
 // Deprecated: Use CookieAuthTransport instead
-func (s *AuthenticationService) AcquireSessionCookieWithContext(ctx context.Context, username, password string) (bool, error) {
+func (s *AuthenticationService) AcquireSessionCookie(ctx context.Context, username, password string) (bool, error) {
 	apiEndpoint := "rest/auth/1/session"
 	body := struct {
 		Username string `json:"username"`
@@ -92,13 +92,6 @@ func (s *AuthenticationService) AcquireSessionCookieWithContext(ctx context.Cont
 	return true, nil
 }
 
-// AcquireSessionCookie wraps AcquireSessionCookieWithContext using the background context.
-//
-// Deprecated: Use CookieAuthTransport instead
-func (s *AuthenticationService) AcquireSessionCookie(username, password string) (bool, error) {
-	return s.AcquireSessionCookieWithContext(context.Background(), username, password)
-}
-
 // SetBasicAuth sets username and password for the basic auth against the Jira instance.
 //
 // Deprecated: Use BasicAuthTransport instead
@@ -121,13 +114,13 @@ func (s *AuthenticationService) Authenticated() bool {
 	return false
 }
 
-// LogoutWithContext logs out the current user that has been authenticated and the session in the client is destroyed.
+// Logout logs out the current user that has been authenticated and the session in the client is destroyed.
 //
 // Jira API docs: https://docs.atlassian.com/jira/REST/latest/#auth/1/session
 //
 // Deprecated: Use CookieAuthTransport to create base client.  Logging out is as simple as not using the
 // client anymore
-func (s *AuthenticationService) LogoutWithContext(ctx context.Context) error {
+func (s *AuthenticationService) Logout(ctx context.Context) error {
 	if s.authType != authTypeSession || s.client.session == nil {
 		return fmt.Errorf("no user is authenticated")
 	}
@@ -154,18 +147,10 @@ func (s *AuthenticationService) LogoutWithContext(ctx context.Context) error {
 
 }
 
-// Logout wraps LogoutWithContext using the background context.
-//
-// Deprecated: Use CookieAuthTransport to create base client.  Logging out is as simple as not using the
-// client anymore
-func (s *AuthenticationService) Logout() error {
-	return s.LogoutWithContext(context.Background())
-}
-
-// GetCurrentUserWithContext gets the details of the current user.
+// GetCurrentUser gets the details of the current user.
 //
 // Jira API docs: https://docs.atlassian.com/jira/REST/latest/#auth/1/session
-func (s *AuthenticationService) GetCurrentUserWithContext(ctx context.Context) (*Session, error) {
+func (s *AuthenticationService) GetCurrentUser(ctx context.Context) (*Session, error) {
 	if s == nil {
 		return nil, fmt.Errorf("authentication Service is not instantiated")
 	}
@@ -200,9 +185,4 @@ func (s *AuthenticationService) GetCurrentUserWithContext(ctx context.Context) (
 	}
 
 	return ret, nil
-}
-
-// GetCurrentUser wraps GetCurrentUserWithContext using the background context.
-func (s *AuthenticationService) GetCurrentUser() (*Session, error) {
-	return s.GetCurrentUserWithContext(context.Background())
 }

--- a/onpremise/authentication_test.go
+++ b/onpremise/authentication_test.go
@@ -2,6 +2,7 @@ package onpremise
 
 import (
 	"bytes"
+	"context"
 	"fmt"
 	"io"
 	"net/http"
@@ -30,7 +31,7 @@ func TestAuthenticationService_AcquireSessionCookie_Failure(t *testing.T) {
 		w.WriteHeader(http.StatusInternalServerError)
 	})
 
-	res, err := testClient.Authentication.AcquireSessionCookie("foo", "bar")
+	res, err := testClient.Authentication.AcquireSessionCookie(context.Background(), "foo", "bar")
 	if err == nil {
 		t.Errorf("Expected error, but no error given")
 	}
@@ -63,7 +64,7 @@ func TestAuthenticationService_AcquireSessionCookie_Success(t *testing.T) {
 		fmt.Fprint(w, `{"session":{"name":"JSESSIONID","value":"12345678901234567890"},"loginInfo":{"failedLoginCount":10,"loginCount":127,"lastFailedLoginTime":"2016-03-16T04:22:35.386+0000","previousLoginTime":"2016-03-16T04:22:35.386+0000"}}`)
 	})
 
-	res, err := testClient.Authentication.AcquireSessionCookie("foo", "bar")
+	res, err := testClient.Authentication.AcquireSessionCookie(context.Background(), "foo", "bar")
 	if err != nil {
 		t.Errorf("No error expected. Got %s", err)
 	}
@@ -162,9 +163,9 @@ func TestAuthenticationService_GetUserInfo_AccessForbidden_Fail(t *testing.T) {
 		}
 	})
 
-	testClient.Authentication.AcquireSessionCookie("foo", "bar")
+	testClient.Authentication.AcquireSessionCookie(context.Background(), "foo", "bar")
 
-	_, err := testClient.Authentication.GetCurrentUser()
+	_, err := testClient.Authentication.GetCurrentUser(context.Background())
 	if err == nil {
 		t.Errorf("Non nil error expect, received nil")
 	}
@@ -200,9 +201,9 @@ func TestAuthenticationService_GetUserInfo_NonOkStatusCode_Fail(t *testing.T) {
 		}
 	})
 
-	testClient.Authentication.AcquireSessionCookie("foo", "bar")
+	testClient.Authentication.AcquireSessionCookie(context.Background(), "foo", "bar")
 
-	_, err := testClient.Authentication.GetCurrentUser()
+	_, err := testClient.Authentication.GetCurrentUser(context.Background())
 	if err == nil {
 		t.Errorf("Non nil error expect, received nil")
 	}
@@ -212,7 +213,7 @@ func TestAuthenticationService_GetUserInfo_FailWithoutLogin(t *testing.T) {
 	// no setup() required here
 	testClient = new(Client)
 
-	_, err := testClient.Authentication.GetCurrentUser()
+	_, err := testClient.Authentication.GetCurrentUser(context.Background())
 	if err == nil {
 		t.Errorf("Expected error, but got %s", err)
 	}
@@ -255,9 +256,9 @@ func TestAuthenticationService_GetUserInfo_Success(t *testing.T) {
 		}
 	})
 
-	testClient.Authentication.AcquireSessionCookie("foo", "bar")
+	testClient.Authentication.AcquireSessionCookie(context.Background(), "foo", "bar")
 
-	userinfo, err := testClient.Authentication.GetCurrentUser()
+	userinfo, err := testClient.Authentication.GetCurrentUser(context.Background())
 	if err != nil {
 		t.Errorf("Nil error expect, received %s", err)
 	}
@@ -296,9 +297,9 @@ func TestAuthenticationService_Logout_Success(t *testing.T) {
 		}
 	})
 
-	testClient.Authentication.AcquireSessionCookie("foo", "bar")
+	testClient.Authentication.AcquireSessionCookie(context.Background(), "foo", "bar")
 
-	err := testClient.Authentication.Logout()
+	err := testClient.Authentication.Logout(context.Background())
 	if err != nil {
 		t.Errorf("Expected nil error, got %s", err)
 	}
@@ -314,7 +315,7 @@ func TestAuthenticationService_Logout_FailWithoutLogin(t *testing.T) {
 			w.WriteHeader(http.StatusUnauthorized)
 		}
 	})
-	err := testClient.Authentication.Logout()
+	err := testClient.Authentication.Logout(context.Background())
 	if err == nil {
 		t.Error("Expected not nil, got nil")
 	}

--- a/onpremise/board.go
+++ b/onpremise/board.go
@@ -125,10 +125,10 @@ type BoardConfigurationColumnStatus struct {
 	Self string `json:"self"`
 }
 
-// GetAllBoardsWithContext will returns all boards. This only includes boards that the user has permission to view.
+// GetAllBoards will returns all boards. This only includes boards that the user has permission to view.
 //
 // Jira API docs: https://docs.atlassian.com/jira-software/REST/cloud/#agile/1.0/board-getAllBoards
-func (s *BoardService) GetAllBoardsWithContext(ctx context.Context, opt *BoardListOptions) (*BoardsList, *Response, error) {
+func (s *BoardService) GetAllBoards(ctx context.Context, opt *BoardListOptions) (*BoardsList, *Response, error) {
 	apiEndpoint := "rest/agile/1.0/board"
 	url, err := addOptions(apiEndpoint, opt)
 	if err != nil {
@@ -149,16 +149,11 @@ func (s *BoardService) GetAllBoardsWithContext(ctx context.Context, opt *BoardLi
 	return boards, resp, err
 }
 
-// GetAllBoards wraps GetAllBoardsWithContext using the background context.
-func (s *BoardService) GetAllBoards(opt *BoardListOptions) (*BoardsList, *Response, error) {
-	return s.GetAllBoardsWithContext(context.Background(), opt)
-}
-
-// GetBoardWithContext will returns the board for the given boardID.
+// GetBoard will returns the board for the given boardID.
 // This board will only be returned if the user has permission to view it.
 //
 // Jira API docs: https://docs.atlassian.com/jira-software/REST/cloud/#agile/1.0/board-getBoard
-func (s *BoardService) GetBoardWithContext(ctx context.Context, boardID int) (*Board, *Response, error) {
+func (s *BoardService) GetBoard(ctx context.Context, boardID int) (*Board, *Response, error) {
 	apiEndpoint := fmt.Sprintf("rest/agile/1.0/board/%v", boardID)
 	req, err := s.client.NewRequest(ctx, "GET", apiEndpoint, nil)
 	if err != nil {
@@ -175,12 +170,7 @@ func (s *BoardService) GetBoardWithContext(ctx context.Context, boardID int) (*B
 	return board, resp, nil
 }
 
-// GetBoard wraps GetBoardWithContext using the background context.
-func (s *BoardService) GetBoard(boardID int) (*Board, *Response, error) {
-	return s.GetBoardWithContext(context.Background(), boardID)
-}
-
-// CreateBoardWithContext creates a new board. Board name, type and filter Id is required.
+// CreateBoard creates a new board. Board name, type and filter Id is required.
 // name - Must be less than 255 characters.
 // type - Valid values: scrum, kanban
 // filterId - Id of a filter that the user has permissions to view.
@@ -188,7 +178,7 @@ func (s *BoardService) GetBoard(boardID int) (*Board, *Response, error) {
 // board will be created instead (remember that board sharing depends on the filter sharing).
 //
 // Jira API docs: https://docs.atlassian.com/jira-software/REST/cloud/#agile/1.0/board-createBoard
-func (s *BoardService) CreateBoardWithContext(ctx context.Context, board *Board) (*Board, *Response, error) {
+func (s *BoardService) CreateBoard(ctx context.Context, board *Board) (*Board, *Response, error) {
 	apiEndpoint := "rest/agile/1.0/board"
 	req, err := s.client.NewRequest(ctx, "POST", apiEndpoint, board)
 	if err != nil {
@@ -205,16 +195,11 @@ func (s *BoardService) CreateBoardWithContext(ctx context.Context, board *Board)
 	return responseBoard, resp, nil
 }
 
-// CreateBoard wraps CreateBoardWithContext using the background context.
-func (s *BoardService) CreateBoard(board *Board) (*Board, *Response, error) {
-	return s.CreateBoardWithContext(context.Background(), board)
-}
-
-// DeleteBoardWithContext will delete an agile board.
+// DeleteBoard will delete an agile board.
 //
 // Jira API docs: https://docs.atlassian.com/jira-software/REST/cloud/#agile/1.0/board-deleteBoard
 // Caller must close resp.Body
-func (s *BoardService) DeleteBoardWithContext(ctx context.Context, boardID int) (*Board, *Response, error) {
+func (s *BoardService) DeleteBoard(ctx context.Context, boardID int) (*Board, *Response, error) {
 	apiEndpoint := fmt.Sprintf("rest/agile/1.0/board/%v", boardID)
 	req, err := s.client.NewRequest(ctx, "DELETE", apiEndpoint, nil)
 	if err != nil {
@@ -228,23 +213,17 @@ func (s *BoardService) DeleteBoardWithContext(ctx context.Context, boardID int) 
 	return nil, resp, err
 }
 
-// DeleteBoard wraps DeleteBoardWithContext using the background context.
-// Caller must close resp.Body
-func (s *BoardService) DeleteBoard(boardID int) (*Board, *Response, error) {
-	return s.DeleteBoardWithContext(context.Background(), boardID)
-}
-
-// GetAllSprintsWithContext will return all sprints from a board, for a given board Id.
+// GetAllSprints will return all sprints from a board, for a given board Id.
 // This only includes sprints that the user has permission to view.
 //
 // Jira API docs: https://docs.atlassian.com/jira-software/REST/cloud/#agile/1.0/board/{boardId}/sprint
-func (s *BoardService) GetAllSprintsWithContext(ctx context.Context, boardID string) ([]Sprint, *Response, error) {
+func (s *BoardService) GetAllSprints(ctx context.Context, boardID string) ([]Sprint, *Response, error) {
 	id, err := strconv.Atoi(boardID)
 	if err != nil {
 		return nil, nil, err
 	}
 
-	result, response, err := s.GetAllSprintsWithOptions(id, &GetAllSprintsOptions{})
+	result, response, err := s.GetAllSprintsWithOptions(ctx, id, &GetAllSprintsOptions{})
 	if err != nil {
 		return nil, nil, err
 	}
@@ -252,16 +231,11 @@ func (s *BoardService) GetAllSprintsWithContext(ctx context.Context, boardID str
 	return result.Values, response, nil
 }
 
-// GetAllSprints wraps GetAllSprintsWithContext using the background context.
-func (s *BoardService) GetAllSprints(boardID string) ([]Sprint, *Response, error) {
-	return s.GetAllSprintsWithContext(context.Background(), boardID)
-}
-
-// GetAllSprintsWithOptionsWithContext will return sprints from a board, for a given board Id and filtering options
+// GetAllSprintsWithOptions will return sprints from a board, for a given board Id and filtering options
 // This only includes sprints that the user has permission to view.
 //
 // Jira API docs: https://docs.atlassian.com/jira-software/REST/cloud/#agile/1.0/board/{boardId}/sprint
-func (s *BoardService) GetAllSprintsWithOptionsWithContext(ctx context.Context, boardID int, options *GetAllSprintsOptions) (*SprintsList, *Response, error) {
+func (s *BoardService) GetAllSprintsWithOptions(ctx context.Context, boardID int, options *GetAllSprintsOptions) (*SprintsList, *Response, error) {
 	apiEndpoint := fmt.Sprintf("rest/agile/1.0/board/%d/sprint", boardID)
 	url, err := addOptions(apiEndpoint, options)
 	if err != nil {
@@ -281,14 +255,9 @@ func (s *BoardService) GetAllSprintsWithOptionsWithContext(ctx context.Context, 
 	return result, resp, err
 }
 
-// GetAllSprintsWithOptions wraps GetAllSprintsWithOptionsWithContext using the background context.
-func (s *BoardService) GetAllSprintsWithOptions(boardID int, options *GetAllSprintsOptions) (*SprintsList, *Response, error) {
-	return s.GetAllSprintsWithOptionsWithContext(context.Background(), boardID, options)
-}
-
-// GetBoardConfigurationWithContext will return a board configuration for a given board Id
+// GetBoardConfiguration will return a board configuration for a given board Id
 // Jira API docs:https://developer.atlassian.com/cloud/jira/software/rest/#api-rest-agile-1-0-board-boardId-configuration-get
-func (s *BoardService) GetBoardConfigurationWithContext(ctx context.Context, boardID int) (*BoardConfiguration, *Response, error) {
+func (s *BoardService) GetBoardConfiguration(ctx context.Context, boardID int) (*BoardConfiguration, *Response, error) {
 	apiEndpoint := fmt.Sprintf("rest/agile/1.0/board/%d/configuration", boardID)
 
 	req, err := s.client.NewRequest(ctx, "GET", apiEndpoint, nil)
@@ -305,9 +274,4 @@ func (s *BoardService) GetBoardConfigurationWithContext(ctx context.Context, boa
 
 	return result, resp, err
 
-}
-
-// GetBoardConfiguration wraps GetBoardConfigurationWithContext using the background context.
-func (s *BoardService) GetBoardConfiguration(boardID int) (*BoardConfiguration, *Response, error) {
-	return s.GetBoardConfigurationWithContext(context.Background(), boardID)
 }

--- a/onpremise/board_test.go
+++ b/onpremise/board_test.go
@@ -1,6 +1,7 @@
 package onpremise
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 	"os"
@@ -22,7 +23,7 @@ func TestBoardService_GetAllBoards(t *testing.T) {
 		fmt.Fprint(w, string(raw))
 	})
 
-	projects, _, err := testClient.Board.GetAllBoards(nil)
+	projects, _, err := testClient.Board.GetAllBoards(context.Background(), nil)
 	if projects == nil {
 		t.Error("Expected boards list. Boards list is nil")
 	}
@@ -56,7 +57,7 @@ func TestBoardService_GetAllBoards_WithFilter(t *testing.T) {
 	boardsListOptions.StartAt = 1
 	boardsListOptions.MaxResults = 10
 
-	projects, _, err := testClient.Board.GetAllBoards(boardsListOptions)
+	projects, _, err := testClient.Board.GetAllBoards(context.Background(), boardsListOptions)
 	if projects == nil {
 		t.Error("Expected boards list. Boards list is nil")
 	}
@@ -76,7 +77,7 @@ func TestBoardService_GetBoard(t *testing.T) {
 		fmt.Fprint(w, `{"id":4,"self":"https://test.jira.org/rest/agile/1.0/board/1","name":"Test Weekly","type":"scrum"}`)
 	})
 
-	board, _, err := testClient.Board.GetBoard(1)
+	board, _, err := testClient.Board.GetBoard(context.Background(), 1)
 	if board == nil {
 		t.Error("Expected board list. Board list is nil")
 	}
@@ -96,7 +97,7 @@ func TestBoardService_GetBoard_WrongID(t *testing.T) {
 		fmt.Fprint(w, nil)
 	})
 
-	board, resp, err := testClient.Board.GetBoard(99999999)
+	board, resp, err := testClient.Board.GetBoard(context.Background(), 99999999)
 	if board != nil {
 		t.Errorf("Expected nil. Got %s", err)
 	}
@@ -125,7 +126,7 @@ func TestBoardService_CreateBoard(t *testing.T) {
 		Type:     "kanban",
 		FilterID: 17,
 	}
-	issue, _, err := testClient.Board.CreateBoard(b)
+	issue, _, err := testClient.Board.CreateBoard(context.Background(), b)
 	if issue == nil {
 		t.Error("Expected board. Board is nil")
 	}
@@ -145,7 +146,7 @@ func TestBoardService_DeleteBoard(t *testing.T) {
 		fmt.Fprint(w, `{}`)
 	})
 
-	_, resp, err := testClient.Board.DeleteBoard(1)
+	_, resp, err := testClient.Board.DeleteBoard(context.Background(), 1)
 	if resp.StatusCode != 204 {
 		t.Error("Expected board not deleted.")
 	}
@@ -171,7 +172,7 @@ func TestBoardService_GetAllSprints(t *testing.T) {
 		fmt.Fprint(w, string(raw))
 	})
 
-	sprints, _, err := testClient.Board.GetAllSprints("123")
+	sprints, _, err := testClient.Board.GetAllSprints(context.Background(), "123")
 
 	if err != nil {
 		t.Errorf("Got error: %v", err)
@@ -203,7 +204,7 @@ func TestBoardService_GetAllSprintsWithOptions(t *testing.T) {
 		fmt.Fprint(w, string(raw))
 	})
 
-	sprints, _, err := testClient.Board.GetAllSprintsWithOptions(123, &GetAllSprintsOptions{State: "active,future"})
+	sprints, _, err := testClient.Board.GetAllSprintsWithOptions(context.Background(), 123, &GetAllSprintsOptions{State: "active,future"})
 	if err != nil {
 		t.Errorf("Got error: %v", err)
 	}
@@ -234,7 +235,7 @@ func TestBoardService_GetBoardConfigoration(t *testing.T) {
 		fmt.Fprint(w, string(raw))
 	})
 
-	boardConfiguration, _, err := testClient.Board.GetBoardConfiguration(35)
+	boardConfiguration, _, err := testClient.Board.GetBoardConfiguration(context.Background(), 35)
 	if err != nil {
 		t.Errorf("Got error: %v", err)
 	}

--- a/onpremise/examples/addlabel/main.go
+++ b/onpremise/examples/addlabel/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"bufio"
+	"context"
 	"fmt"
 	"io"
 	"os"
@@ -62,7 +63,7 @@ func main() {
 		},
 	}
 
-	resp, err := client.Issue.UpdateIssue(issueId, c)
+	resp, err := client.Issue.UpdateIssue(context.Background(), issueId, c)
 
 	if err != nil {
 		fmt.Println(err)
@@ -70,7 +71,7 @@ func main() {
 	body, _ := io.ReadAll(resp.Body)
 	fmt.Println(string(body))
 
-	issue, _, _ := client.Issue.Get(issueId, nil)
+	issue, _, _ := client.Issue.Get(context.Background(), issueId, nil)
 
 	fmt.Printf("Issue: %s:%s\n", issue.Key, issue.Fields.Summary)
 	fmt.Printf("\tLabels: %+v\n", issue.Fields.Labels)

--- a/onpremise/examples/create/main.go
+++ b/onpremise/examples/create/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"bufio"
+	"context"
 	"fmt"
 	"os"
 	"strings"
@@ -54,7 +55,7 @@ func main() {
 		},
 	}
 
-	issue, _, err := client.Issue.Create(&i)
+	issue, _, err := client.Issue.Create(context.Background(), &i)
 	if err != nil {
 		panic(err)
 	}

--- a/onpremise/examples/createwithcustomfields/main.go
+++ b/onpremise/examples/createwithcustomfields/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"bufio"
+	"context"
 	"fmt"
 	"os"
 	"strings"
@@ -65,7 +66,7 @@ func main() {
 		},
 	}
 
-	issue, _, err := client.Issue.Create(&i)
+	issue, _, err := client.Issue.Create(context.Background(), &i)
 	if err != nil {
 		panic(err)
 	}

--- a/onpremise/examples/ignorecerts/main.go
+++ b/onpremise/examples/ignorecerts/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"crypto/tls"
 	"fmt"
 	"net/http"
@@ -15,7 +16,7 @@ func main() {
 	client := &http.Client{Transport: tr}
 
 	jiraClient, _ := jira.NewClient("https://issues.apache.org/jira/", client)
-	issue, _, _ := jiraClient.Issue.Get("MESOS-3325", nil)
+	issue, _, _ := jiraClient.Issue.Get(context.Background(), "MESOS-3325", nil)
 
 	fmt.Printf("%s: %+v\n", issue.Key, issue.Fields.Summary)
 	fmt.Printf("Type: %s\n", issue.Fields.Type.Name)

--- a/onpremise/examples/jql/main.go
+++ b/onpremise/examples/jql/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"fmt"
 
 	jira "github.com/andygrunwald/go-jira/onpremise"
@@ -13,7 +14,7 @@ func main() {
 
 	jql := "project = Mesos and type = Bug and Status NOT IN (Resolved)"
 	fmt.Printf("Usecase: Running a JQL query '%s'\n", jql)
-	issues, resp, err := jiraClient.Issue.Search(jql, nil)
+	issues, resp, err := jiraClient.Issue.Search(context.Background(), jql, nil)
 	if err != nil {
 		panic(err)
 	}
@@ -25,7 +26,7 @@ func main() {
 	// Running an empty JQL query to get all tickets
 	jql = ""
 	fmt.Printf("Usecase: Running an empty JQL query to get all tickets\n")
-	issues, resp, err = jiraClient.Issue.Search(jql, nil)
+	issues, resp, err = jiraClient.Issue.Search(context.Background(), jql, nil)
 	if err != nil {
 		panic(err)
 	}

--- a/onpremise/examples/newclient/main.go
+++ b/onpremise/examples/newclient/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"fmt"
 
 	jira "github.com/andygrunwald/go-jira/onpremise"
@@ -8,7 +9,7 @@ import (
 
 func main() {
 	jiraClient, _ := jira.NewClient("https://issues.apache.org/jira/", nil)
-	issue, _, _ := jiraClient.Issue.Get("MESOS-3325", nil)
+	issue, _, _ := jiraClient.Issue.Get(context.Background(), "MESOS-3325", nil)
 
 	fmt.Printf("%s: %+v\n", issue.Key, issue.Fields.Summary)
 	fmt.Printf("Type: %s\n", issue.Fields.Type.Name)

--- a/onpremise/examples/pagination/main.go
+++ b/onpremise/examples/pagination/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"fmt"
 
 	jira "github.com/andygrunwald/go-jira/onpremise"
@@ -19,7 +20,7 @@ func GetAllIssues(client *jira.Client, searchString string) ([]jira.Issue, error
 			StartAt:    last,
 		}
 
-		chunk, resp, err := client.Issue.Search(searchString, opt)
+		chunk, resp, err := client.Issue.Search(context.Background(), searchString, opt)
 		if err != nil {
 			return nil, err
 		}

--- a/onpremise/examples/renderedfields/main.go
+++ b/onpremise/examples/renderedfields/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"bufio"
+	"context"
 	"fmt"
 	"net/http"
 	"os"
@@ -52,7 +53,7 @@ func main() {
 	fmt.Printf("Targeting %s for issue %s\n", strings.TrimSpace(jiraURL), key)
 
 	options := &jira.GetQueryOptions{Expand: "renderedFields"}
-	u, _, err := client.Issue.Get(key, options)
+	u, _, err := client.Issue.Get(context.Background(), key, options)
 
 	if err != nil {
 		fmt.Printf("\n==> error: %v\n", err)

--- a/onpremise/examples/searchpages/main.go
+++ b/onpremise/examples/searchpages/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"bufio"
+	"context"
 	"fmt"
 	"log"
 	"os"
@@ -49,7 +50,7 @@ func main() {
 
 	// SearchPages will page through results and pass each issue to appendFunc
 	// In this example, we'll search for all the issues in the target project
-	err = client.Issue.SearchPages(fmt.Sprintf(`project=%s`, strings.TrimSpace(jiraPK)), nil, appendFunc)
+	err = client.Issue.SearchPages(context.Background(), fmt.Sprintf(`project=%s`, strings.TrimSpace(jiraPK)), nil, appendFunc)
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/onpremise/issue.go
+++ b/onpremise/issue.go
@@ -605,7 +605,7 @@ type RemoteLinkStatus struct {
 	Icon     *RemoteLinkIcon `json:"icon,omitempty" structs:"icon,omitempty"`
 }
 
-// GetWithContext returns a full representation of the issue for the given issue key.
+// Get returns a full representation of the issue for the given issue key.
 // Jira will attempt to identify the issue by the issueIdOrKey path parameter.
 // This can be an issue id, or an issue key.
 // If the issue cannot be found via an exact match, Jira will also look for the issue in a case-insensitive way, or by looking to see if the issue was moved.
@@ -613,7 +613,7 @@ type RemoteLinkStatus struct {
 // # The given options will be appended to the query string
 //
 // Jira API docs: https://docs.atlassian.com/jira/REST/latest/#api/2/issue-getIssue
-func (s *IssueService) GetWithContext(ctx context.Context, issueID string, options *GetQueryOptions) (*Issue, *Response, error) {
+func (s *IssueService) Get(ctx context.Context, issueID string, options *GetQueryOptions) (*Issue, *Response, error) {
 	apiEndpoint := fmt.Sprintf("rest/api/2/issue/%s", issueID)
 	req, err := s.client.NewRequest(ctx, "GET", apiEndpoint, nil)
 	if err != nil {
@@ -638,16 +638,11 @@ func (s *IssueService) GetWithContext(ctx context.Context, issueID string, optio
 	return issue, resp, nil
 }
 
-// Get wraps GetWithContext using the background context.
-func (s *IssueService) Get(issueID string, options *GetQueryOptions) (*Issue, *Response, error) {
-	return s.GetWithContext(context.Background(), issueID, options)
-}
-
-// DownloadAttachmentWithContext returns a Response of an attachment for a given attachmentID.
+// DownloadAttachment returns a Response of an attachment for a given attachmentID.
 // The attachment is in the Response.Body of the response.
 // This is an io.ReadCloser.
 // Caller must close resp.Body.
-func (s *IssueService) DownloadAttachmentWithContext(ctx context.Context, attachmentID string) (*Response, error) {
+func (s *IssueService) DownloadAttachment(ctx context.Context, attachmentID string) (*Response, error) {
 	apiEndpoint := fmt.Sprintf("secure/attachment/%s/", attachmentID)
 	req, err := s.client.NewRequest(ctx, "GET", apiEndpoint, nil)
 	if err != nil {
@@ -663,14 +658,8 @@ func (s *IssueService) DownloadAttachmentWithContext(ctx context.Context, attach
 	return resp, nil
 }
 
-// DownloadAttachment wraps DownloadAttachmentWithContext using the background context.
-// Caller must close resp.Body
-func (s *IssueService) DownloadAttachment(attachmentID string) (*Response, error) {
-	return s.DownloadAttachmentWithContext(context.Background(), attachmentID)
-}
-
-// PostAttachmentWithContext uploads r (io.Reader) as an attachment to a given issueID
-func (s *IssueService) PostAttachmentWithContext(ctx context.Context, issueID string, r io.Reader, attachmentName string) (*[]Attachment, *Response, error) {
+// PostAttachment uploads r (io.Reader) as an attachment to a given issueID
+func (s *IssueService) PostAttachment(ctx context.Context, issueID string, r io.Reader, attachmentName string) (*[]Attachment, *Response, error) {
 	apiEndpoint := fmt.Sprintf("rest/api/2/issue/%s/attachments", issueID)
 
 	b := new(bytes.Buffer)
@@ -707,14 +696,9 @@ func (s *IssueService) PostAttachmentWithContext(ctx context.Context, issueID st
 	return attachment, resp, nil
 }
 
-// PostAttachment wraps PostAttachmentWithContext using the background context.
-func (s *IssueService) PostAttachment(issueID string, r io.Reader, attachmentName string) (*[]Attachment, *Response, error) {
-	return s.PostAttachmentWithContext(context.Background(), issueID, r, attachmentName)
-}
-
-// DeleteAttachmentWithContext deletes an attachment of a given attachmentID
+// DeleteAttachment deletes an attachment of a given attachmentID
 // Caller must close resp.Body
-func (s *IssueService) DeleteAttachmentWithContext(ctx context.Context, attachmentID string) (*Response, error) {
+func (s *IssueService) DeleteAttachment(ctx context.Context, attachmentID string) (*Response, error) {
 	apiEndpoint := fmt.Sprintf("rest/api/2/attachment/%s", attachmentID)
 
 	req, err := s.client.NewRequest(ctx, "DELETE", apiEndpoint, nil)
@@ -731,15 +715,9 @@ func (s *IssueService) DeleteAttachmentWithContext(ctx context.Context, attachme
 	return resp, nil
 }
 
-// DeleteAttachment wraps DeleteAttachmentWithContext using the background context.
+// DeleteLink deletes a link of a given linkID
 // Caller must close resp.Body
-func (s *IssueService) DeleteAttachment(attachmentID string) (*Response, error) {
-	return s.DeleteAttachmentWithContext(context.Background(), attachmentID)
-}
-
-// DeleteLinkWithContext deletes a link of a given linkID
-// Caller must close resp.Body
-func (s *IssueService) DeleteLinkWithContext(ctx context.Context, linkID string) (*Response, error) {
+func (s *IssueService) DeleteLink(ctx context.Context, linkID string) (*Response, error) {
 	apiEndpoint := fmt.Sprintf("rest/api/2/issueLink/%s", linkID)
 
 	req, err := s.client.NewRequest(ctx, "DELETE", apiEndpoint, nil)
@@ -756,17 +734,11 @@ func (s *IssueService) DeleteLinkWithContext(ctx context.Context, linkID string)
 	return resp, nil
 }
 
-// DeleteLink wraps DeleteLinkWithContext using the background context.
-// Caller must close resp.Body
-func (s *IssueService) DeleteLink(linkID string) (*Response, error) {
-	return s.DeleteLinkWithContext(context.Background(), linkID)
-}
-
-// GetWorklogsWithContext gets all the worklogs for an issue.
+// GetWorklogs gets all the worklogs for an issue.
 // This method is especially important if you need to read all the worklogs, not just the first page.
 //
 // https://docs.atlassian.com/jira/REST/cloud/#api/2/issue/{issueIdOrKey}/worklog-getIssueWorklog
-func (s *IssueService) GetWorklogsWithContext(ctx context.Context, issueID string, options ...func(*http.Request) error) (*Worklog, *Response, error) {
+func (s *IssueService) GetWorklogs(ctx context.Context, issueID string, options ...func(*http.Request) error) (*Worklog, *Response, error) {
 	apiEndpoint := fmt.Sprintf("rest/api/2/issue/%s/worklog", issueID)
 
 	req, err := s.client.NewRequest(ctx, "GET", apiEndpoint, nil)
@@ -786,11 +758,6 @@ func (s *IssueService) GetWorklogsWithContext(ctx context.Context, issueID strin
 	return v, resp, err
 }
 
-// GetWorklogs wraps GetWorklogsWithContext using the background context.
-func (s *IssueService) GetWorklogs(issueID string, options ...func(*http.Request) error) (*Worklog, *Response, error) {
-	return s.GetWorklogsWithContext(context.Background(), issueID, options...)
-}
-
 // Applies query options to http request.
 // This helper is meant to be used with all "QueryOptions" structs.
 func WithQueryOptions(options interface{}) func(*http.Request) error {
@@ -807,12 +774,12 @@ func WithQueryOptions(options interface{}) func(*http.Request) error {
 	}
 }
 
-// CreateWithContext creates an issue or a sub-task from a JSON representation.
+// Create creates an issue or a sub-task from a JSON representation.
 // Creating a sub-task is similar to creating a regular issue, with two important differences:
 // The issueType field must correspond to a sub-task issue type and you must provide a parent field in the issue create request containing the id or key of the parent issue.
 //
 // Jira API docs: https://docs.atlassian.com/jira/REST/latest/#api/2/issue-createIssues
-func (s *IssueService) CreateWithContext(ctx context.Context, issue *Issue) (*Issue, *Response, error) {
+func (s *IssueService) Create(ctx context.Context, issue *Issue) (*Issue, *Response, error) {
 	apiEndpoint := "rest/api/2/issue"
 	req, err := s.client.NewRequest(ctx, "POST", apiEndpoint, issue)
 	if err != nil {
@@ -837,17 +804,12 @@ func (s *IssueService) CreateWithContext(ctx context.Context, issue *Issue) (*Is
 	return responseIssue, resp, nil
 }
 
-// Create wraps CreateWithContext using the background context.
-func (s *IssueService) Create(issue *Issue) (*Issue, *Response, error) {
-	return s.CreateWithContext(context.Background(), issue)
-}
-
-// UpdateWithOptionsWithContext updates an issue from a JSON representation,
+// UpdateWithOptions updates an issue from a JSON representation,
 // while also specifying query params. The issue is found by key.
 //
 // Jira API docs: https://docs.atlassian.com/jira/REST/cloud/#api/2/issue-editIssue
 // Caller must close resp.Body
-func (s *IssueService) UpdateWithOptionsWithContext(ctx context.Context, issue *Issue, opts *UpdateQueryOptions) (*Issue, *Response, error) {
+func (s *IssueService) UpdateWithOptions(ctx context.Context, issue *Issue, opts *UpdateQueryOptions) (*Issue, *Response, error) {
 	apiEndpoint := fmt.Sprintf("rest/api/2/issue/%v", issue.Key)
 	url, err := addOptions(apiEndpoint, opts)
 	if err != nil {
@@ -869,29 +831,18 @@ func (s *IssueService) UpdateWithOptionsWithContext(ctx context.Context, issue *
 	return &ret, resp, nil
 }
 
-// UpdateWithOptions wraps UpdateWithOptionsWithContext using the background context.
-// Caller must close resp.Body
-func (s *IssueService) UpdateWithOptions(issue *Issue, opts *UpdateQueryOptions) (*Issue, *Response, error) {
-	return s.UpdateWithOptionsWithContext(context.Background(), issue, opts)
-}
-
-// UpdateWithContext updates an issue from a JSON representation. The issue is found by key.
+// Update updates an issue from a JSON representation. The issue is found by key.
 //
 // Jira API docs: https://docs.atlassian.com/jira/REST/cloud/#api/2/issue-editIssue
-func (s *IssueService) UpdateWithContext(ctx context.Context, issue *Issue) (*Issue, *Response, error) {
-	return s.UpdateWithOptionsWithContext(ctx, issue, nil)
+func (s *IssueService) Update(ctx context.Context, issue *Issue) (*Issue, *Response, error) {
+	return s.UpdateWithOptions(ctx, issue, nil)
 }
 
-// Update wraps UpdateWithContext using the background context.
-func (s *IssueService) Update(issue *Issue) (*Issue, *Response, error) {
-	return s.UpdateWithContext(context.Background(), issue)
-}
-
-// UpdateIssueWithContext updates an issue from a JSON representation. The issue is found by key.
+// UpdateIssue updates an issue from a JSON representation. The issue is found by key.
 //
 // https://docs.atlassian.com/jira/REST/7.4.0/#api/2/issue-editIssue
 // Caller must close resp.Body
-func (s *IssueService) UpdateIssueWithContext(ctx context.Context, jiraID string, data map[string]interface{}) (*Response, error) {
+func (s *IssueService) UpdateIssue(ctx context.Context, jiraID string, data map[string]interface{}) (*Response, error) {
 	apiEndpoint := fmt.Sprintf("rest/api/2/issue/%v", jiraID)
 	req, err := s.client.NewRequest(ctx, "PUT", apiEndpoint, data)
 	if err != nil {
@@ -907,16 +858,10 @@ func (s *IssueService) UpdateIssueWithContext(ctx context.Context, jiraID string
 	return resp, nil
 }
 
-// UpdateIssue wraps UpdateIssueWithContext using the background context.
-// Caller must close resp.Body
-func (s *IssueService) UpdateIssue(jiraID string, data map[string]interface{}) (*Response, error) {
-	return s.UpdateIssueWithContext(context.Background(), jiraID, data)
-}
-
-// AddCommentWithContext adds a new comment to issueID.
+// AddComment adds a new comment to issueID.
 //
 // Jira API docs: https://docs.atlassian.com/jira/REST/latest/#api/2/issue-addComment
-func (s *IssueService) AddCommentWithContext(ctx context.Context, issueID string, comment *Comment) (*Comment, *Response, error) {
+func (s *IssueService) AddComment(ctx context.Context, issueID string, comment *Comment) (*Comment, *Response, error) {
 	apiEndpoint := fmt.Sprintf("rest/api/2/issue/%s/comment", issueID)
 	req, err := s.client.NewRequest(ctx, "POST", apiEndpoint, comment)
 	if err != nil {
@@ -933,15 +878,10 @@ func (s *IssueService) AddCommentWithContext(ctx context.Context, issueID string
 	return responseComment, resp, nil
 }
 
-// AddComment wraps AddCommentWithContext using the background context.
-func (s *IssueService) AddComment(issueID string, comment *Comment) (*Comment, *Response, error) {
-	return s.AddCommentWithContext(context.Background(), issueID, comment)
-}
-
-// UpdateCommentWithContext updates the body of a comment, identified by comment.ID, on the issueID.
+// UpdateComment updates the body of a comment, identified by comment.ID, on the issueID.
 //
 // Jira API docs: https://docs.atlassian.com/jira/REST/cloud/#api/2/issue/{issueIdOrKey}/comment-updateComment
-func (s *IssueService) UpdateCommentWithContext(ctx context.Context, issueID string, comment *Comment) (*Comment, *Response, error) {
+func (s *IssueService) UpdateComment(ctx context.Context, issueID string, comment *Comment) (*Comment, *Response, error) {
 	reqBody := struct {
 		Body string `json:"body"`
 	}{
@@ -962,15 +902,10 @@ func (s *IssueService) UpdateCommentWithContext(ctx context.Context, issueID str
 	return responseComment, resp, nil
 }
 
-// UpdateComment wraps UpdateCommentWithContext using the background context.
-func (s *IssueService) UpdateComment(issueID string, comment *Comment) (*Comment, *Response, error) {
-	return s.UpdateCommentWithContext(context.Background(), issueID, comment)
-}
-
-// DeleteCommentWithContext Deletes a comment from an issueID.
+// DeleteComment Deletes a comment from an issueID.
 //
 // Jira API docs: https://developer.atlassian.com/cloud/jira/platform/rest/v3/#api-api-3-issue-issueIdOrKey-comment-id-delete
-func (s *IssueService) DeleteCommentWithContext(ctx context.Context, issueID, commentID string) error {
+func (s *IssueService) DeleteComment(ctx context.Context, issueID, commentID string) error {
 	apiEndpoint := fmt.Sprintf("rest/api/2/issue/%s/comment/%s", issueID, commentID)
 	req, err := s.client.NewRequest(ctx, "DELETE", apiEndpoint, nil)
 	if err != nil {
@@ -987,15 +922,10 @@ func (s *IssueService) DeleteCommentWithContext(ctx context.Context, issueID, co
 	return nil
 }
 
-// DeleteComment wraps DeleteCommentWithContext using the background context.
-func (s *IssueService) DeleteComment(issueID, commentID string) error {
-	return s.DeleteCommentWithContext(context.Background(), issueID, commentID)
-}
-
-// AddWorklogRecordWithContext adds a new worklog record to issueID.
+// AddWorklogRecord adds a new worklog record to issueID.
 //
 // https://developer.atlassian.com/cloud/jira/platform/rest/#api-api-2-issue-issueIdOrKey-worklog-post
-func (s *IssueService) AddWorklogRecordWithContext(ctx context.Context, issueID string, record *WorklogRecord, options ...func(*http.Request) error) (*WorklogRecord, *Response, error) {
+func (s *IssueService) AddWorklogRecord(ctx context.Context, issueID string, record *WorklogRecord, options ...func(*http.Request) error) (*WorklogRecord, *Response, error) {
 	apiEndpoint := fmt.Sprintf("rest/api/2/issue/%s/worklog", issueID)
 	req, err := s.client.NewRequest(ctx, "POST", apiEndpoint, record)
 	if err != nil {
@@ -1019,15 +949,10 @@ func (s *IssueService) AddWorklogRecordWithContext(ctx context.Context, issueID 
 	return responseRecord, resp, nil
 }
 
-// AddWorklogRecord wraps AddWorklogRecordWithContext using the background context.
-func (s *IssueService) AddWorklogRecord(issueID string, record *WorklogRecord, options ...func(*http.Request) error) (*WorklogRecord, *Response, error) {
-	return s.AddWorklogRecordWithContext(context.Background(), issueID, record, options...)
-}
-
-// UpdateWorklogRecordWithContext updates a worklog record.
+// UpdateWorklogRecord updates a worklog record.
 //
 // https://docs.atlassian.com/software/jira/docs/api/REST/7.1.2/#api/2/issue-updateWorklog
-func (s *IssueService) UpdateWorklogRecordWithContext(ctx context.Context, issueID, worklogID string, record *WorklogRecord, options ...func(*http.Request) error) (*WorklogRecord, *Response, error) {
+func (s *IssueService) UpdateWorklogRecord(ctx context.Context, issueID, worklogID string, record *WorklogRecord, options ...func(*http.Request) error) (*WorklogRecord, *Response, error) {
 	apiEndpoint := fmt.Sprintf("rest/api/2/issue/%s/worklog/%s", issueID, worklogID)
 	req, err := s.client.NewRequest(ctx, "PUT", apiEndpoint, record)
 	if err != nil {
@@ -1051,16 +976,11 @@ func (s *IssueService) UpdateWorklogRecordWithContext(ctx context.Context, issue
 	return responseRecord, resp, nil
 }
 
-// UpdateWorklogRecord wraps UpdateWorklogRecordWithContext using the background context.
-func (s *IssueService) UpdateWorklogRecord(issueID, worklogID string, record *WorklogRecord, options ...func(*http.Request) error) (*WorklogRecord, *Response, error) {
-	return s.UpdateWorklogRecordWithContext(context.Background(), issueID, worklogID, record, options...)
-}
-
-// AddLinkWithContext adds a link between two issues.
+// AddLink adds a link between two issues.
 //
 // Jira API docs: https://docs.atlassian.com/jira/REST/latest/#api/2/issueLink
 // Caller must close resp.Body
-func (s *IssueService) AddLinkWithContext(ctx context.Context, issueLink *IssueLink) (*Response, error) {
+func (s *IssueService) AddLink(ctx context.Context, issueLink *IssueLink) (*Response, error) {
 	apiEndpoint := "rest/api/2/issueLink"
 	req, err := s.client.NewRequest(ctx, "POST", apiEndpoint, issueLink)
 	if err != nil {
@@ -1075,16 +995,10 @@ func (s *IssueService) AddLinkWithContext(ctx context.Context, issueLink *IssueL
 	return resp, err
 }
 
-// AddLink wraps AddLinkWithContext using the background context.
-// Caller must close resp.Body
-func (s *IssueService) AddLink(issueLink *IssueLink) (*Response, error) {
-	return s.AddLinkWithContext(context.Background(), issueLink)
-}
-
-// SearchWithContext will search for tickets according to the jql
+// Search will search for tickets according to the jql
 //
 // Jira API docs: https://developer.atlassian.com/jiradev/jira-apis/jira-rest-apis/jira-rest-api-tutorials/jira-rest-api-example-query-issues
-func (s *IssueService) SearchWithContext(ctx context.Context, jql string, options *SearchOptions) ([]Issue, *Response, error) {
+func (s *IssueService) Search(ctx context.Context, jql string, options *SearchOptions) ([]Issue, *Response, error) {
 	u := url.URL{
 		Path: "rest/api/2/search",
 	}
@@ -1126,15 +1040,10 @@ func (s *IssueService) SearchWithContext(ctx context.Context, jql string, option
 	return v.Issues, resp, err
 }
 
-// Search wraps SearchWithContext using the background context.
-func (s *IssueService) Search(jql string, options *SearchOptions) ([]Issue, *Response, error) {
-	return s.SearchWithContext(context.Background(), jql, options)
-}
-
-// SearchPagesWithContext will get issues from all pages in a search
+// SearchPages will get issues from all pages in a search
 //
 // Jira API docs: https://developer.atlassian.com/jiradev/jira-apis/jira-rest-apis/jira-rest-api-tutorials/jira-rest-api-example-query-issues
-func (s *IssueService) SearchPagesWithContext(ctx context.Context, jql string, options *SearchOptions, f func(Issue) error) error {
+func (s *IssueService) SearchPages(ctx context.Context, jql string, options *SearchOptions, f func(Issue) error) error {
 	if options == nil {
 		options = &SearchOptions{
 			StartAt:    0,
@@ -1146,7 +1055,7 @@ func (s *IssueService) SearchPagesWithContext(ctx context.Context, jql string, o
 		options.MaxResults = 50
 	}
 
-	issues, resp, err := s.SearchWithContext(ctx, jql, options)
+	issues, resp, err := s.Search(ctx, jql, options)
 	if err != nil {
 		return err
 	}
@@ -1168,20 +1077,15 @@ func (s *IssueService) SearchPagesWithContext(ctx context.Context, jql string, o
 		}
 
 		options.StartAt += resp.MaxResults
-		issues, resp, err = s.SearchWithContext(ctx, jql, options)
+		issues, resp, err = s.Search(ctx, jql, options)
 		if err != nil {
 			return err
 		}
 	}
 }
 
-// SearchPages wraps SearchPagesWithContext using the background context.
-func (s *IssueService) SearchPages(jql string, options *SearchOptions, f func(Issue) error) error {
-	return s.SearchPagesWithContext(context.Background(), jql, options, f)
-}
-
-// GetCustomFieldsWithContext returns a map of customfield_* keys with string values
-func (s *IssueService) GetCustomFieldsWithContext(ctx context.Context, issueID string) (CustomFields, *Response, error) {
+// GetCustomFields returns a map of customfield_* keys with string values
+func (s *IssueService) GetCustomFields(ctx context.Context, issueID string) (CustomFields, *Response, error) {
 	apiEndpoint := fmt.Sprintf("rest/api/2/issue/%s", issueID)
 	req, err := s.client.NewRequest(ctx, "GET", apiEndpoint, nil)
 	if err != nil {
@@ -1217,16 +1121,11 @@ func (s *IssueService) GetCustomFieldsWithContext(ctx context.Context, issueID s
 	return cf, resp, nil
 }
 
-// GetCustomFields wraps GetCustomFieldsWithContext using the background context.
-func (s *IssueService) GetCustomFields(issueID string) (CustomFields, *Response, error) {
-	return s.GetCustomFieldsWithContext(context.Background(), issueID)
-}
-
-// GetTransitionsWithContext gets a list of the transitions possible for this issue by the current user,
+// GetTransitions gets a list of the transitions possible for this issue by the current user,
 // along with fields that are required and their types.
 //
 // Jira API docs: https://docs.atlassian.com/jira/REST/latest/#api/2/issue-getTransitions
-func (s *IssueService) GetTransitionsWithContext(ctx context.Context, id string) ([]Transition, *Response, error) {
+func (s *IssueService) GetTransitions(ctx context.Context, id string) ([]Transition, *Response, error) {
 	apiEndpoint := fmt.Sprintf("rest/api/2/issue/%s/transitions?expand=transitions.fields", id)
 	req, err := s.client.NewRequest(ctx, "GET", apiEndpoint, nil)
 	if err != nil {
@@ -1241,35 +1140,25 @@ func (s *IssueService) GetTransitionsWithContext(ctx context.Context, id string)
 	return result.Transitions, resp, err
 }
 
-// GetTransitions wraps GetTransitionsWithContext using the background context.
-func (s *IssueService) GetTransitions(id string) ([]Transition, *Response, error) {
-	return s.GetTransitionsWithContext(context.Background(), id)
-}
-
-// DoTransitionWithContext performs a transition on an issue.
+// DoTransition performs a transition on an issue.
 // When performing the transition you can update or set other issue fields.
 //
 // Jira API docs: https://docs.atlassian.com/jira/REST/latest/#api/2/issue-doTransition
-func (s *IssueService) DoTransitionWithContext(ctx context.Context, ticketID, transitionID string) (*Response, error) {
+func (s *IssueService) DoTransition(ctx context.Context, ticketID, transitionID string) (*Response, error) {
 	payload := CreateTransitionPayload{
 		Transition: TransitionPayload{
 			ID: transitionID,
 		},
 	}
-	return s.DoTransitionWithPayloadWithContext(ctx, ticketID, payload)
+	return s.DoTransitionWithPayload(ctx, ticketID, payload)
 }
 
-// DoTransition wraps DoTransitionWithContext using the background context.
-func (s *IssueService) DoTransition(ticketID, transitionID string) (*Response, error) {
-	return s.DoTransitionWithContext(context.Background(), ticketID, transitionID)
-}
-
-// DoTransitionWithPayloadWithContext performs a transition on an issue using any payload.
+// DoTransitionWithPayload performs a transition on an issue using any payload.
 // When performing the transition you can update or set other issue fields.
 //
 // Jira API docs: https://docs.atlassian.com/jira/REST/latest/#api/2/issue-doTransition
 // Caller must close resp.Body
-func (s *IssueService) DoTransitionWithPayloadWithContext(ctx context.Context, ticketID, payload interface{}) (*Response, error) {
+func (s *IssueService) DoTransitionWithPayload(ctx context.Context, ticketID, payload interface{}) (*Response, error) {
 	apiEndpoint := fmt.Sprintf("rest/api/2/issue/%s/transitions", ticketID)
 
 	req, err := s.client.NewRequest(ctx, "POST", apiEndpoint, payload)
@@ -1283,12 +1172,6 @@ func (s *IssueService) DoTransitionWithPayloadWithContext(ctx context.Context, t
 	}
 
 	return resp, err
-}
-
-// DoTransitionWithPayload wraps DoTransitionWithPayloadWithContext using the background context.
-// Caller must close resp.Body
-func (s *IssueService) DoTransitionWithPayload(ticketID, payload interface{}) (*Response, error) {
-	return s.DoTransitionWithPayloadWithContext(context.Background(), ticketID, payload)
 }
 
 // InitIssueWithMetaAndFields returns Issue with with values from fieldsConfig properly set.
@@ -1372,9 +1255,9 @@ func InitIssueWithMetaAndFields(metaProject *MetaProject, metaIssuetype *MetaIss
 	return issue, nil
 }
 
-// DeleteWithContext will delete a specified issue.
+// Delete will delete a specified issue.
 // Caller must close resp.Body
-func (s *IssueService) DeleteWithContext(ctx context.Context, issueID string) (*Response, error) {
+func (s *IssueService) Delete(ctx context.Context, issueID string) (*Response, error) {
 	apiEndpoint := fmt.Sprintf("rest/api/2/issue/%s", issueID)
 
 	// to enable deletion of subtasks; without this, the request will fail if the issue has subtasks
@@ -1391,16 +1274,10 @@ func (s *IssueService) DeleteWithContext(ctx context.Context, issueID string) (*
 	return resp, err
 }
 
-// Delete wraps DeleteWithContext using the background context.
-// Caller must close resp.Body
-func (s *IssueService) Delete(issueID string) (*Response, error) {
-	return s.DeleteWithContext(context.Background(), issueID)
-}
-
-// GetWatchersWithContext wil return all the users watching/observing the given issue
+// GetWatchers wil return all the users watching/observing the given issue
 //
 // Jira API docs: https://docs.atlassian.com/software/jira/docs/api/REST/latest/#api/2/issue-getIssueWatchers
-func (s *IssueService) GetWatchersWithContext(ctx context.Context, issueID string) (*[]User, *Response, error) {
+func (s *IssueService) GetWatchers(ctx context.Context, issueID string) (*[]User, *Response, error) {
 	watchesAPIEndpoint := fmt.Sprintf("rest/api/2/issue/%s/watchers", issueID)
 
 	req, err := s.client.NewRequest(ctx, "GET", watchesAPIEndpoint, nil)
@@ -1429,16 +1306,11 @@ func (s *IssueService) GetWatchersWithContext(ctx context.Context, issueID strin
 	return &result, resp, nil
 }
 
-// GetWatchers wraps GetWatchersWithContext using the background context.
-func (s *IssueService) GetWatchers(issueID string) (*[]User, *Response, error) {
-	return s.GetWatchersWithContext(context.Background(), issueID)
-}
-
-// AddWatcherWithContext adds watcher to the given issue
+// AddWatcher adds watcher to the given issue
 //
 // Jira API docs: https://docs.atlassian.com/software/jira/docs/api/REST/latest/#api/2/issue-addWatcher
 // Caller must close resp.Body
-func (s *IssueService) AddWatcherWithContext(ctx context.Context, issueID string, userName string) (*Response, error) {
+func (s *IssueService) AddWatcher(ctx context.Context, issueID string, userName string) (*Response, error) {
 	apiEndPoint := fmt.Sprintf("rest/api/2/issue/%s/watchers", issueID)
 
 	req, err := s.client.NewRequest(ctx, "POST", apiEndPoint, userName)
@@ -1454,17 +1326,11 @@ func (s *IssueService) AddWatcherWithContext(ctx context.Context, issueID string
 	return resp, err
 }
 
-// AddWatcher wraps AddWatcherWithContext using the background context.
-// Caller must close resp.Body
-func (s *IssueService) AddWatcher(issueID string, userName string) (*Response, error) {
-	return s.AddWatcherWithContext(context.Background(), issueID, userName)
-}
-
-// RemoveWatcherWithContext removes given user from given issue
+// RemoveWatcher removes given user from given issue
 //
 // Jira API docs: https://docs.atlassian.com/software/jira/docs/api/REST/latest/#api/2/issue-removeWatcher
 // Caller must close resp.Body
-func (s *IssueService) RemoveWatcherWithContext(ctx context.Context, issueID string, userName string) (*Response, error) {
+func (s *IssueService) RemoveWatcher(ctx context.Context, issueID string, userName string) (*Response, error) {
 	apiEndPoint := fmt.Sprintf("rest/api/2/issue/%s/watchers", issueID)
 
 	req, err := s.client.NewRequest(ctx, "DELETE", apiEndPoint, userName)
@@ -1480,17 +1346,11 @@ func (s *IssueService) RemoveWatcherWithContext(ctx context.Context, issueID str
 	return resp, err
 }
 
-// RemoveWatcher wraps RemoveWatcherWithContext using the background context.
-// Caller must close resp.Body
-func (s *IssueService) RemoveWatcher(issueID string, userName string) (*Response, error) {
-	return s.RemoveWatcherWithContext(context.Background(), issueID, userName)
-}
-
-// UpdateAssigneeWithContext updates the user assigned to work on the given issue
+// UpdateAssignee updates the user assigned to work on the given issue
 //
 // Jira API docs: https://docs.atlassian.com/software/jira/docs/api/REST/7.10.2/#api/2/issue-assign
 // Caller must close resp.Body
-func (s *IssueService) UpdateAssigneeWithContext(ctx context.Context, issueID string, assignee *User) (*Response, error) {
+func (s *IssueService) UpdateAssignee(ctx context.Context, issueID string, assignee *User) (*Response, error) {
 	apiEndPoint := fmt.Sprintf("rest/api/2/issue/%s/assignee", issueID)
 
 	req, err := s.client.NewRequest(ctx, "PUT", apiEndPoint, assignee)
@@ -1506,12 +1366,6 @@ func (s *IssueService) UpdateAssigneeWithContext(ctx context.Context, issueID st
 	return resp, err
 }
 
-// UpdateAssignee wraps UpdateAssigneeWithContext using the background context.
-// Caller must close resp.Body
-func (s *IssueService) UpdateAssignee(issueID string, assignee *User) (*Response, error) {
-	return s.UpdateAssigneeWithContext(context.Background(), issueID, assignee)
-}
-
 func (c ChangelogHistory) CreatedTime() (time.Time, error) {
 	var t time.Time
 	// Ignore null
@@ -1522,10 +1376,10 @@ func (c ChangelogHistory) CreatedTime() (time.Time, error) {
 	return t, err
 }
 
-// GetRemoteLinksWithContext gets remote issue links on the issue.
+// GetRemoteLinks gets remote issue links on the issue.
 //
 // Jira API docs: https://docs.atlassian.com/jira/REST/latest/#api/2/issue-getRemoteIssueLinks
-func (s *IssueService) GetRemoteLinksWithContext(ctx context.Context, id string) (*[]RemoteLink, *Response, error) {
+func (s *IssueService) GetRemoteLinks(ctx context.Context, id string) (*[]RemoteLink, *Response, error) {
 	apiEndpoint := fmt.Sprintf("rest/api/2/issue/%s/remotelink", id)
 	req, err := s.client.NewRequest(ctx, "GET", apiEndpoint, nil)
 	if err != nil {
@@ -1540,16 +1394,10 @@ func (s *IssueService) GetRemoteLinksWithContext(ctx context.Context, id string)
 	return result, resp, err
 }
 
-// GetRemoteLinks wraps GetRemoteLinksWithContext using the background context.
-// Caller must close resp.Body
-func (s *IssueService) GetRemoteLinks(id string) (*[]RemoteLink, *Response, error) {
-	return s.GetRemoteLinksWithContext(context.Background(), id)
-}
-
-// AddRemoteLinkWithContext adds a remote link to issueID.
+// AddRemoteLink adds a remote link to issueID.
 //
 // Jira API docs: https://developer.atlassian.com/cloud/jira/platform/rest/v2/#api-rest-api-2-issue-issueIdOrKey-remotelink-post
-func (s *IssueService) AddRemoteLinkWithContext(ctx context.Context, issueID string, remotelink *RemoteLink) (*RemoteLink, *Response, error) {
+func (s *IssueService) AddRemoteLink(ctx context.Context, issueID string, remotelink *RemoteLink) (*RemoteLink, *Response, error) {
 	apiEndpoint := fmt.Sprintf("rest/api/2/issue/%s/remotelink", issueID)
 	req, err := s.client.NewRequest(ctx, "POST", apiEndpoint, remotelink)
 	if err != nil {
@@ -1566,15 +1414,10 @@ func (s *IssueService) AddRemoteLinkWithContext(ctx context.Context, issueID str
 	return responseRemotelink, resp, nil
 }
 
-// AddRemoteLink wraps AddRemoteLinkWithContext using the background context.
-func (s *IssueService) AddRemoteLink(issueID string, remotelink *RemoteLink) (*RemoteLink, *Response, error) {
-	return s.AddRemoteLinkWithContext(context.Background(), issueID, remotelink)
-}
-
-// UpdateRemoteLinkWithContext updates a remote issue link by linkID.
+// UpdateRemoteLink updates a remote issue link by linkID.
 //
 // Jira API docs: https://developer.atlassian.com/cloud/jira/platform/rest/v2/api-group-issue-remote-links/#api-rest-api-2-issue-issueidorkey-remotelink-linkid-put
-func (s *IssueService) UpdateRemoteLinkWithContext(ctx context.Context, issueID string, linkID int, remotelink *RemoteLink) (*Response, error) {
+func (s *IssueService) UpdateRemoteLink(ctx context.Context, issueID string, linkID int, remotelink *RemoteLink) (*Response, error) {
 	apiEndpoint := fmt.Sprintf("rest/api/2/issue/%s/remotelink/%d", issueID, linkID)
 	req, err := s.client.NewRequest(ctx, "PUT", apiEndpoint, remotelink)
 	if err != nil {
@@ -1588,9 +1431,4 @@ func (s *IssueService) UpdateRemoteLinkWithContext(ctx context.Context, issueID 
 	}
 
 	return resp, nil
-}
-
-// UpdateRemoteLink wraps UpdateRemoteLinkWithContext using the background context.
-func (s *IssueService) UpdateRemoteLink(issueID string, linkID int, remotelink *RemoteLink) (*Response, error) {
-	return s.UpdateRemoteLinkWithContext(context.Background(), issueID, linkID, remotelink)
 }

--- a/onpremise/issue_test.go
+++ b/onpremise/issue_test.go
@@ -1,6 +1,7 @@
 package onpremise
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -25,7 +26,7 @@ func TestIssueService_Get_Success(t *testing.T) {
 		fmt.Fprint(w, `{"expand":"renderedFields,names,schema,transitions,operations,editmeta,changelog,versionedRepresentations","id":"10002","self":"http://www.example.com/jira/rest/api/2/issue/10002","key":"EX-1","fields":{"watcher":{"self":"http://www.example.com/jira/rest/api/2/issue/EX-1/watchers","isWatching":false,"watchCount":1,"watchers":[{"self":"http://www.example.com/jira/rest/api/2/user?username=fred","name":"fred","displayName":"Fred F. User","active":false}]},"attachment":[{"self":"http://www.example.com/jira/rest/api/2.0/attachments/10000","filename":"picture.jpg","author":{"self":"http://www.example.com/jira/rest/api/2/user?username=fred","name":"fred","avatarUrls":{"48x48":"http://www.example.com/jira/secure/useravatar?size=large&ownerId=fred","24x24":"http://www.example.com/jira/secure/useravatar?size=small&ownerId=fred","16x16":"http://www.example.com/jira/secure/useravatar?size=xsmall&ownerId=fred","32x32":"http://www.example.com/jira/secure/useravatar?size=medium&ownerId=fred"},"displayName":"Fred F. User","active":false},"created":"2016-03-16T04:22:37.461+0000","size":23123,"mimeType":"image/jpeg","content":"http://www.example.com/jira/attachments/10000","thumbnail":"http://www.example.com/jira/secure/thumbnail/10000"}],"sub-tasks":[{"id":"10000","type":{"id":"10000","name":"","inward":"Parent","outward":"Sub-task"},"outwardIssue":{"id":"10003","key":"EX-2","self":"http://www.example.com/jira/rest/api/2/issue/EX-2","fields":{"status":{"iconUrl":"http://www.example.com/jira//images/icons/statuses/open.png","name":"Open"}}}}],"description":"example bug report","project":{"self":"http://www.example.com/jira/rest/api/2/project/EX","id":"10000","key":"EX","name":"Example","avatarUrls":{"48x48":"http://www.example.com/jira/secure/projectavatar?size=large&pid=10000","24x24":"http://www.example.com/jira/secure/projectavatar?size=small&pid=10000","16x16":"http://www.example.com/jira/secure/projectavatar?size=xsmall&pid=10000","32x32":"http://www.example.com/jira/secure/projectavatar?size=medium&pid=10000"},"projectCategory":{"self":"http://www.example.com/jira/rest/api/2/projectCategory/10000","id":"10000","name":"FIRST","description":"First Project Category"}},"comment":{"comments":[{"self":"http://www.example.com/jira/rest/api/2/issue/10010/comment/10000","id":"10000","author":{"self":"http://www.example.com/jira/rest/api/2/user?username=fred","name":"fred","displayName":"Fred F. User","active":false},"body":"Lorem ipsum dolor sit amet, consectetur adipiscing elit. Pellentesque eget venenatis elit. Duis eu justo eget augue iaculis fermentum. Sed semper quam laoreet nisi egestas at posuere augue semper.","updateAuthor":{"self":"http://www.example.com/jira/rest/api/2/user?username=fred","name":"fred","displayName":"Fred F. User","active":false},"created":"2016-03-16T04:22:37.356+0000","updated":"2016-03-16T04:22:37.356+0000","visibility":{"type":"role","value":"Administrators"}}]},"issuelinks":[{"id":"10001","type":{"id":"10000","name":"Dependent","inward":"depends on","outward":"is depended by"},"outwardIssue":{"id":"10004L","key":"PRJ-2","self":"http://www.example.com/jira/rest/api/2/issue/PRJ-2","fields":{"status":{"iconUrl":"http://www.example.com/jira//images/icons/statuses/open.png","name":"Open"}}}},{"id":"10002","type":{"id":"10000","name":"Dependent","inward":"depends on","outward":"is depended by"},"inwardIssue":{"id":"10004","key":"PRJ-3","self":"http://www.example.com/jira/rest/api/2/issue/PRJ-3","fields":{"status":{"iconUrl":"http://www.example.com/jira//images/icons/statuses/open.png","name":"Open"}}}}],"worklog":{"worklogs":[{"self":"http://www.example.com/jira/rest/api/2/issue/10010/worklog/10000","author":{"self":"http://www.example.com/jira/rest/api/2/user?username=fred","name":"fred","displayName":"Fred F. User","active":false},"updateAuthor":{"self":"http://www.example.com/jira/rest/api/2/user?username=fred","name":"fred","displayName":"Fred F. User","active":false},"comment":"I did some work here.","updated":"2016-03-16T04:22:37.471+0000","visibility":{"type":"group","value":"jira-developers"},"started":"2016-03-16T04:22:37.471+0000","timeSpent":"3h 20m","timeSpentSeconds":12000,"id":"100028","issueId":"10002"}]},"updated":"2016-04-06T02:36:53.594-0700","duedate":"2018-01-19","timetracking":{"originalEstimate":"10m","remainingEstimate":"3m","timeSpent":"6m","originalEstimateSeconds":600,"remainingEstimateSeconds":200,"timeSpentSeconds":400}},"names":{"watcher":"watcher","attachment":"attachment","sub-tasks":"sub-tasks","description":"description","project":"project","comment":"comment","issuelinks":"issuelinks","worklog":"worklog","updated":"updated","timetracking":"timetracking"},"schema":{}}`)
 	})
 
-	issue, _, err := testClient.Issue.Get("10002", nil)
+	issue, _, err := testClient.Issue.Get(context.Background(), "10002", nil)
 	if issue == nil {
 		t.Error("Expected issue. Issue is nil")
 	}
@@ -47,7 +48,7 @@ func TestIssueService_Get_WithQuerySuccess(t *testing.T) {
 	opt := &GetQueryOptions{
 		Expand: "foo",
 	}
-	issue, _, err := testClient.Issue.Get("10002", opt)
+	issue, _, err := testClient.Issue.Get(context.Background(), "10002", opt)
 	if issue == nil {
 		t.Error("Expected issue. Issue is nil")
 	}
@@ -72,7 +73,7 @@ func TestIssueService_Create(t *testing.T) {
 			Description: "example bug report",
 		},
 	}
-	issue, _, err := testClient.Issue.Create(i)
+	issue, _, err := testClient.Issue.Create(context.Background(), i)
 	if issue == nil {
 		t.Error("Expected issue. Issue is nil")
 	}
@@ -98,7 +99,7 @@ func TestIssueService_CreateThenGet(t *testing.T) {
 			Created:     Time(time.Now()),
 		},
 	}
-	issue, _, err := testClient.Issue.Create(i)
+	issue, _, err := testClient.Issue.Create(context.Background(), i)
 	if issue == nil {
 		t.Error("Expected issue. Issue is nil")
 	}
@@ -120,7 +121,7 @@ func TestIssueService_CreateThenGet(t *testing.T) {
 		}
 	})
 
-	issue2, _, err := testClient.Issue.Get("10002", nil)
+	issue2, _, err := testClient.Issue.Get(context.Background(), "10002", nil)
 	if issue2 == nil {
 		t.Error("Expected issue. Issue is nil")
 	}
@@ -145,7 +146,7 @@ func TestIssueService_Update(t *testing.T) {
 			Description: "example bug report",
 		},
 	}
-	issue, _, err := testClient.Issue.Update(i)
+	issue, _, err := testClient.Issue.Update(context.Background(), i)
 	if issue == nil {
 		t.Error("Expected issue. Issue is nil")
 	}
@@ -167,7 +168,7 @@ func TestIssueService_UpdateIssue(t *testing.T) {
 	i := make(map[string]interface{})
 	fields := make(map[string]interface{})
 	i["fields"] = fields
-	resp, err := testClient.Issue.UpdateIssue(jID, i)
+	resp, err := testClient.Issue.UpdateIssue(context.Background(), jID, i)
 	if resp == nil {
 		t.Error("Expected resp. resp is nil")
 	}
@@ -195,7 +196,7 @@ func TestIssueService_AddComment(t *testing.T) {
 			Value: "Administrators",
 		},
 	}
-	comment, _, err := testClient.Issue.AddComment("10000", c)
+	comment, _, err := testClient.Issue.AddComment(context.Background(), "10000", c)
 	if comment == nil {
 		t.Error("Expected Comment. Comment is nil")
 	}
@@ -223,7 +224,7 @@ func TestIssueService_UpdateComment(t *testing.T) {
 			Value: "Administrators",
 		},
 	}
-	comment, _, err := testClient.Issue.UpdateComment("10000", c)
+	comment, _, err := testClient.Issue.UpdateComment(context.Background(), "10000", c)
 	if comment == nil {
 		t.Error("Expected Comment. Comment is nil")
 	}
@@ -243,7 +244,7 @@ func TestIssueService_DeleteComment(t *testing.T) {
 		fmt.Fprint(w, `{}`)
 	})
 
-	err := testClient.Issue.DeleteComment("10000", "10001")
+	err := testClient.Issue.DeleteComment(context.Background(), "10000", "10001")
 	if err != nil {
 		t.Errorf("Error given: %s", err)
 	}
@@ -262,7 +263,7 @@ func TestIssueService_AddWorklogRecord(t *testing.T) {
 	r := &WorklogRecord{
 		TimeSpent: "1h",
 	}
-	record, _, err := testClient.Issue.AddWorklogRecord("10000", r)
+	record, _, err := testClient.Issue.AddWorklogRecord(context.Background(), "10000", r)
 	if record == nil {
 		t.Error("Expected Record. Record is nil")
 	}
@@ -284,7 +285,7 @@ func TestIssueService_UpdateWorklogRecord(t *testing.T) {
 	r := &WorklogRecord{
 		TimeSpent: "1h",
 	}
-	record, _, err := testClient.Issue.UpdateWorklogRecord("10000", "1", r)
+	record, _, err := testClient.Issue.UpdateWorklogRecord(context.Background(), "10000", "1", r)
 	if record == nil {
 		t.Error("Expected Record. Record is nil")
 	}
@@ -321,7 +322,7 @@ func TestIssueService_AddLink(t *testing.T) {
 			},
 		},
 	}
-	resp, err := testClient.Issue.AddLink(il)
+	resp, err := testClient.Issue.AddLink(context.Background(), il)
 	if err != nil {
 		t.Errorf("Error given: %s", err)
 	}
@@ -344,7 +345,7 @@ func TestIssueService_Get_Fields(t *testing.T) {
 		fmt.Fprint(w, `{"expand":"renderedFields,names,schema,transitions,operations,editmeta,changelog,versionedRepresentations","id":"10002","self":"http://www.example.com/jira/rest/api/2/issue/10002","key":"EX-1","fields":{"labels":["test"],"watcher":{"self":"http://www.example.com/jira/rest/api/2/issue/EX-1/watchers","isWatching":false,"watchCount":1,"watchers":[{"self":"http://www.example.com/jira/rest/api/2/user?username=fred","name":"fred","displayName":"Fred F. User","active":false}]},"epic": {"id": 19415,"key": "EPIC-77","self": "https://example.atlassian.net/rest/agile/1.0/epic/19415","name": "Epic Name","summary": "Do it","color": {"key": "color_11"},"done": false},"attachment":[{"self":"http://www.example.com/jira/rest/api/2.0/attachments/10000","filename":"picture.jpg","author":{"self":"http://www.example.com/jira/rest/api/2/user?username=fred","name":"fred","avatarUrls":{"48x48":"http://www.example.com/jira/secure/useravatar?size=large&ownerId=fred","24x24":"http://www.example.com/jira/secure/useravatar?size=small&ownerId=fred","16x16":"http://www.example.com/jira/secure/useravatar?size=xsmall&ownerId=fred","32x32":"http://www.example.com/jira/secure/useravatar?size=medium&ownerId=fred"},"displayName":"Fred F. User","active":false},"created":"2016-03-16T04:22:37.461+0000","size":23123,"mimeType":"image/jpeg","content":"http://www.example.com/jira/attachments/10000","thumbnail":"http://www.example.com/jira/secure/thumbnail/10000"}],"sub-tasks":[{"id":"10000","type":{"id":"10000","name":"","inward":"Parent","outward":"Sub-task"},"outwardIssue":{"id":"10003","key":"EX-2","self":"http://www.example.com/jira/rest/api/2/issue/EX-2","fields":{"status":{"iconUrl":"http://www.example.com/jira//images/icons/statuses/open.png","name":"Open"}}}}],"description":"example bug report","project":{"self":"http://www.example.com/jira/rest/api/2/project/EX","id":"10000","key":"EX","name":"Example","avatarUrls":{"48x48":"http://www.example.com/jira/secure/projectavatar?size=large&pid=10000","24x24":"http://www.example.com/jira/secure/projectavatar?size=small&pid=10000","16x16":"http://www.example.com/jira/secure/projectavatar?size=xsmall&pid=10000","32x32":"http://www.example.com/jira/secure/projectavatar?size=medium&pid=10000"},"projectCategory":{"self":"http://www.example.com/jira/rest/api/2/projectCategory/10000","id":"10000","name":"FIRST","description":"First Project Category"}},"comment":{"comments":[{"self":"http://www.example.com/jira/rest/api/2/issue/10010/comment/10000","id":"10000","author":{"self":"http://www.example.com/jira/rest/api/2/user?username=fred","name":"fred","displayName":"Fred F. User","active":false},"body":"Lorem ipsum dolor sit amet, consectetur adipiscing elit. Pellentesque eget venenatis elit. Duis eu justo eget augue iaculis fermentum. Sed semper quam laoreet nisi egestas at posuere augue semper.","updateAuthor":{"self":"http://www.example.com/jira/rest/api/2/user?username=fred","name":"fred","displayName":"Fred F. User","active":false},"created":"2016-03-16T04:22:37.356+0000","updated":"2016-03-16T04:22:37.356+0000","visibility":{"type":"role","value":"Administrators"}}]},"issuelinks":[{"id":"10001","type":{"id":"10000","name":"Dependent","inward":"depends on","outward":"is depended by"},"outwardIssue":{"id":"10004L","key":"PRJ-2","self":"http://www.example.com/jira/rest/api/2/issue/PRJ-2","fields":{"status":{"iconUrl":"http://www.example.com/jira//images/icons/statuses/open.png","name":"Open"}}}},{"id":"10002","type":{"id":"10000","name":"Dependent","inward":"depends on","outward":"is depended by"},"inwardIssue":{"id":"10004","key":"PRJ-3","self":"http://www.example.com/jira/rest/api/2/issue/PRJ-3","fields":{"status":{"iconUrl":"http://www.example.com/jira//images/icons/statuses/open.png","name":"Open"}}}}],"worklog":{"worklogs":[{"self":"http://www.example.com/jira/rest/api/2/issue/10010/worklog/10000","author":{"self":"http://www.example.com/jira/rest/api/2/user?username=fred","name":"fred","displayName":"Fred F. User","active":false},"updateAuthor":{"self":"http://www.example.com/jira/rest/api/2/user?username=fred","name":"fred","displayName":"Fred F. User","active":false},"comment":"I did some work here.","updated":"2016-03-16T04:22:37.471+0000","visibility":{"type":"group","value":"jira-developers"},"started":"2016-03-16T04:22:37.471+0000","timeSpent":"3h 20m","timeSpentSeconds":12000,"id":"100028","issueId":"10002"}]},"updated":"2016-04-06T02:36:53.594-0700","duedate":"2018-01-19","timetracking":{"originalEstimate":"10m","remainingEstimate":"3m","timeSpent":"6m","originalEstimateSeconds":600,"remainingEstimateSeconds":200,"timeSpentSeconds":400}},"names":{"watcher":"watcher","attachment":"attachment","sub-tasks":"sub-tasks","description":"description","project":"project","comment":"comment","issuelinks":"issuelinks","worklog":"worklog","updated":"updated","timetracking":"timetracking"},"schema":{}}`)
 	})
 
-	issue, _, err := testClient.Issue.Get("10002", nil)
+	issue, _, err := testClient.Issue.Get(context.Background(), "10002", nil)
 	if err != nil {
 		t.Errorf("Error given: %s", err)
 	}
@@ -374,7 +375,7 @@ func TestIssueService_Get_RenderedFields(t *testing.T) {
 		fmt.Fprint(w, `{"expand":"renderedFields,names,schema,transitions,operations,editmeta,changelog,versionedRepresentations","id":"10002","self":"http://www.example.com/jira/rest/api/2/issue/10002","key":"EX-1","fields":{"labels":["test"],"watcher":{"self":"http://www.example.com/jira/rest/api/2/issue/EX-1/watchers","isWatching":false,"watchCount":1,"watchers":[{"self":"http://www.example.com/jira/rest/api/2/user?username=fred","name":"fred","displayName":"Fred F. User","active":false}]},"epic": {"id": 19415,"key": "EPIC-77","self": "https://example.atlassian.net/rest/agile/1.0/epic/19415","name": "Epic Name","summary": "Do it","color": {"key": "color_11"},"done": false},"attachment":[{"self":"http://www.example.com/jira/rest/api/2.0/attachments/10000","filename":"picture.jpg","author":{"self":"http://www.example.com/jira/rest/api/2/user?username=fred","name":"fred","avatarUrls":{"48x48":"http://www.example.com/jira/secure/useravatar?size=large&ownerId=fred","24x24":"http://www.example.com/jira/secure/useravatar?size=small&ownerId=fred","16x16":"http://www.example.com/jira/secure/useravatar?size=xsmall&ownerId=fred","32x32":"http://www.example.com/jira/secure/useravatar?size=medium&ownerId=fred"},"displayName":"Fred F. User","active":false},"created":"2016-03-16T04:22:37.461+0000","size":23123,"mimeType":"image/jpeg","content":"http://www.example.com/jira/attachments/10000","thumbnail":"http://www.example.com/jira/secure/thumbnail/10000"}],"sub-tasks":[{"id":"10000","type":{"id":"10000","name":"","inward":"Parent","outward":"Sub-task"},"outwardIssue":{"id":"10003","key":"EX-2","self":"http://www.example.com/jira/rest/api/2/issue/EX-2","fields":{"status":{"iconUrl":"http://www.example.com/jira//images/icons/statuses/open.png","name":"Open"}}}}],"description":"example bug report","project":{"self":"http://www.example.com/jira/rest/api/2/project/EX","id":"10000","key":"EX","name":"Example","avatarUrls":{"48x48":"http://www.example.com/jira/secure/projectavatar?size=large&pid=10000","24x24":"http://www.example.com/jira/secure/projectavatar?size=small&pid=10000","16x16":"http://www.example.com/jira/secure/projectavatar?size=xsmall&pid=10000","32x32":"http://www.example.com/jira/secure/projectavatar?size=medium&pid=10000"},"projectCategory":{"self":"http://www.example.com/jira/rest/api/2/projectCategory/10000","id":"10000","name":"FIRST","description":"First Project Category"}},"comment":{"comments":[{"self":"http://www.example.com/jira/rest/api/2/issue/10010/comment/10000","id":"10000","author":{"self":"http://www.example.com/jira/rest/api/2/user?username=fred","name":"fred","displayName":"Fred F. User","active":false},"body":"Lorem ipsum dolor sit amet, consectetur adipiscing elit. Pellentesque eget venenatis elit. Duis eu justo eget augue iaculis fermentum. Sed semper quam laoreet nisi egestas at posuere augue semper.","updateAuthor":{"self":"http://www.example.com/jira/rest/api/2/user?username=fred","name":"fred","displayName":"Fred F. User","active":false},"created":"2016-03-16T04:22:37.356+0000","updated":"2016-03-16T04:22:37.356+0000","visibility":{"type":"role","value":"Administrators"}}]},"issuelinks":[{"id":"10001","type":{"id":"10000","name":"Dependent","inward":"depends on","outward":"is depended by"},"outwardIssue":{"id":"10004L","key":"PRJ-2","self":"http://www.example.com/jira/rest/api/2/issue/PRJ-2","fields":{"status":{"iconUrl":"http://www.example.com/jira//images/icons/statuses/open.png","name":"Open"}}}},{"id":"10002","type":{"id":"10000","name":"Dependent","inward":"depends on","outward":"is depended by"},"inwardIssue":{"id":"10004","key":"PRJ-3","self":"http://www.example.com/jira/rest/api/2/issue/PRJ-3","fields":{"status":{"iconUrl":"http://www.example.com/jira//images/icons/statuses/open.png","name":"Open"}}}}],"worklog":{"worklogs":[{"self":"http://www.example.com/jira/rest/api/2/issue/10010/worklog/10000","author":{"self":"http://www.example.com/jira/rest/api/2/user?username=fred","name":"fred","displayName":"Fred F. User","active":false},"updateAuthor":{"self":"http://www.example.com/jira/rest/api/2/user?username=fred","name":"fred","displayName":"Fred F. User","active":false},"comment":"I did some work here.","updated":"2016-03-16T04:22:37.471+0000","visibility":{"type":"group","value":"jira-developers"},"started":"2016-03-16T04:22:37.471+0000","timeSpent":"3h 20m","timeSpentSeconds":12000,"id":"100028","issueId":"10002"}]},"updated":"2016-04-06T02:36:53.594-0700","duedate":"2018-01-19","timetracking":{"originalEstimate":"10m","remainingEstimate":"3m","timeSpent":"6m","originalEstimateSeconds":600,"remainingEstimateSeconds":200,"timeSpentSeconds":400}},"names":{"watcher":"watcher","attachment":"attachment","sub-tasks":"sub-tasks","description":"description","project":"project","comment":"comment","issuelinks":"issuelinks","worklog":"worklog","updated":"updated","timetracking":"timetracking"},"schema":{},"renderedFields":{"resolutiondate":"In 1 week","updated":"2 hours ago","comment":{"comments":[{"body":"This <strong>is</strong> HTML"}]}}}`)
 	})
 
-	issue, _, err := testClient.Issue.Get("10002", nil)
+	issue, _, err := testClient.Issue.Get(context.Background(), "10002", nil)
 	if err != nil {
 		t.Errorf("Error given: %s", err)
 	}
@@ -408,7 +409,7 @@ func TestIssueService_DownloadAttachment(t *testing.T) {
 		w.Write([]byte(testAttachment))
 	})
 
-	resp, err := testClient.Issue.DownloadAttachment("10000")
+	resp, err := testClient.Issue.DownloadAttachment(context.Background(), "10000")
 	if err != nil {
 		t.Errorf("Error given: %s", err)
 	}
@@ -442,7 +443,7 @@ func TestIssueService_DownloadAttachment_BadStatus(t *testing.T) {
 		w.WriteHeader(http.StatusForbidden)
 	})
 
-	resp, err := testClient.Issue.DownloadAttachment("10000")
+	resp, err := testClient.Issue.DownloadAttachment(context.Background(), "10000")
 	if resp == nil {
 		t.Error("Expected response. Response is nil")
 		return
@@ -491,7 +492,7 @@ func TestIssueService_PostAttachment(t *testing.T) {
 
 	reader := strings.NewReader(testAttachment)
 
-	issue, resp, err := testClient.Issue.PostAttachment("10000", reader, "attachment")
+	issue, resp, err := testClient.Issue.PostAttachment(context.Background(), "10000", reader, "attachment")
 
 	if issue == nil {
 		t.Error("Expected response. Response is nil")
@@ -518,7 +519,7 @@ func TestIssueService_PostAttachment_NoResponse(t *testing.T) {
 	})
 	reader := strings.NewReader(testAttachment)
 
-	_, _, err := testClient.Issue.PostAttachment("10000", reader, "attachment")
+	_, _, err := testClient.Issue.PostAttachment(context.Background(), "10000", reader, "attachment")
 
 	if err == nil {
 		t.Errorf("Error expected: %s", err)
@@ -538,7 +539,7 @@ func TestIssueService_PostAttachment_NoFilename(t *testing.T) {
 	})
 	reader := strings.NewReader(testAttachment)
 
-	_, _, err := testClient.Issue.PostAttachment("10000", reader, "")
+	_, _, err := testClient.Issue.PostAttachment(context.Background(), "10000", reader, "")
 
 	if err != nil {
 		t.Errorf("Error expected: %s", err)
@@ -555,7 +556,7 @@ func TestIssueService_PostAttachment_NoAttachment(t *testing.T) {
 		fmt.Fprint(w, `[{"self":"http://jira/jira/rest/api/2/attachment/228924","id":"228924","filename":"example.jpg","author":{"self":"http://jira/jira/rest/api/2/user?username=test","name":"test","emailAddress":"test@test.com","avatarUrls":{"16x16":"http://jira/jira/secure/useravatar?size=small&avatarId=10082","48x48":"http://jira/jira/secure/useravatar?avatarId=10082"},"displayName":"Tester","active":true},"created":"2016-05-24T00:25:17.000-0700","size":32280,"mimeType":"image/jpeg","content":"http://jira/jira/secure/attachment/228924/example.jpg","thumbnail":"http://jira/jira/secure/thumbnail/228924/_thumb_228924.png"}]`)
 	})
 
-	_, _, err := testClient.Issue.PostAttachment("10000", nil, "attachment")
+	_, _, err := testClient.Issue.PostAttachment(context.Background(), "10000", nil, "attachment")
 
 	if err != nil {
 		t.Errorf("Error given: %s", err)
@@ -573,7 +574,7 @@ func TestIssueService_DeleteAttachment(t *testing.T) {
 		fmt.Fprint(w, `{}`)
 	})
 
-	resp, err := testClient.Issue.DeleteAttachment("10054")
+	resp, err := testClient.Issue.DeleteAttachment(context.Background(), "10054")
 	if resp.StatusCode != 204 {
 		t.Error("Expected attachment not deleted.")
 		if resp.StatusCode == 403 {
@@ -600,7 +601,7 @@ func TestIssueService_DeleteLink(t *testing.T) {
 		fmt.Fprint(w, `{}`)
 	})
 
-	resp, err := testClient.Issue.DeleteLink("10054")
+	resp, err := testClient.Issue.DeleteLink(context.Background(), "10054")
 	if resp.StatusCode != 204 {
 		t.Error("Expected link not deleted.")
 		if resp.StatusCode == 403 {
@@ -627,7 +628,7 @@ func TestIssueService_Search(t *testing.T) {
 	})
 
 	opt := &SearchOptions{StartAt: 1, MaxResults: 40, Expand: "foo"}
-	_, resp, err := testClient.Issue.Search("type = Bug and Status NOT IN (Resolved)", opt)
+	_, resp, err := testClient.Issue.Search(context.Background(), "type = Bug and Status NOT IN (Resolved)", opt)
 
 	if resp == nil {
 		t.Errorf("Response given: %+v", resp)
@@ -658,7 +659,7 @@ func TestIssueService_SearchEmptyJQL(t *testing.T) {
 	})
 
 	opt := &SearchOptions{StartAt: 1, MaxResults: 40, Expand: "foo"}
-	_, resp, err := testClient.Issue.Search("", opt)
+	_, resp, err := testClient.Issue.Search(context.Background(), "", opt)
 
 	if resp == nil {
 		t.Errorf("Response given: %+v", resp)
@@ -687,7 +688,7 @@ func TestIssueService_Search_WithoutPaging(t *testing.T) {
 		w.WriteHeader(http.StatusOK)
 		fmt.Fprint(w, `{"expand": "schema,names","startAt": 0,"maxResults": 50,"total": 6,"issues": [{"expand": "html","id": "10230","self": "http://kelpie9:8081/rest/api/2/issue/BULK-62","key": "BULK-62","fields": {"summary": "testing","timetracking": null,"issuetype": {"self": "http://kelpie9:8081/rest/api/2/issuetype/5","id": "5","description": "The sub-task of the issue","iconUrl": "http://kelpie9:8081/images/icons/issue_subtask.gif","name": "Sub-task","subtask": true},"customfield_10071": null}},{"expand": "html","id": "10004","self": "http://kelpie9:8081/rest/api/2/issue/BULK-47","key": "BULK-47","fields": {"summary": "Cheese v1 2.0 issue","timetracking": null,"issuetype": {"self": "http://kelpie9:8081/rest/api/2/issuetype/3","id": "3","description": "A task that needs to be done.","iconUrl": "http://kelpie9:8081/images/icons/task.gif","name": "Task","subtask": false}}}]}`)
 	})
-	_, resp, err := testClient.Issue.Search("something", nil)
+	_, resp, err := testClient.Issue.Search(context.Background(), "something", nil)
 
 	if resp == nil {
 		t.Errorf("Response given: %+v", resp)
@@ -731,7 +732,7 @@ func TestIssueService_SearchPages(t *testing.T) {
 
 	opt := &SearchOptions{StartAt: 1, MaxResults: 2, Expand: "foo", ValidateQuery: "warn"}
 	issues := make([]Issue, 0)
-	err := testClient.Issue.SearchPages("something", opt, func(issue Issue) error {
+	err := testClient.Issue.SearchPages(context.Background(), "something", opt, func(issue Issue) error {
 		issues = append(issues, issue)
 		return nil
 	})
@@ -762,7 +763,7 @@ func TestIssueService_SearchPages_EmptyResult(t *testing.T) {
 
 	opt := &SearchOptions{StartAt: 1, MaxResults: 50, Expand: "foo", ValidateQuery: "warn"}
 	issues := make([]Issue, 0)
-	err := testClient.Issue.SearchPages("something", opt, func(issue Issue) error {
+	err := testClient.Issue.SearchPages(context.Background(), "something", opt, func(issue Issue) error {
 		issues = append(issues, issue)
 		return nil
 	})
@@ -782,7 +783,7 @@ func TestIssueService_GetCustomFields(t *testing.T) {
 		fmt.Fprint(w, `{"expand":"renderedFields,names,schema,transitions,operations,editmeta,changelog,versionedRepresentations","id":"10002","self":"http://www.example.com/jira/rest/api/2/issue/10002","key":"EX-1","fields":{"customfield_123":"test","watcher":{"self":"http://www.example.com/jira/rest/api/2/issue/EX-1/watchers","isWatching":false,"watchCount":1,"watchers":[{"self":"http://www.example.com/jira/rest/api/2/user?username=fred","name":"fred","displayName":"Fred F. User","active":false}]},"attachment":[{"self":"http://www.example.com/jira/rest/api/2.0/attachments/10000","filename":"picture.jpg","author":{"self":"http://www.example.com/jira/rest/api/2/user?username=fred","name":"fred","avatarUrls":{"48x48":"http://www.example.com/jira/secure/useravatar?size=large&ownerId=fred","24x24":"http://www.example.com/jira/secure/useravatar?size=small&ownerId=fred","16x16":"http://www.example.com/jira/secure/useravatar?size=xsmall&ownerId=fred","32x32":"http://www.example.com/jira/secure/useravatar?size=medium&ownerId=fred"},"displayName":"Fred F. User","active":false},"created":"2016-03-16T04:22:37.461+0000","size":23123,"mimeType":"image/jpeg","content":"http://www.example.com/jira/attachments/10000","thumbnail":"http://www.example.com/jira/secure/thumbnail/10000"}],"sub-tasks":[{"id":"10000","type":{"id":"10000","name":"","inward":"Parent","outward":"Sub-task"},"outwardIssue":{"id":"10003","key":"EX-2","self":"http://www.example.com/jira/rest/api/2/issue/EX-2","fields":{"status":{"iconUrl":"http://www.example.com/jira//images/icons/statuses/open.png","name":"Open"}}}}],"description":"example bug report","project":{"self":"http://www.example.com/jira/rest/api/2/project/EX","id":"10000","key":"EX","name":"Example","avatarUrls":{"48x48":"http://www.example.com/jira/secure/projectavatar?size=large&pid=10000","24x24":"http://www.example.com/jira/secure/projectavatar?size=small&pid=10000","16x16":"http://www.example.com/jira/secure/projectavatar?size=xsmall&pid=10000","32x32":"http://www.example.com/jira/secure/projectavatar?size=medium&pid=10000"},"projectCategory":{"self":"http://www.example.com/jira/rest/api/2/projectCategory/10000","id":"10000","name":"FIRST","description":"First Project Category"}},"comment":{"comments":[{"self":"http://www.example.com/jira/rest/api/2/issue/10010/comment/10000","id":"10000","author":{"self":"http://www.example.com/jira/rest/api/2/user?username=fred","name":"fred","displayName":"Fred F. User","active":false},"body":"Lorem ipsum dolor sit amet, consectetur adipiscing elit. Pellentesque eget venenatis elit. Duis eu justo eget augue iaculis fermentum. Sed semper quam laoreet nisi egestas at posuere augue semper.","updateAuthor":{"self":"http://www.example.com/jira/rest/api/2/user?username=fred","name":"fred","displayName":"Fred F. User","active":false},"created":"2016-03-16T04:22:37.356+0000","updated":"2016-03-16T04:22:37.356+0000","visibility":{"type":"role","value":"Administrators"}}]},"issuelinks":[{"id":"10001","type":{"id":"10000","name":"Dependent","inward":"depends on","outward":"is depended by"},"outwardIssue":{"id":"10004L","key":"PRJ-2","self":"http://www.example.com/jira/rest/api/2/issue/PRJ-2","fields":{"status":{"iconUrl":"http://www.example.com/jira//images/icons/statuses/open.png","name":"Open"}}}},{"id":"10002","type":{"id":"10000","name":"Dependent","inward":"depends on","outward":"is depended by"},"inwardIssue":{"id":"10004","key":"PRJ-3","self":"http://www.example.com/jira/rest/api/2/issue/PRJ-3","fields":{"status":{"iconUrl":"http://www.example.com/jira//images/icons/statuses/open.png","name":"Open"}}}}],"worklog":{"worklogs":[{"self":"http://www.example.com/jira/rest/api/2/issue/10010/worklog/10000","author":{"self":"http://www.example.com/jira/rest/api/2/user?username=fred","name":"fred","displayName":"Fred F. User","active":false},"updateAuthor":{"self":"http://www.example.com/jira/rest/api/2/user?username=fred","name":"fred","displayName":"Fred F. User","active":false},"comment":"I did some work here.","updated":"2016-03-16T04:22:37.471+0000","visibility":{"type":"group","value":"jira-developers"},"started":"2016-03-16T04:22:37.471+0000","timeSpent":"3h 20m","timeSpentSeconds":12000,"id":"100028","issueId":"10002"}]},"updated":"2016-04-06T02:36:53.594-0700","duedate":"2018-01-19","timetracking":{"originalEstimate":"10m","remainingEstimate":"3m","timeSpent":"6m","originalEstimateSeconds":600,"remainingEstimateSeconds":200,"timeSpentSeconds":400}},"names":{"watcher":"watcher","attachment":"attachment","sub-tasks":"sub-tasks","description":"description","project":"project","comment":"comment","issuelinks":"issuelinks","worklog":"worklog","updated":"updated","timetracking":"timetracking"},"schema":{}}`)
 	})
 
-	issue, _, err := testClient.Issue.GetCustomFields("10002")
+	issue, _, err := testClient.Issue.GetCustomFields(context.Background(), "10002")
 	if err != nil {
 		t.Errorf("Error given: %s", err)
 	}
@@ -804,7 +805,7 @@ func TestIssueService_GetComplexCustomFields(t *testing.T) {
 		fmt.Fprint(w, `{"expand":"renderedFields,names,schema,transitions,operations,editmeta,changelog,versionedRepresentations","id":"10002","self":"http://www.example.com/jira/rest/api/2/issue/10002","key":"EX-1","fields":{"customfield_123":{"self":"http://www.example.com/jira/rest/api/2/customFieldOption/123","value":"test","id":"123"},"watcher":{"self":"http://www.example.com/jira/rest/api/2/issue/EX-1/watchers","isWatching":false,"watchCount":1,"watchers":[{"self":"http://www.example.com/jira/rest/api/2/user?username=fred","name":"fred","displayName":"Fred F. User","active":false}]},"attachment":[{"self":"http://www.example.com/jira/rest/api/2.0/attachments/10000","filename":"picture.jpg","author":{"self":"http://www.example.com/jira/rest/api/2/user?username=fred","name":"fred","avatarUrls":{"48x48":"http://www.example.com/jira/secure/useravatar?size=large&ownerId=fred","24x24":"http://www.example.com/jira/secure/useravatar?size=small&ownerId=fred","16x16":"http://www.example.com/jira/secure/useravatar?size=xsmall&ownerId=fred","32x32":"http://www.example.com/jira/secure/useravatar?size=medium&ownerId=fred"},"displayName":"Fred F. User","active":false},"created":"2016-03-16T04:22:37.461+0000","size":23123,"mimeType":"image/jpeg","content":"http://www.example.com/jira/attachments/10000","thumbnail":"http://www.example.com/jira/secure/thumbnail/10000"}],"sub-tasks":[{"id":"10000","type":{"id":"10000","name":"","inward":"Parent","outward":"Sub-task"},"outwardIssue":{"id":"10003","key":"EX-2","self":"http://www.example.com/jira/rest/api/2/issue/EX-2","fields":{"status":{"iconUrl":"http://www.example.com/jira//images/icons/statuses/open.png","name":"Open"}}}}],"description":"example bug report","project":{"self":"http://www.example.com/jira/rest/api/2/project/EX","id":"10000","key":"EX","name":"Example","avatarUrls":{"48x48":"http://www.example.com/jira/secure/projectavatar?size=large&pid=10000","24x24":"http://www.example.com/jira/secure/projectavatar?size=small&pid=10000","16x16":"http://www.example.com/jira/secure/projectavatar?size=xsmall&pid=10000","32x32":"http://www.example.com/jira/secure/projectavatar?size=medium&pid=10000"},"projectCategory":{"self":"http://www.example.com/jira/rest/api/2/projectCategory/10000","id":"10000","name":"FIRST","description":"First Project Category"}},"comment":{"comments":[{"self":"http://www.example.com/jira/rest/api/2/issue/10010/comment/10000","id":"10000","author":{"self":"http://www.example.com/jira/rest/api/2/user?username=fred","name":"fred","displayName":"Fred F. User","active":false},"body":"Lorem ipsum dolor sit amet, consectetur adipiscing elit. Pellentesque eget venenatis elit. Duis eu justo eget augue iaculis fermentum. Sed semper quam laoreet nisi egestas at posuere augue semper.","updateAuthor":{"self":"http://www.example.com/jira/rest/api/2/user?username=fred","name":"fred","displayName":"Fred F. User","active":false},"created":"2016-03-16T04:22:37.356+0000","updated":"2016-03-16T04:22:37.356+0000","visibility":{"type":"role","value":"Administrators"}}]},"issuelinks":[{"id":"10001","type":{"id":"10000","name":"Dependent","inward":"depends on","outward":"is depended by"},"outwardIssue":{"id":"10004L","key":"PRJ-2","self":"http://www.example.com/jira/rest/api/2/issue/PRJ-2","fields":{"status":{"iconUrl":"http://www.example.com/jira//images/icons/statuses/open.png","name":"Open"}}}},{"id":"10002","type":{"id":"10000","name":"Dependent","inward":"depends on","outward":"is depended by"},"inwardIssue":{"id":"10004","key":"PRJ-3","self":"http://www.example.com/jira/rest/api/2/issue/PRJ-3","fields":{"status":{"iconUrl":"http://www.example.com/jira//images/icons/statuses/open.png","name":"Open"}}}}],"worklog":{"worklogs":[{"self":"http://www.example.com/jira/rest/api/2/issue/10010/worklog/10000","author":{"self":"http://www.example.com/jira/rest/api/2/user?username=fred","name":"fred","displayName":"Fred F. User","active":false},"updateAuthor":{"self":"http://www.example.com/jira/rest/api/2/user?username=fred","name":"fred","displayName":"Fred F. User","active":false},"comment":"I did some work here.","updated":"2016-03-16T04:22:37.471+0000","visibility":{"type":"group","value":"jira-developers"},"started":"2016-03-16T04:22:37.471+0000","timeSpent":"3h 20m","timeSpentSeconds":12000,"id":"100028","issueId":"10002"}]},"updated":"2016-04-06T02:36:53.594-0700","duedate":"2018-01-19","timetracking":{"originalEstimate":"10m","remainingEstimate":"3m","timeSpent":"6m","originalEstimateSeconds":600,"remainingEstimateSeconds":200,"timeSpentSeconds":400}},"names":{"watcher":"watcher","attachment":"attachment","sub-tasks":"sub-tasks","description":"description","project":"project","comment":"comment","issuelinks":"issuelinks","worklog":"worklog","updated":"updated","timetracking":"timetracking"},"schema":{}}`)
 	})
 
-	issue, _, err := testClient.Issue.GetCustomFields("10002")
+	issue, _, err := testClient.Issue.GetCustomFields(context.Background(), "10002")
 	if err != nil {
 		t.Errorf("Error given: %s", err)
 	}
@@ -834,7 +835,7 @@ func TestIssueService_GetTransitions(t *testing.T) {
 		fmt.Fprint(w, string(raw))
 	})
 
-	transitions, _, err := testClient.Issue.GetTransitions("123")
+	transitions, _, err := testClient.Issue.GetTransitions(context.Background(), "123")
 
 	if err != nil {
 		t.Errorf("Got error: %v", err)
@@ -876,7 +877,7 @@ func TestIssueService_DoTransition(t *testing.T) {
 			t.Errorf("Expected %s to be in payload, got %s instead", transitionID, payload.Transition.ID)
 		}
 	})
-	_, err := testClient.Issue.DoTransition("123", transitionID)
+	_, err := testClient.Issue.DoTransition(context.Background(), "123", transitionID)
 
 	if err != nil {
 		t.Errorf("Got error: %v", err)
@@ -935,7 +936,7 @@ func TestIssueService_DoTransitionWithPayload(t *testing.T) {
 			t.Errorf("Expected %s to be in payload, got %s instead", transitionID, transition["id"])
 		}
 	})
-	_, err := testClient.Issue.DoTransitionWithPayload("123", customPayload)
+	_, err := testClient.Issue.DoTransitionWithPayload(context.Background(), "123", customPayload)
 
 	if err != nil {
 		t.Errorf("Got error: %v", err)
@@ -1449,7 +1450,7 @@ func TestIssueService_Delete(t *testing.T) {
 		fmt.Fprint(w, `{}`)
 	})
 
-	resp, err := testClient.Issue.Delete("10002")
+	resp, err := testClient.Issue.Delete(context.Background(), "10002")
 	if resp.StatusCode != 204 {
 		t.Error("Expected issue not deleted.")
 	}
@@ -1567,9 +1568,9 @@ func TestIssueService_GetWorklogs(t *testing.T) {
 			var err error
 
 			if tc.option != nil {
-				worklog, _, err = testClient.Issue.GetWorklogs(tc.issueId, WithQueryOptions(tc.option))
+				worklog, _, err = testClient.Issue.GetWorklogs(context.Background(), tc.issueId, WithQueryOptions(tc.option))
 			} else {
-				worklog, _, err = testClient.Issue.GetWorklogs(tc.issueId)
+				worklog, _, err = testClient.Issue.GetWorklogs(context.Background(), tc.issueId)
 			}
 
 			if err != nil && !cmp.Equal(err, tc.err) {
@@ -1606,7 +1607,7 @@ func TestIssueService_GetWatchers(t *testing.T) {
         }]},"applicationRoles":{"size":1,"items":[]},"expand":"groups,applicationRoles"}`)
 	})
 
-	watchers, _, err := testClient.Issue.GetWatchers("10002")
+	watchers, _, err := testClient.Issue.GetWatchers(context.Background(), "10002")
 	if err != nil {
 		t.Errorf("Error given: %s", err)
 		return
@@ -1646,7 +1647,7 @@ func TestIssueService_DeprecatedGetWatchers(t *testing.T) {
         }]},"applicationRoles":{"size":1,"items":[]},"expand":"groups,applicationRoles"}`)
 	})
 
-	watchers, _, err := testClient.Issue.GetWatchers("10002")
+	watchers, _, err := testClient.Issue.GetWatchers(context.Background(), "10002")
 	if err != nil {
 		t.Errorf("Error given: %s", err)
 		return
@@ -1674,7 +1675,7 @@ func TestIssueService_UpdateAssignee(t *testing.T) {
 		w.WriteHeader(http.StatusNoContent)
 	})
 
-	resp, err := testClient.Issue.UpdateAssignee("10002", &User{
+	resp, err := testClient.Issue.UpdateAssignee(context.Background(), "10002", &User{
 		Name: "test-username",
 	})
 
@@ -1696,7 +1697,7 @@ func TestIssueService_Get_Fields_Changelog(t *testing.T) {
 		fmt.Fprint(w, `{"expand":"changelog","id":"10002","self":"http://www.example.com/jira/rest/api/2/issue/10002","key":"EX-1","changelog":{"startAt": 0,"maxResults": 1, "total": 1, "histories": [{"id": "10002", "author": {"self": "http://www.example.com/jira/rest/api/2/user?username=fred", "name": "fred", "key": "fred", "emailAddress": "fred@example.com", "avatarUrls": {"48x48": "http://www.example.com/secure/useravatar?ownerId=fred&avatarId=33072", "24x24": "http://www.example.com/secure/useravatar?size=small&ownerId=fred&avatarId=33072", "16x16": "http://www.example.com/secure/useravatar?size=xsmall&ownerId=fred&avatarId=33072", "32x32": "http://www.example.com/secure/useravatar?size=medium&ownerId=fred&avatarId=33072"},"displayName":"Fred","active": true,"timeZone":"Australia/Sydney"},"created":"2018-06-20T16:50:35.000+0300","items":[{"field":"Rank","fieldtype":"custom","from":"","fromString":"","to":"","toString":"Ranked higher"}]}]}}`)
 	})
 
-	issue, _, _ := testClient.Issue.Get("10002", &GetQueryOptions{Expand: "changelog"})
+	issue, _, _ := testClient.Issue.Get(context.Background(), "10002", &GetQueryOptions{Expand: "changelog"})
 	if issue == nil {
 		t.Error("Expected issue. Issue is nil")
 		return
@@ -1727,7 +1728,7 @@ func TestIssueService_Get_Transitions(t *testing.T) {
 		fmt.Fprint(w, `{"expand":"renderedFields,names,schema,transitions,operations,editmeta,changelog,versionedRepresentations","id":"10002","self":"http://www.example.com/jira/api/latest/issue/10002","key":"EX-1","transitions":[{"id":"121","name":"Start","to":{"self":"http://www.example.com/rest/api/2/status/10444","description":"","iconUrl":"http://www.example.com/images/icons/statuses/inprogress.png","name":"In progress","id":"10444","statusCategory":{"self":"http://www.example.com/rest/api/2/statuscategory/4","id":4,"key":"indeterminate","colorName":"yellow","name":"In Progress"}}}]}`)
 	})
 
-	issue, _, _ := testClient.Issue.Get("10002", &GetQueryOptions{Expand: "transitions"})
+	issue, _, _ := testClient.Issue.Get(context.Background(), "10002", &GetQueryOptions{Expand: "transitions"})
 	if issue == nil {
 		t.Error("Expected issue. Issue is nil")
 		return
@@ -1758,7 +1759,7 @@ func TestIssueService_Get_Fields_AffectsVersions(t *testing.T) {
 		fmt.Fprint(w, `{"fields":{"versions":[{"self":"http://www.example.com/jira/rest/api/2/version/10705","id":"10705","description":"test description","name":"2.1.0-rc3","archived":false,"released":false,"releaseDate":"2018-09-30"}]}}`)
 	})
 
-	issue, _, err := testClient.Issue.Get("10002", nil)
+	issue, _, err := testClient.Issue.Get(context.Background(), "10002", nil)
 	if err != nil {
 		t.Errorf("Error given: %s", err)
 	}
@@ -1798,7 +1799,7 @@ func TestIssueService_GetRemoteLinks(t *testing.T) {
 		fmt.Fprint(w, string(raw))
 	})
 
-	remoteLinks, _, err := testClient.Issue.GetRemoteLinks("123")
+	remoteLinks, _, err := testClient.Issue.GetRemoteLinks(context.Background(), "123")
 	if err != nil {
 		t.Errorf("Got error: %v", err)
 	}
@@ -1852,7 +1853,7 @@ func TestIssueService_AddRemoteLink(t *testing.T) {
 			},
 		},
 	}
-	record, _, err := testClient.Issue.AddRemoteLink("10000", r)
+	record, _, err := testClient.Issue.AddRemoteLink(context.Background(), "10000", r)
 	if record == nil {
 		t.Error("Expected Record. Record is nil")
 	}
@@ -1895,7 +1896,7 @@ func TestIssueService_UpdateRemoteLink(t *testing.T) {
 			},
 		},
 	}
-	_, err := testClient.Issue.UpdateRemoteLink("100", 200, r)
+	_, err := testClient.Issue.UpdateRemoteLink(context.Background(), "100", 200, r)
 	if err != nil {
 		t.Errorf("Error given: %s", err)
 	}

--- a/onpremise/issuelinktype.go
+++ b/onpremise/issuelinktype.go
@@ -12,10 +12,10 @@ import (
 // Jira API docs: https://developer.atlassian.com/cloud/jira/platform/rest/v2/#api-group-Issue-link-types
 type IssueLinkTypeService service
 
-// GetListWithContext gets all of the issue link types from Jira.
+// GetList gets all of the issue link types from Jira.
 //
 // Jira API docs: https://developer.atlassian.com/cloud/jira/platform/rest/v2/#api-rest-api-2-issueLinkType-get
-func (s *IssueLinkTypeService) GetListWithContext(ctx context.Context) ([]IssueLinkType, *Response, error) {
+func (s *IssueLinkTypeService) GetList(ctx context.Context) ([]IssueLinkType, *Response, error) {
 	apiEndpoint := "rest/api/2/issueLinkType"
 	req, err := s.client.NewRequest(ctx, "GET", apiEndpoint, nil)
 	if err != nil {
@@ -30,15 +30,10 @@ func (s *IssueLinkTypeService) GetListWithContext(ctx context.Context) ([]IssueL
 	return linkTypeList, resp, nil
 }
 
-// GetList wraps GetListWithContext using the background context.
-func (s *IssueLinkTypeService) GetList() ([]IssueLinkType, *Response, error) {
-	return s.GetListWithContext(context.Background())
-}
-
-// GetWithContext gets info of a specific issue link type from Jira.
+// Get gets info of a specific issue link type from Jira.
 //
 // Jira API docs: https://developer.atlassian.com/cloud/jira/platform/rest/v2/#api-rest-api-2-issueLinkType-issueLinkTypeId-get
-func (s *IssueLinkTypeService) GetWithContext(ctx context.Context, ID string) (*IssueLinkType, *Response, error) {
+func (s *IssueLinkTypeService) Get(ctx context.Context, ID string) (*IssueLinkType, *Response, error) {
 	apiEndPoint := fmt.Sprintf("rest/api/2/issueLinkType/%s", ID)
 	req, err := s.client.NewRequest(ctx, "GET", apiEndPoint, nil)
 	if err != nil {
@@ -53,15 +48,10 @@ func (s *IssueLinkTypeService) GetWithContext(ctx context.Context, ID string) (*
 	return linkType, resp, nil
 }
 
-// Get wraps GetWithContext using the background context.
-func (s *IssueLinkTypeService) Get(ID string) (*IssueLinkType, *Response, error) {
-	return s.GetWithContext(context.Background(), ID)
-}
-
-// CreateWithContext creates an issue link type in Jira.
+// Create creates an issue link type in Jira.
 //
 // Jira API docs: https://developer.atlassian.com/cloud/jira/platform/rest/v2/#api-rest-api-2-issueLinkType-post
-func (s *IssueLinkTypeService) CreateWithContext(ctx context.Context, linkType *IssueLinkType) (*IssueLinkType, *Response, error) {
+func (s *IssueLinkTypeService) Create(ctx context.Context, linkType *IssueLinkType) (*IssueLinkType, *Response, error) {
 	apiEndpoint := "/rest/api/2/issueLinkType"
 	req, err := s.client.NewRequest(ctx, "POST", apiEndpoint, linkType)
 	if err != nil {
@@ -88,16 +78,11 @@ func (s *IssueLinkTypeService) CreateWithContext(ctx context.Context, linkType *
 	return linkType, resp, nil
 }
 
-// Create wraps CreateWithContext using the background context.
-func (s *IssueLinkTypeService) Create(linkType *IssueLinkType) (*IssueLinkType, *Response, error) {
-	return s.CreateWithContext(context.Background(), linkType)
-}
-
-// UpdateWithContext updates an issue link type.  The issue is found by key.
+// Update updates an issue link type.  The issue is found by key.
 //
 // Jira API docs: https://developer.atlassian.com/cloud/jira/platform/rest/v2/#api-rest-api-2-issueLinkType-issueLinkTypeId-put
 // Caller must close resp.Body
-func (s *IssueLinkTypeService) UpdateWithContext(ctx context.Context, linkType *IssueLinkType) (*IssueLinkType, *Response, error) {
+func (s *IssueLinkTypeService) Update(ctx context.Context, linkType *IssueLinkType) (*IssueLinkType, *Response, error) {
 	apiEndpoint := fmt.Sprintf("rest/api/2/issueLinkType/%s", linkType.ID)
 	req, err := s.client.NewRequest(ctx, "PUT", apiEndpoint, linkType)
 	if err != nil {
@@ -111,17 +96,11 @@ func (s *IssueLinkTypeService) UpdateWithContext(ctx context.Context, linkType *
 	return &ret, resp, nil
 }
 
-// Update wraps UpdateWithContext using the background context.
-// Caller must close resp.Body
-func (s *IssueLinkTypeService) Update(linkType *IssueLinkType) (*IssueLinkType, *Response, error) {
-	return s.UpdateWithContext(context.Background(), linkType)
-}
-
-// DeleteWithContext deletes an issue link type based on provided ID.
+// Delete deletes an issue link type based on provided ID.
 //
 // Jira API docs: https://developer.atlassian.com/cloud/jira/platform/rest/v2/#api-rest-api-2-issueLinkType-issueLinkTypeId-delete
 // Caller must close resp.Body
-func (s *IssueLinkTypeService) DeleteWithContext(ctx context.Context, ID string) (*Response, error) {
+func (s *IssueLinkTypeService) Delete(ctx context.Context, ID string) (*Response, error) {
 	apiEndpoint := fmt.Sprintf("rest/api/2/issueLinkType/%s", ID)
 	req, err := s.client.NewRequest(ctx, "DELETE", apiEndpoint, nil)
 	if err != nil {
@@ -130,10 +109,4 @@ func (s *IssueLinkTypeService) DeleteWithContext(ctx context.Context, ID string)
 
 	resp, err := s.client.Do(req, nil)
 	return resp, err
-}
-
-// Delete wraps DeleteWithContext using the background context.
-// Caller must close resp.Body
-func (s *IssueLinkTypeService) Delete(ID string) (*Response, error) {
-	return s.DeleteWithContext(context.Background(), ID)
 }

--- a/onpremise/issuelinktype_test.go
+++ b/onpremise/issuelinktype_test.go
@@ -1,6 +1,7 @@
 package onpremise
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 	"os"
@@ -22,7 +23,7 @@ func TestIssueLinkTypeService_GetList(t *testing.T) {
 		fmt.Fprint(w, string(raw))
 	})
 
-	linkTypes, _, err := testClient.IssueLinkType.GetList()
+	linkTypes, _, err := testClient.IssueLinkType.GetList(context.Background())
 	if linkTypes == nil {
 		t.Error("Expected issueLinkType list. LinkTypes is nil")
 	}
@@ -42,7 +43,7 @@ func TestIssueLinkTypeService_Get(t *testing.T) {
 		"self": "https://www.example.com/jira/rest/api/2/issueLinkType/123"}`)
 	})
 
-	if linkType, _, err := testClient.IssueLinkType.Get("123"); err != nil {
+	if linkType, _, err := testClient.IssueLinkType.Get(context.Background(), "123"); err != nil {
 		t.Errorf("Error given: %s", err)
 	} else if linkType == nil {
 		t.Error("Expected linkType. LinkType is nil")
@@ -67,7 +68,7 @@ func TestIssueLinkTypeService_Create(t *testing.T) {
 		Outward: "causes",
 	}
 
-	if linkType, _, err := testClient.IssueLinkType.Create(lt); err != nil {
+	if linkType, _, err := testClient.IssueLinkType.Create(context.Background(), lt); err != nil {
 		t.Errorf("Error given: %s", err)
 	} else if linkType == nil {
 		t.Error("Expected linkType. LinkType is nil")
@@ -91,7 +92,7 @@ func TestIssueLinkTypeService_Update(t *testing.T) {
 		Outward: "causes",
 	}
 
-	if linkType, _, err := testClient.IssueLinkType.Update(lt); err != nil {
+	if linkType, _, err := testClient.IssueLinkType.Update(context.Background(), lt); err != nil {
 		t.Errorf("Error given: %s", err)
 	} else if linkType == nil {
 		t.Error("Expected linkType. LinkType is nil")
@@ -108,7 +109,7 @@ func TestIssueLinkTypeService_Delete(t *testing.T) {
 		w.WriteHeader(http.StatusNoContent)
 	})
 
-	resp, err := testClient.IssueLinkType.Delete("100")
+	resp, err := testClient.IssueLinkType.Delete(context.Background(), "100")
 	if resp.StatusCode != http.StatusNoContent {
 		t.Error("Expected issue not deleted.")
 	}

--- a/onpremise/organization.go
+++ b/onpremise/organization.go
@@ -53,14 +53,14 @@ type PropertyKeys struct {
 	Keys []PropertyKey `json:"keys,omitempty" structs:"keys,omitempty"`
 }
 
-// GetAllOrganizationsWithContext returns a list of organizations in
+// GetAllOrganizations returns a list of organizations in
 // the Jira Service Management instance.
 // Use this method when you want to present a list
 // of organizations or want to locate an organization
 // by name.
 //
 // Jira API docs: https://developer.atlassian.com/cloud/jira/service-desk/rest/api-group-organization/#api-group-organization
-func (s *OrganizationService) GetAllOrganizationsWithContext(ctx context.Context, start int, limit int, accountID string) (*PagedDTO, *Response, error) {
+func (s *OrganizationService) GetAllOrganizations(ctx context.Context, start int, limit int, accountID string) (*PagedDTO, *Response, error) {
 	apiEndPoint := fmt.Sprintf("rest/servicedeskapi/organization?start=%d&limit=%d", start, limit)
 	if accountID != "" {
 		apiEndPoint += fmt.Sprintf("&accountId=%s", accountID)
@@ -83,16 +83,11 @@ func (s *OrganizationService) GetAllOrganizationsWithContext(ctx context.Context
 	return v, resp, nil
 }
 
-// GetAllOrganizations wraps GetAllOrganizationsWithContext using the background context.
-func (s *OrganizationService) GetAllOrganizations(start int, limit int, accountID string) (*PagedDTO, *Response, error) {
-	return s.GetAllOrganizationsWithContext(context.Background(), start, limit, accountID)
-}
-
-// CreateOrganizationWithContext creates an organization by
+// CreateOrganization creates an organization by
 // passing the name of the organization.
 //
 // Jira API docs: https://developer.atlassian.com/cloud/jira/service-desk/rest/api-group-organization/#api-rest-servicedeskapi-organization-post
-func (s *OrganizationService) CreateOrganizationWithContext(ctx context.Context, name string) (*Organization, *Response, error) {
+func (s *OrganizationService) CreateOrganization(ctx context.Context, name string) (*Organization, *Response, error) {
 	apiEndPoint := "rest/servicedeskapi/organization"
 
 	organization := OrganizationCreationDTO{
@@ -116,19 +111,14 @@ func (s *OrganizationService) CreateOrganizationWithContext(ctx context.Context,
 	return o, resp, nil
 }
 
-// CreateOrganization wraps CreateOrganizationWithContext using the background context.
-func (s *OrganizationService) CreateOrganization(name string) (*Organization, *Response, error) {
-	return s.CreateOrganizationWithContext(context.Background(), name)
-}
-
-// GetOrganizationWithContext returns details of an
+// GetOrganization returns details of an
 // organization. Use this method to get organization
 // details whenever your application component is
 // passed an organization ID but needs to display
 // other organization details.
 //
 // Jira API docs: https://developer.atlassian.com/cloud/jira/service-desk/rest/api-group-organization/#api-rest-servicedeskapi-organization-organizationid-get
-func (s *OrganizationService) GetOrganizationWithContext(ctx context.Context, organizationID int) (*Organization, *Response, error) {
+func (s *OrganizationService) GetOrganization(ctx context.Context, organizationID int) (*Organization, *Response, error) {
 	apiEndPoint := fmt.Sprintf("rest/servicedeskapi/organization/%d", organizationID)
 
 	req, err := s.client.NewRequest(ctx, "GET", apiEndPoint, nil)
@@ -148,19 +138,14 @@ func (s *OrganizationService) GetOrganizationWithContext(ctx context.Context, or
 	return o, resp, nil
 }
 
-// GetOrganization wraps GetOrganizationWithContext using the background context.
-func (s *OrganizationService) GetOrganization(organizationID int) (*Organization, *Response, error) {
-	return s.GetOrganizationWithContext(context.Background(), organizationID)
-}
-
-// DeleteOrganizationWithContext deletes an organization. Note that
+// DeleteOrganization deletes an organization. Note that
 // the organization is deleted regardless
 // of other associations it may have.
 // For example, associations with service desks.
 //
 // Jira API docs: https://developer.atlassian.com/cloud/jira/service-desk/rest/api-group-organization/#api-rest-servicedeskapi-organization-organizationid-delete
 // Caller must close resp.Body
-func (s *OrganizationService) DeleteOrganizationWithContext(ctx context.Context, organizationID int) (*Response, error) {
+func (s *OrganizationService) DeleteOrganization(ctx context.Context, organizationID int) (*Response, error) {
 	apiEndPoint := fmt.Sprintf("rest/servicedeskapi/organization/%d", organizationID)
 
 	req, err := s.client.NewRequest(ctx, "DELETE", apiEndPoint, nil)
@@ -178,19 +163,13 @@ func (s *OrganizationService) DeleteOrganizationWithContext(ctx context.Context,
 	return resp, nil
 }
 
-// DeleteOrganization wraps DeleteOrganizationWithContext using the background context.
-// Caller must close resp.Body
-func (s *OrganizationService) DeleteOrganization(organizationID int) (*Response, error) {
-	return s.DeleteOrganizationWithContext(context.Background(), organizationID)
-}
-
-// GetPropertiesKeysWithContext returns the keys of
+// GetPropertiesKeys returns the keys of
 // all properties for an organization. Use this resource
 // when you need to find out what additional properties
 // items have been added to an organization.
 //
 // https://developer.atlassian.com/cloud/jira/service-desk/rest/api-group-organization/#api-rest-servicedeskapi-organization-organizationid-property-get
-func (s *OrganizationService) GetPropertiesKeysWithContext(ctx context.Context, organizationID int) (*PropertyKeys, *Response, error) {
+func (s *OrganizationService) GetPropertiesKeys(ctx context.Context, organizationID int) (*PropertyKeys, *Response, error) {
 	apiEndPoint := fmt.Sprintf("rest/servicedeskapi/organization/%d/property", organizationID)
 
 	req, err := s.client.NewRequest(ctx, "GET", apiEndPoint, nil)
@@ -210,17 +189,12 @@ func (s *OrganizationService) GetPropertiesKeysWithContext(ctx context.Context, 
 	return pk, resp, nil
 }
 
-// GetPropertiesKeys wraps GetPropertiesKeysWithContext using the background context.
-func (s *OrganizationService) GetPropertiesKeys(organizationID int) (*PropertyKeys, *Response, error) {
-	return s.GetPropertiesKeysWithContext(context.Background(), organizationID)
-}
-
-// GetPropertyWithContext returns the value of a property
+// GetProperty returns the value of a property
 // from an organization. Use this method to obtain the JSON
 // content for an organization's property.
 //
 // https://developer.atlassian.com/cloud/jira/service-desk/rest/api-group-organization/#api-rest-servicedeskapi-organization-organizationid-property-propertykey-get
-func (s *OrganizationService) GetPropertyWithContext(ctx context.Context, organizationID int, propertyKey string) (*EntityProperty, *Response, error) {
+func (s *OrganizationService) GetProperty(ctx context.Context, organizationID int, propertyKey string) (*EntityProperty, *Response, error) {
 	apiEndPoint := fmt.Sprintf("rest/servicedeskapi/organization/%d/property/%s", organizationID, propertyKey)
 
 	req, err := s.client.NewRequest(ctx, "GET", apiEndPoint, nil)
@@ -240,18 +214,13 @@ func (s *OrganizationService) GetPropertyWithContext(ctx context.Context, organi
 	return ep, resp, nil
 }
 
-// GetProperty wraps GetPropertyWithContext using the background context.
-func (s *OrganizationService) GetProperty(organizationID int, propertyKey string) (*EntityProperty, *Response, error) {
-	return s.GetPropertyWithContext(context.Background(), organizationID, propertyKey)
-}
-
-// SetPropertyWithContext sets the value of a
+// SetProperty sets the value of a
 // property for an organization. Use this
 // resource to store custom data against an organization.
 //
 // https://developer.atlassian.com/cloud/jira/service-desk/rest/api-group-organization/#api-rest-servicedeskapi-organization-organizationid-property-propertykey-put
 // Caller must close resp.Body
-func (s *OrganizationService) SetPropertyWithContext(ctx context.Context, organizationID int, propertyKey string) (*Response, error) {
+func (s *OrganizationService) SetProperty(ctx context.Context, organizationID int, propertyKey string) (*Response, error) {
 	apiEndPoint := fmt.Sprintf("rest/servicedeskapi/organization/%d/property/%s", organizationID, propertyKey)
 
 	req, err := s.client.NewRequest(ctx, "PUT", apiEndPoint, nil)
@@ -270,17 +239,11 @@ func (s *OrganizationService) SetPropertyWithContext(ctx context.Context, organi
 	return resp, nil
 }
 
-// SetProperty wraps SetPropertyWithContext using the background context.
-// Caller must close resp.Body
-func (s *OrganizationService) SetProperty(organizationID int, propertyKey string) (*Response, error) {
-	return s.SetPropertyWithContext(context.Background(), organizationID, propertyKey)
-}
-
-// DeletePropertyWithContext removes a property from an organization.
+// DeleteProperty removes a property from an organization.
 //
 // https://developer.atlassian.com/cloud/jira/service-desk/rest/api-group-organization/#api-rest-servicedeskapi-organization-organizationid-property-propertykey-delete
 // Caller must close resp.Body
-func (s *OrganizationService) DeletePropertyWithContext(ctx context.Context, organizationID int, propertyKey string) (*Response, error) {
+func (s *OrganizationService) DeleteProperty(ctx context.Context, organizationID int, propertyKey string) (*Response, error) {
 	apiEndPoint := fmt.Sprintf("rest/servicedeskapi/organization/%d/property/%s", organizationID, propertyKey)
 
 	req, err := s.client.NewRequest(ctx, "DELETE", apiEndPoint, nil)
@@ -299,20 +262,14 @@ func (s *OrganizationService) DeletePropertyWithContext(ctx context.Context, org
 	return resp, nil
 }
 
-// DeleteProperty wraps DeletePropertyWithContext using the background context.
-// Caller must close resp.Body
-func (s *OrganizationService) DeleteProperty(organizationID int, propertyKey string) (*Response, error) {
-	return s.DeletePropertyWithContext(context.Background(), organizationID, propertyKey)
-}
-
-// GetUsersWithContext returns all the users
+// GetUsers returns all the users
 // associated with an organization. Use this
 // method where you want to provide a list of
 // users for an organization or determine if
 // a user is associated with an organization.
 //
 // https://developer.atlassian.com/cloud/jira/service-desk/rest/api-group-organization/#api-rest-servicedeskapi-organization-organizationid-user-get
-func (s *OrganizationService) GetUsersWithContext(ctx context.Context, organizationID int, start int, limit int) (*PagedDTO, *Response, error) {
+func (s *OrganizationService) GetUsers(ctx context.Context, organizationID int, start int, limit int) (*PagedDTO, *Response, error) {
 	apiEndPoint := fmt.Sprintf("rest/servicedeskapi/organization/%d/user?start=%d&limit=%d", organizationID, start, limit)
 
 	req, err := s.client.NewRequest(ctx, "GET", apiEndPoint, nil)
@@ -332,16 +289,11 @@ func (s *OrganizationService) GetUsersWithContext(ctx context.Context, organizat
 	return users, resp, nil
 }
 
-// GetUsers wraps GetUsersWithContext using the background context.
-func (s *OrganizationService) GetUsers(organizationID int, start int, limit int) (*PagedDTO, *Response, error) {
-	return s.GetUsersWithContext(context.Background(), organizationID, start, limit)
-}
-
-// AddUsersWithContext adds users to an organization.
+// AddUsers adds users to an organization.
 //
 // https://developer.atlassian.com/cloud/jira/service-desk/rest/api-group-organization/#api-rest-servicedeskapi-organization-organizationid-user-post
 // Caller must close resp.Body
-func (s *OrganizationService) AddUsersWithContext(ctx context.Context, organizationID int, users OrganizationUsersDTO) (*Response, error) {
+func (s *OrganizationService) AddUsers(ctx context.Context, organizationID int, users OrganizationUsersDTO) (*Response, error) {
 	apiEndPoint := fmt.Sprintf("rest/servicedeskapi/organization/%d/user", organizationID)
 
 	req, err := s.client.NewRequest(ctx, "POST", apiEndPoint, users)
@@ -359,17 +311,11 @@ func (s *OrganizationService) AddUsersWithContext(ctx context.Context, organizat
 	return resp, nil
 }
 
-// AddUsers wraps AddUsersWithContext using the background context.
-// Caller must close resp.Body
-func (s *OrganizationService) AddUsers(organizationID int, users OrganizationUsersDTO) (*Response, error) {
-	return s.AddUsersWithContext(context.Background(), organizationID, users)
-}
-
-// RemoveUsersWithContext removes users from an organization.
+// RemoveUsers removes users from an organization.
 //
 // https://developer.atlassian.com/cloud/jira/service-desk/rest/api-group-organization/#api-rest-servicedeskapi-organization-organizationid-user-delete
 // Caller must close resp.Body
-func (s *OrganizationService) RemoveUsersWithContext(ctx context.Context, organizationID int, users OrganizationUsersDTO) (*Response, error) {
+func (s *OrganizationService) RemoveUsers(ctx context.Context, organizationID int, users OrganizationUsersDTO) (*Response, error) {
 	apiEndPoint := fmt.Sprintf("rest/servicedeskapi/organization/%d/user", organizationID)
 
 	req, err := s.client.NewRequest(ctx, "DELETE", apiEndPoint, nil)
@@ -386,10 +332,4 @@ func (s *OrganizationService) RemoveUsersWithContext(ctx context.Context, organi
 	}
 
 	return resp, nil
-}
-
-// RemoveUsers wraps RemoveUsersWithContext using the background context.
-// Caller must close resp.Body
-func (s *OrganizationService) RemoveUsers(organizationID int, users OrganizationUsersDTO) (*Response, error) {
-	return s.RemoveUsersWithContext(context.Background(), organizationID, users)
 }

--- a/onpremise/organization_test.go
+++ b/onpremise/organization_test.go
@@ -1,13 +1,14 @@
 package onpremise
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"net/http"
 	"testing"
 )
 
-func TestOrganizationService_GetAllOrganizationsWithContext(t *testing.T) {
+func TestOrganizationService_GetAllOrganizations(t *testing.T) {
 	setup()
 	defer teardown()
 	testMux.HandleFunc("/rest/servicedeskapi/organization", func(w http.ResponseWriter, r *http.Request) {
@@ -18,7 +19,7 @@ func TestOrganizationService_GetAllOrganizationsWithContext(t *testing.T) {
 		fmt.Fprint(w, `{ "_expands": [], "size": 1, "start": 1, "limit": 1, "isLastPage": false, "_links": { "base": "https://your-domain.atlassian.net/rest/servicedeskapi", "context": "context", "next": "https://your-domain.atlassian.net/rest/servicedeskapi/organization?start=2&limit=1", "prev": "https://your-domain.atlassian.net/rest/servicedeskapi/organization?start=0&limit=1" }, "values": [ { "id": "1", "name": "Charlie Cakes Franchises", "_links": { "self": "https://your-domain.atlassian.net/rest/servicedeskapi/organization/1" } } ] }`)
 	})
 
-	result, _, err := testClient.Organization.GetAllOrganizations(0, 50, "")
+	result, _, err := testClient.Organization.GetAllOrganizations(context.Background(), 0, 50, "")
 
 	if result == nil {
 		t.Error("Expected Organizations. Result is nil")
@@ -45,7 +46,7 @@ func TestOrganizationService_CreateOrganization(t *testing.T) {
 	})
 
 	name := "MyOrg"
-	o, _, err := testClient.Organization.CreateOrganization(name)
+	o, _, err := testClient.Organization.CreateOrganization(context.Background(), name)
 
 	if o == nil {
 		t.Error("Expected Organization. Result is nil")
@@ -70,7 +71,7 @@ func TestOrganizationService_GetOrganization(t *testing.T) {
 	})
 
 	id := 1
-	o, _, err := testClient.Organization.GetOrganization(id)
+	o, _, err := testClient.Organization.GetOrganization(context.Background(), id)
 
 	if err != nil {
 		t.Errorf("Error given: %s", err)
@@ -93,7 +94,7 @@ func TestOrganizationService_DeleteOrganization(t *testing.T) {
 		w.WriteHeader(http.StatusNoContent)
 	})
 
-	_, err := testClient.Organization.DeleteOrganization(1)
+	_, err := testClient.Organization.DeleteOrganization(context.Background(), 1)
 
 	if err != nil {
 		t.Errorf("Error given: %s", err)
@@ -118,7 +119,7 @@ func TestOrganizationService_GetPropertiesKeys(t *testing.T) {
 		  }`)
 	})
 
-	pk, _, err := testClient.Organization.GetPropertiesKeys(1)
+	pk, _, err := testClient.Organization.GetPropertiesKeys(context.Background(), 1)
 
 	if err != nil {
 		t.Errorf("Error given: %s", err)
@@ -149,7 +150,7 @@ func TestOrganizationService_GetProperty(t *testing.T) {
 	})
 
 	key := "organization.attributes"
-	ep, _, err := testClient.Organization.GetProperty(1, key)
+	ep, _, err := testClient.Organization.GetProperty(context.Background(), 1, key)
 
 	if err != nil {
 		t.Errorf("Error given: %s", err)
@@ -173,7 +174,7 @@ func TestOrganizationService_SetProperty(t *testing.T) {
 	})
 
 	key := "organization.attributes"
-	_, err := testClient.Organization.SetProperty(1, key)
+	_, err := testClient.Organization.SetProperty(context.Background(), 1, key)
 
 	if err != nil {
 		t.Errorf("Error given: %s", err)
@@ -191,7 +192,7 @@ func TestOrganizationService_DeleteProperty(t *testing.T) {
 	})
 
 	key := "organization.attributes"
-	_, err := testClient.Organization.DeleteProperty(1, key)
+	_, err := testClient.Organization.DeleteProperty(context.Background(), 1, key)
 
 	if err != nil {
 		t.Errorf("Error given: %s", err)
@@ -261,7 +262,7 @@ func TestOrganizationService_GetUsers(t *testing.T) {
 		  }`)
 	})
 
-	users, _, err := testClient.Organization.GetUsers(1, 0, 50)
+	users, _, err := testClient.Organization.GetUsers(context.Background(), 1, 0, 50)
 
 	if err != nil {
 		t.Errorf("Error given: %s", err)
@@ -294,7 +295,7 @@ func TestOrganizationService_AddUsers(t *testing.T) {
 			"qm:a713c8ea-1075-4e30-9d96-891a7d181739:5ad6d3a01db05e2a66fa80bd",
 		},
 	}
-	_, err := testClient.Organization.AddUsers(1, users)
+	_, err := testClient.Organization.AddUsers(context.Background(), 1, users)
 
 	if err != nil {
 		t.Errorf("Error given: %s", err)
@@ -317,7 +318,7 @@ func TestOrganizationService_RemoveUsers(t *testing.T) {
 			"qm:a713c8ea-1075-4e30-9d96-891a7d181739:5ad6d3a01db05e2a66fa80bd",
 		},
 	}
-	_, err := testClient.Organization.RemoveUsers(1, users)
+	_, err := testClient.Organization.RemoveUsers(context.Background(), 1, users)
 
 	if err != nil {
 		t.Errorf("Error given: %s", err)


### PR DESCRIPTION
Remove "WithContext" API methods for the following services:

* [Organization Service](https://github.com/andygrunwald/go-jira/commit/770cb36ed55bd55f6518dceae0dbf7049b329b44)
* [Issuelink Service](https://github.com/andygrunwald/go-jira/commit/ef937e6d2899d86349a5b199e34d29922200625f)
* [Board Service](https://github.com/andygrunwald/go-jira/commit/3b8985fe9e2a085a6055bd11744c69d3983cdf64)
* [Issue Service](https://github.com/andygrunwald/go-jira/commit/fb4caf4642732769dfc2065d68a9eccd351a5442)
* [Authentication Service](https://github.com/andygrunwald/go-jira/commit/948e8bc53cfe33e79192f0e39817be0c4f8b5daa)

Related: #337