### PR TITLE
Generic response error handling

### DIFF
--- a/cloud/board.go
+++ b/cloud/board.go
@@ -142,8 +142,7 @@ func (s *BoardService) GetAllBoards(ctx context.Context, opt *BoardListOptions) 
 	boards := new(BoardsList)
 	resp, err := s.client.Do(req, boards)
 	if err != nil {
-		jerr := NewJiraError(resp, err)
-		return nil, resp, jerr
+		return nil, resp, err
 	}
 
 	return boards, resp, err
@@ -163,8 +162,7 @@ func (s *BoardService) GetBoard(ctx context.Context, boardID int) (*Board, *Resp
 	board := new(Board)
 	resp, err := s.client.Do(req, board)
 	if err != nil {
-		jerr := NewJiraError(resp, err)
-		return nil, resp, jerr
+		return nil, resp, err
 	}
 
 	return board, resp, nil
@@ -188,8 +186,7 @@ func (s *BoardService) CreateBoard(ctx context.Context, board *Board) (*Board, *
 	responseBoard := new(Board)
 	resp, err := s.client.Do(req, responseBoard)
 	if err != nil {
-		jerr := NewJiraError(resp, err)
-		return nil, resp, jerr
+		return nil, resp, err
 	}
 
 	return responseBoard, resp, nil
@@ -207,9 +204,6 @@ func (s *BoardService) DeleteBoard(ctx context.Context, boardID int) (*Board, *R
 	}
 
 	resp, err := s.client.Do(req, nil)
-	if err != nil {
-		err = NewJiraError(resp, err)
-	}
 	return nil, resp, err
 }
 
@@ -230,10 +224,6 @@ func (s *BoardService) GetAllSprints(ctx context.Context, boardID int, options *
 
 	result := new(SprintsList)
 	resp, err := s.client.Do(req, result)
-	if err != nil {
-		err = NewJiraError(resp, err)
-	}
-
 	return result, resp, err
 }
 
@@ -250,10 +240,5 @@ func (s *BoardService) GetBoardConfiguration(ctx context.Context, boardID int) (
 
 	result := new(BoardConfiguration)
 	resp, err := s.client.Do(req, result)
-	if err != nil {
-		err = NewJiraError(resp, err)
-	}
-
 	return result, resp, err
-
 }

--- a/cloud/component.go
+++ b/cloud/component.go
@@ -31,9 +31,8 @@ func (s *ComponentService) Create(ctx context.Context, options *CreateComponentO
 
 	component := new(ProjectComponent)
 	resp, err := s.client.Do(req, component)
-
 	if err != nil {
-		return nil, resp, NewJiraError(resp, err)
+		return nil, resp, err
 	}
 
 	return component, resp, nil

--- a/cloud/customer.go
+++ b/cloud/customer.go
@@ -58,7 +58,7 @@ func (c *CustomerService) Create(ctx context.Context, email, displayName string)
 	responseCustomer := new(Customer)
 	resp, err := c.client.Do(req, responseCustomer)
 	if err != nil {
-		return nil, resp, NewJiraError(resp, err)
+		return nil, resp, err
 	}
 
 	return responseCustomer, resp, nil

--- a/cloud/error.go
+++ b/cloud/error.go
@@ -1,97 +1,25 @@
 package cloud
 
 import (
-	"bytes"
 	"encoding/json"
+	"errors"
 	"fmt"
-	"io"
 	"net/http"
 	"net/url"
-	"strings"
 )
 
-// Error message from Jira
+// JiraRestError error message from Jira REST API
 // See https://docs.atlassian.com/jira/REST/cloud/#error-responses
-type Error struct {
-	HTTPError     error
+type JiraRestError struct {
 	ErrorMessages []string          `json:"errorMessages"`
 	Errors        map[string]string `json:"errors"`
-}
-
-// NewJiraError creates a new jira Error
-func NewJiraError(resp *Response, httpError error) error {
-	if resp == nil {
-		return fmt.Errorf("no response returned: %w", httpError)
-	}
-
-	defer resp.Body.Close()
-	body, err := io.ReadAll(resp.Body)
-	if err != nil {
-		return fmt.Errorf("%s: %w", httpError.Error(), err)
-	}
-	jerr := Error{HTTPError: httpError}
-	contentType := resp.Header.Get("Content-Type")
-	if strings.HasPrefix(contentType, "application/json") {
-		err = json.Unmarshal(body, &jerr)
-		if err != nil {
-			return fmt.Errorf("%s: could not parse JSON: %w", httpError.Error(), err)
-		}
-	} else {
-		if httpError == nil {
-			return fmt.Errorf("got response status %s:%s", resp.Status, string(body))
-		}
-		return fmt.Errorf("%s: %s: %w", resp.Status, string(body), httpError)
-	}
-
-	return &jerr
-}
-
-// Error is a short string representing the error
-func (e *Error) Error() string {
-	if len(e.ErrorMessages) > 0 {
-		// return fmt.Sprintf("%v", e.HTTPError)
-		return fmt.Sprintf("%s: %v", e.ErrorMessages[0], e.HTTPError)
-	}
-	if len(e.Errors) > 0 {
-		for key, value := range e.Errors {
-			return fmt.Sprintf("%s - %s: %v", key, value, e.HTTPError)
-		}
-	}
-	return e.HTTPError.Error()
-}
-
-// LongError is a full representation of the error as a string
-func (e *Error) LongError() string {
-	var msg bytes.Buffer
-	if e.HTTPError != nil {
-		msg.WriteString("Original:\n")
-		msg.WriteString(e.HTTPError.Error())
-		msg.WriteString("\n")
-	}
-	if len(e.ErrorMessages) > 0 {
-		msg.WriteString("Messages:\n")
-		for _, v := range e.ErrorMessages {
-			msg.WriteString(" - ")
-			msg.WriteString(v)
-			msg.WriteString("\n")
-		}
-	}
-	if len(e.Errors) > 0 {
-		for key, value := range e.Errors {
-			msg.WriteString(" - ")
-			msg.WriteString(key)
-			msg.WriteString(" - ")
-			msg.WriteString(value)
-			msg.WriteString("\n")
-		}
-	}
-	return msg.String()
 }
 
 var ErrValidation = ResponseError{statusCode: http.StatusBadRequest}
 var ErrUnauthorized = ResponseError{statusCode: http.StatusUnauthorized}
 var ErrNotFound = ResponseError{statusCode: http.StatusNotFound}
 var ErrUnknown = ResponseError{statusCode: http.StatusInternalServerError}
+var ErrNoBody = errors.New("no body in response error")
 
 type ResponseError struct {
 	status     string
@@ -108,6 +36,16 @@ func (r *ResponseError) Error() string {
 // Body returns the response body if present
 func (r *ResponseError) Body() []byte {
 	return r.body
+}
+
+func (r *ResponseError) JiraRESTError() (*JiraRestError, error) {
+	if r.body == nil {
+		return nil, ErrNoBody
+	}
+
+	var jiraErr JiraRestError
+	err := json.Unmarshal(r.body, &jiraErr)
+	return &jiraErr, err
 }
 
 // Is checks if the error status code is equal

--- a/cloud/error.go
+++ b/cloud/error.go
@@ -15,10 +15,10 @@ type JiraRestError struct {
 	Errors        map[string]string `json:"errors"`
 }
 
-var ErrValidation = ResponseError{statusCode: http.StatusBadRequest}
-var ErrUnauthorized = ResponseError{statusCode: http.StatusUnauthorized}
-var ErrNotFound = ResponseError{statusCode: http.StatusNotFound}
-var ErrUnknown = ResponseError{statusCode: http.StatusInternalServerError}
+var ErrValidation = &ResponseError{statusCode: http.StatusBadRequest}
+var ErrUnauthorized = &ResponseError{statusCode: http.StatusUnauthorized}
+var ErrNotFound = &ResponseError{statusCode: http.StatusNotFound}
+var ErrUnknown = &ResponseError{statusCode: http.StatusInternalServerError}
 var ErrNoBody = errors.New("no body in response error")
 
 type ResponseError struct {

--- a/cloud/error.go
+++ b/cloud/error.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"net/url"
 	"strings"
 )
 
@@ -84,4 +85,26 @@ func (e *Error) LongError() string {
 		}
 	}
 	return msg.String()
+}
+
+type ResponseError struct {
+	status     string
+	statusCode int
+	url        *url.URL
+	body       []byte
+}
+
+// Error is a short string representing the error
+func (r *ResponseError) Error() string {
+	return fmt.Sprintf("%s: %d %s", r.url.String(), r.statusCode, r.status)
+}
+
+// Is checks the error with a different
+func (r *ResponseError) Is(tgt error) bool {
+	target, ok := tgt.(*ResponseError)
+	if !ok {
+		return false
+	}
+
+	return r.statusCode == target.statusCode
 }

--- a/cloud/error.go
+++ b/cloud/error.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"net/http"
 	"net/url"
 	"strings"
 )
@@ -87,6 +88,11 @@ func (e *Error) LongError() string {
 	return msg.String()
 }
 
+var ErrValidation = ResponseError{statusCode: http.StatusBadRequest}
+var ErrUnauthorized = ResponseError{statusCode: http.StatusUnauthorized}
+var ErrNotFound = ResponseError{statusCode: http.StatusNotFound}
+var ErrUnknown = ResponseError{statusCode: http.StatusInternalServerError}
+
 type ResponseError struct {
 	status     string
 	statusCode int
@@ -99,7 +105,12 @@ func (r *ResponseError) Error() string {
 	return fmt.Sprintf("%s: %d %s", r.url.String(), r.statusCode, r.status)
 }
 
-// Is checks the error with a different
+// Body returns the response body if present
+func (r *ResponseError) Body() []byte {
+	return r.body
+}
+
+// Is checks if the error status code is equal
 func (r *ResponseError) Is(tgt error) bool {
 	target, ok := tgt.(*ResponseError)
 	if !ok {

--- a/cloud/error_test.go
+++ b/cloud/error_test.go
@@ -1,206 +1,197 @@
 package cloud
 
-import (
-	"context"
-	"errors"
-	"fmt"
-	"net/http"
-	"strings"
-	"testing"
-)
-
-func TestError_NewJiraError(t *testing.T) {
-	setup()
-	defer teardown()
-
-	testMux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
-		w.Header().Set("Content-Type", "application/json")
-		fmt.Fprint(w, `{"errorMessages":["Issue does not exist or you do not have permission to see it."],"errors":{}}`)
-	})
-
-	req, _ := testClient.NewRequest(context.Background(), http.MethodGet, "/", nil)
-	resp, _ := testClient.Do(req, nil)
-
-	err := NewJiraError(resp, errors.New("Original http error"))
-	if err, ok := err.(*Error); !ok {
-		t.Errorf("Expected jira Error. Got %s", err.Error())
-	}
-
-	if !strings.Contains(err.Error(), "Issue does not exist") {
-		t.Errorf("Expected issue message. Got: %s", err.Error())
-	}
-}
-
-func TestError_NoResponse(t *testing.T) {
-	err := NewJiraError(nil, errors.New("Original http error"))
-
-	msg := err.Error()
-	if !strings.Contains(msg, "Original http error") {
-		t.Errorf("Expected the original error message: Got\n%s\n", msg)
-	}
-
-	if !strings.Contains(msg, "no response returned") {
-		t.Errorf("Expected the 'no response returned' error message: Got\n%s\n", msg)
-	}
-}
-
-func TestError_NoJSON(t *testing.T) {
-	setup()
-	defer teardown()
-
-	testMux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
-		fmt.Fprint(w, `Original message body`)
-	})
-
-	req, _ := testClient.NewRequest(context.Background(), http.MethodGet, "/", nil)
-	resp, _ := testClient.Do(req, nil)
-
-	err := NewJiraError(resp, errors.New("Original http error"))
-	msg := err.Error()
-
-	if !strings.Contains(msg, "200 OK: Original message body: Original http error") {
-		t.Errorf("Expected the HTTP status: Got\n%s\n", msg)
-	}
-}
-
-func TestError_Unauthorized_NilError(t *testing.T) {
-	setup()
-	defer teardown()
-
-	testMux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
-		w.WriteHeader(http.StatusUnauthorized)
-		fmt.Fprint(w, `User is not authorized`)
-	})
-
-	req, _ := testClient.NewRequest(context.Background(), http.MethodGet, "/", nil)
-	resp, _ := testClient.Do(req, nil)
-
-	err := NewJiraError(resp, nil)
-	msg := err.Error()
-	if !strings.Contains(msg, "401 Unauthorized:User is not authorized") {
-		t.Errorf("Expected Unauthorized HTTP status: Got\n%s\n", msg)
-	}
-}
-
-func TestError_BadJSON(t *testing.T) {
-	setup()
-	defer teardown()
-
-	testMux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
-		w.Header().Set("Content-Type", "application/json")
-		fmt.Fprint(w, `<html>Not JSON</html>`)
-	})
-
-	req, _ := testClient.NewRequest(context.Background(), http.MethodGet, "/", nil)
-	resp, _ := testClient.Do(req, nil)
-
-	err := NewJiraError(resp, errors.New("Original http error"))
-	msg := err.Error()
-
-	if !strings.Contains(msg, "could not parse JSON") {
-		t.Errorf("Expected the 'could not parse JSON' error message: Got\n%s\n", msg)
-	}
-}
-
-func TestError_NilOriginalMessage(t *testing.T) {
-	defer func() {
-		if r := recover(); r != nil {
-			t.Errorf("Expected an error message. Got a panic (%v)", r)
-		}
-	}()
-
-	msgErr := &Error{
-		HTTPError:     nil,
-		ErrorMessages: []string{"Issue does not exist"},
-		Errors: map[string]string{
-			"issuetype": "issue type is required",
-			"title":     "title is required",
-		},
-	}
-
-	_ = msgErr.Error()
-}
-
-func TestError_NilOriginalMessageLongError(t *testing.T) {
-	defer func() {
-		if r := recover(); r != nil {
-			t.Errorf("Expected an error message. Got a panic (%v)", r)
-		}
-	}()
-
-	msgErr := &Error{
-		HTTPError:     nil,
-		ErrorMessages: []string{"Issue does not exist"},
-		Errors: map[string]string{
-			"issuetype": "issue type is required",
-			"title":     "title is required",
-		},
-	}
-
-	_ = msgErr.LongError()
-}
-
-func TestError_ShortMessage(t *testing.T) {
-	msgErr := &Error{
-		HTTPError:     errors.New("Original http error"),
-		ErrorMessages: []string{"Issue does not exist"},
-		Errors: map[string]string{
-			"issuetype": "issue type is required",
-			"title":     "title is required",
-		},
-	}
-
-	mapErr := &Error{
-		HTTPError:     errors.New("Original http error"),
-		ErrorMessages: nil,
-		Errors: map[string]string{
-			"issuetype": "issue type is required",
-			"title":     "title is required",
-		},
-	}
-
-	noErr := &Error{
-		HTTPError:     errors.New("Original http error"),
-		ErrorMessages: nil,
-		Errors:        nil,
-	}
-
-	err := msgErr.Error()
-	if err != "Issue does not exist: Original http error" {
-		t.Errorf("Expected short message. Got %s", err)
-	}
-
-	err = mapErr.Error()
-	if !(strings.Contains(err, "issue type is required") || strings.Contains(err, "title is required")) {
-		t.Errorf("Expected short message. Got %s", err)
-	}
-
-	err = noErr.Error()
-	if err != "Original http error" {
-		t.Errorf("Expected original error message. Got %s", err)
-	}
-}
-
-func TestError_LongMessage(t *testing.T) {
-	longError := &Error{
-		HTTPError:     errors.New("Original http error"),
-		ErrorMessages: []string{"Issue does not exist."},
-		Errors: map[string]string{
-			"issuetype": "issue type is required",
-			"title":     "title is required",
-		},
-	}
-
-	msg := longError.LongError()
-	if !strings.Contains(msg, "Original http error") {
-		t.Errorf("Expected the error message: Got\n%s\n", msg)
-	}
-
-	if !strings.Contains(msg, "Issue does not exist") {
-		t.Errorf("Expected the error message: Got\n%s\n", msg)
-	}
-
-	if !strings.Contains(msg, "title - title is required") {
-		t.Errorf("Expected the error map: Got\n%s\n", msg)
-	}
-}
+//func TestError_NewJiraError(t *testing.T) {
+//	setup()
+//	defer teardown()
+//
+//	testMux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+//		w.Header().Set("Content-Type", "application/json")
+//		fmt.Fprint(w, `{"errorMessages":["Issue does not exist or you do not have permission to see it."],"errors":{}}`)
+//	})
+//
+//	req, _ := testClient.NewRequest(context.Background(), http.MethodGet, "/", nil)
+//	resp, _ := testClient.Do(req, nil)
+//
+//	err := NewJiraError(resp, errors.New("Original http error"))
+//	if err, ok := err.(*Error); !ok {
+//		t.Errorf("Expected jira Error. Got %s", err.Error())
+//	}
+//
+//	if !strings.Contains(err.Error(), "Issue does not exist") {
+//		t.Errorf("Expected issue message. Got: %s", err.Error())
+//	}
+//}
+//
+//func TestError_NoResponse(t *testing.T) {
+//	err := NewJiraError(nil, errors.New("Original http error"))
+//
+//	msg := err.Error()
+//	if !strings.Contains(msg, "Original http error") {
+//		t.Errorf("Expected the original error message: Got\n%s\n", msg)
+//	}
+//
+//	if !strings.Contains(msg, "no response returned") {
+//		t.Errorf("Expected the 'no response returned' error message: Got\n%s\n", msg)
+//	}
+//}
+//
+//func TestError_NoJSON(t *testing.T) {
+//	setup()
+//	defer teardown()
+//
+//	testMux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+//		fmt.Fprint(w, `Original message body`)
+//	})
+//
+//	req, _ := testClient.NewRequest(context.Background(), http.MethodGet, "/", nil)
+//	resp, _ := testClient.Do(req, nil)
+//
+//	err := NewJiraError(resp, errors.New("Original http error"))
+//	msg := err.Error()
+//
+//	if !strings.Contains(msg, "200 OK: Original message body: Original http error") {
+//		t.Errorf("Expected the HTTP status: Got\n%s\n", msg)
+//	}
+//}
+//
+//func TestError_Unauthorized_NilError(t *testing.T) {
+//	setup()
+//	defer teardown()
+//
+//	testMux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+//		w.WriteHeader(http.StatusUnauthorized)
+//		fmt.Fprint(w, `User is not authorized`)
+//	})
+//
+//	req, _ := testClient.NewRequest(context.Background(), http.MethodGet, "/", nil)
+//	resp, _ := testClient.Do(req, nil)
+//
+//	err := NewJiraError(resp, nil)
+//	msg := err.Error()
+//	if !strings.Contains(msg, "401 Unauthorized:User is not authorized") {
+//		t.Errorf("Expected Unauthorized HTTP status: Got\n%s\n", msg)
+//	}
+//}
+//
+//func TestError_BadJSON(t *testing.T) {
+//	setup()
+//	defer teardown()
+//
+//	testMux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+//		w.Header().Set("Content-Type", "application/json")
+//		fmt.Fprint(w, `<html>Not JSON</html>`)
+//	})
+//
+//	req, _ := testClient.NewRequest(context.Background(), http.MethodGet, "/", nil)
+//	resp, _ := testClient.Do(req, nil)
+//
+//	err := NewJiraError(resp, errors.New("Original http error"))
+//	msg := err.Error()
+//
+//	if !strings.Contains(msg, "could not parse JSON") {
+//		t.Errorf("Expected the 'could not parse JSON' error message: Got\n%s\n", msg)
+//	}
+//}
+//
+//func TestError_NilOriginalMessage(t *testing.T) {
+//	defer func() {
+//		if r := recover(); r != nil {
+//			t.Errorf("Expected an error message. Got a panic (%v)", r)
+//		}
+//	}()
+//
+//	msgErr := &Error{
+//		HTTPError:     nil,
+//		ErrorMessages: []string{"Issue does not exist"},
+//		Errors: map[string]string{
+//			"issuetype": "issue type is required",
+//			"title":     "title is required",
+//		},
+//	}
+//
+//	_ = msgErr.Error()
+//}
+//
+//func TestError_NilOriginalMessageLongError(t *testing.T) {
+//	defer func() {
+//		if r := recover(); r != nil {
+//			t.Errorf("Expected an error message. Got a panic (%v)", r)
+//		}
+//	}()
+//
+//	msgErr := &Error{
+//		HTTPError:     nil,
+//		ErrorMessages: []string{"Issue does not exist"},
+//		Errors: map[string]string{
+//			"issuetype": "issue type is required",
+//			"title":     "title is required",
+//		},
+//	}
+//
+//	_ = msgErr.LongError()
+//}
+//
+//func TestError_ShortMessage(t *testing.T) {
+//	msgErr := &Error{
+//		HTTPError:     errors.New("Original http error"),
+//		ErrorMessages: []string{"Issue does not exist"},
+//		Errors: map[string]string{
+//			"issuetype": "issue type is required",
+//			"title":     "title is required",
+//		},
+//	}
+//
+//	mapErr := &Error{
+//		HTTPError:     errors.New("Original http error"),
+//		ErrorMessages: nil,
+//		Errors: map[string]string{
+//			"issuetype": "issue type is required",
+//			"title":     "title is required",
+//		},
+//	}
+//
+//	noErr := &Error{
+//		HTTPError:     errors.New("Original http error"),
+//		ErrorMessages: nil,
+//		Errors:        nil,
+//	}
+//
+//	err := msgErr.Error()
+//	if err != "Issue does not exist: Original http error" {
+//		t.Errorf("Expected short message. Got %s", err)
+//	}
+//
+//	err = mapErr.Error()
+//	if !(strings.Contains(err, "issue type is required") || strings.Contains(err, "title is required")) {
+//		t.Errorf("Expected short message. Got %s", err)
+//	}
+//
+//	err = noErr.Error()
+//	if err != "Original http error" {
+//		t.Errorf("Expected original error message. Got %s", err)
+//	}
+//}
+//
+//func TestError_LongMessage(t *testing.T) {
+//	longError := &Error{
+//		HTTPError:     errors.New("Original http error"),
+//		ErrorMessages: []string{"Issue does not exist."},
+//		Errors: map[string]string{
+//			"issuetype": "issue type is required",
+//			"title":     "title is required",
+//		},
+//	}
+//
+//	msg := longError.LongError()
+//	if !strings.Contains(msg, "Original http error") {
+//		t.Errorf("Expected the error message: Got\n%s\n", msg)
+//	}
+//
+//	if !strings.Contains(msg, "Issue does not exist") {
+//		t.Errorf("Expected the error message: Got\n%s\n", msg)
+//	}
+//
+//	if !strings.Contains(msg, "title - title is required") {
+//		t.Errorf("Expected the error map: Got\n%s\n", msg)
+//	}
+//}

--- a/cloud/field.go
+++ b/cloud/field.go
@@ -45,7 +45,8 @@ func (s *FieldService) GetList(ctx context.Context) ([]Field, *Response, error) 
 	fieldList := []Field{}
 	resp, err := s.client.Do(req, &fieldList)
 	if err != nil {
-		return nil, resp, NewJiraError(resp, err)
+		return nil, resp, err
 	}
+
 	return fieldList, resp, nil
 }

--- a/cloud/filter.go
+++ b/cloud/filter.go
@@ -121,7 +121,6 @@ type FilterSearchOptions struct {
 
 // GetList retrieves all filters from Jira
 func (fs *FilterService) GetList(ctx context.Context) ([]*Filter, *Response, error) {
-
 	options := &GetQueryOptions{}
 	apiEndpoint := "rest/api/2/filter"
 	req, err := fs.client.NewRequest(ctx, http.MethodGet, apiEndpoint, nil)
@@ -138,9 +137,9 @@ func (fs *FilterService) GetList(ctx context.Context) ([]*Filter, *Response, err
 	filters := []*Filter{}
 	resp, err := fs.client.Do(req, &filters)
 	if err != nil {
-		jerr := NewJiraError(resp, err)
-		return nil, resp, jerr
+		return nil, resp, err
 	}
+
 	return filters, resp, err
 }
 
@@ -151,12 +150,13 @@ func (fs *FilterService) GetFavouriteList(ctx context.Context) ([]*Filter, *Resp
 	if err != nil {
 		return nil, nil, err
 	}
+
 	filters := []*Filter{}
 	resp, err := fs.client.Do(req, &filters)
 	if err != nil {
-		jerr := NewJiraError(resp, err)
-		return nil, resp, jerr
+		return nil, resp, err
 	}
+
 	return filters, resp, err
 }
 
@@ -167,11 +167,11 @@ func (fs *FilterService) Get(ctx context.Context, filterID int) (*Filter, *Respo
 	if err != nil {
 		return nil, nil, err
 	}
+
 	filter := new(Filter)
 	resp, err := fs.client.Do(req, filter)
 	if err != nil {
-		jerr := NewJiraError(resp, err)
-		return nil, resp, jerr
+		return nil, resp, err
 	}
 
 	return filter, resp, err
@@ -186,6 +186,7 @@ func (fs *FilterService) GetMyFilters(ctx context.Context, opts *GetMyFiltersQue
 	if err != nil {
 		return nil, nil, err
 	}
+
 	req, err := fs.client.NewRequest(ctx, http.MethodGet, url, nil)
 	if err != nil {
 		return nil, nil, err
@@ -194,9 +195,9 @@ func (fs *FilterService) GetMyFilters(ctx context.Context, opts *GetMyFiltersQue
 	filters := []*Filter{}
 	resp, err := fs.client.Do(req, &filters)
 	if err != nil {
-		jerr := NewJiraError(resp, err)
-		return nil, resp, jerr
+		return nil, resp, err
 	}
+
 	return filters, resp, nil
 }
 
@@ -209,6 +210,7 @@ func (fs *FilterService) Search(ctx context.Context, opt *FilterSearchOptions) (
 	if err != nil {
 		return nil, nil, err
 	}
+
 	req, err := fs.client.NewRequest(ctx, http.MethodGet, url, nil)
 	if err != nil {
 		return nil, nil, err
@@ -217,8 +219,7 @@ func (fs *FilterService) Search(ctx context.Context, opt *FilterSearchOptions) (
 	filters := new(FiltersList)
 	resp, err := fs.client.Do(req, filters)
 	if err != nil {
-		jerr := NewJiraError(resp, err)
-		return nil, resp, jerr
+		return nil, resp, err
 	}
 
 	return filters, resp, err

--- a/cloud/group.go
+++ b/cloud/group.go
@@ -109,8 +109,7 @@ func (s *GroupService) Add(ctx context.Context, groupname string, username strin
 	responseGroup := new(Group)
 	resp, err := s.client.Do(req, responseGroup)
 	if err != nil {
-		jerr := NewJiraError(resp, err)
-		return nil, resp, jerr
+		return nil, resp, err
 	}
 
 	return responseGroup, resp, nil
@@ -129,8 +128,7 @@ func (s *GroupService) Remove(ctx context.Context, groupname string, username st
 
 	resp, err := s.client.Do(req, nil)
 	if err != nil {
-		jerr := NewJiraError(resp, err)
-		return resp, jerr
+		return resp, err
 	}
 
 	return resp, nil

--- a/cloud/issuelinktype.go
+++ b/cloud/issuelinktype.go
@@ -26,8 +26,9 @@ func (s *IssueLinkTypeService) GetList(ctx context.Context) ([]IssueLinkType, *R
 	linkTypeList := []IssueLinkType{}
 	resp, err := s.client.Do(req, &linkTypeList)
 	if err != nil {
-		return nil, resp, NewJiraError(resp, err)
+		return nil, resp, err
 	}
+
 	return linkTypeList, resp, nil
 }
 
@@ -44,8 +45,9 @@ func (s *IssueLinkTypeService) Get(ctx context.Context, ID string) (*IssueLinkTy
 	linkType := new(IssueLinkType)
 	resp, err := s.client.Do(req, linkType)
 	if err != nil {
-		return nil, resp, NewJiraError(resp, err)
+		return nil, resp, err
 	}
+
 	return linkType, resp, nil
 }
 
@@ -68,14 +70,14 @@ func (s *IssueLinkTypeService) Create(ctx context.Context, linkType *IssueLinkTy
 	defer resp.Body.Close()
 	data, err := io.ReadAll(resp.Body)
 	if err != nil {
-		e := fmt.Errorf("could not read the returned data")
-		return nil, resp, NewJiraError(resp, e)
+		return nil, resp, fmt.Errorf("could not read the returned data: %w", err)
 	}
+
 	err = json.Unmarshal(data, responseLinkType)
 	if err != nil {
-		e := fmt.Errorf("could no unmarshal the data into struct")
-		return nil, resp, NewJiraError(resp, e)
+		return nil, resp, fmt.Errorf("could no unmarshal the data into struct: %w", err)
 	}
+
 	return linkType, resp, nil
 }
 
@@ -89,10 +91,12 @@ func (s *IssueLinkTypeService) Update(ctx context.Context, linkType *IssueLinkTy
 	if err != nil {
 		return nil, nil, err
 	}
+
 	resp, err := s.client.Do(req, nil)
 	if err != nil {
-		return nil, resp, NewJiraError(resp, err)
+		return nil, resp, err
 	}
+
 	ret := *linkType
 	return &ret, resp, nil
 }
@@ -108,6 +112,5 @@ func (s *IssueLinkTypeService) Delete(ctx context.Context, ID string) (*Response
 		return nil, err
 	}
 
-	resp, err := s.client.Do(req, nil)
-	return resp, err
+	return s.client.Do(req, nil)
 }

--- a/cloud/jira.go
+++ b/cloud/jira.go
@@ -290,9 +290,7 @@ func (c *Client) Do(req *http.Request, v interface{}) (*Response, error) {
 
 	err = CheckResponse(req, httpResp)
 	if err != nil {
-		// Even though there was an error, we still return the response
-		// in case the caller wants to inspect it further
-		return newResponse(httpResp, nil), err
+		return nil, err
 	}
 
 	if v != nil {
@@ -308,7 +306,7 @@ func (c *Client) Do(req *http.Request, v interface{}) (*Response, error) {
 // CheckResponse checks the API response for errors, and returns them if present.
 // A response is considered an error if it has a status code outside the 200 range.
 // The caller is responsible to analyze the response body.
-// The body can contain JSON (if the error is intended) or xml (sometimes Jira just failes).
+// The body can contain JSON (if the error is intended) or xml (sometimes Jira just fails).
 func CheckResponse(req *http.Request, res *http.Response) error {
 	switch res.StatusCode {
 	case http.StatusBadRequest:

--- a/cloud/jira_test.go
+++ b/cloud/jira_test.go
@@ -148,10 +148,13 @@ func TestCheckResponse(t *testing.T) {
 	}
 
 	for _, c := range codes {
-		r := &http.Response{
+		req := &http.Request{
+			URL: &url.URL{},
+		}
+		res := &http.Response{
 			StatusCode: c,
 		}
-		if err := CheckResponse(r); err != nil {
+		if err := CheckResponse(req, res); err != nil {
 			t.Errorf("CheckResponse throws an error: %s", err)
 		}
 	}

--- a/cloud/organization.go
+++ b/cloud/organization.go
@@ -77,8 +77,7 @@ func (s *OrganizationService) GetAllOrganizations(ctx context.Context, start int
 	v := new(PagedDTO)
 	resp, err := s.client.Do(req, v)
 	if err != nil {
-		jerr := NewJiraError(resp, err)
-		return nil, resp, jerr
+		return nil, resp, err
 	}
 
 	return v, resp, nil
@@ -105,8 +104,7 @@ func (s *OrganizationService) CreateOrganization(ctx context.Context, name strin
 	o := new(Organization)
 	resp, err := s.client.Do(req, &o)
 	if err != nil {
-		jerr := NewJiraError(resp, err)
-		return nil, resp, jerr
+		return nil, resp, err
 	}
 
 	return o, resp, nil
@@ -123,17 +121,15 @@ func (s *OrganizationService) GetOrganization(ctx context.Context, organizationI
 	apiEndPoint := fmt.Sprintf("rest/servicedeskapi/organization/%d", organizationID)
 
 	req, err := s.client.NewRequest(ctx, http.MethodGet, apiEndPoint, nil)
-	req.Header.Set("Accept", "application/json")
-
 	if err != nil {
 		return nil, nil, err
 	}
+	req.Header.Set("Accept", "application/json")
 
 	o := new(Organization)
 	resp, err := s.client.Do(req, &o)
 	if err != nil {
-		jerr := NewJiraError(resp, err)
-		return nil, resp, jerr
+		return nil, resp, err
 	}
 
 	return o, resp, nil
@@ -150,15 +146,13 @@ func (s *OrganizationService) DeleteOrganization(ctx context.Context, organizati
 	apiEndPoint := fmt.Sprintf("rest/servicedeskapi/organization/%d", organizationID)
 
 	req, err := s.client.NewRequest(ctx, http.MethodDelete, apiEndPoint, nil)
-
 	if err != nil {
 		return nil, err
 	}
 
 	resp, err := s.client.Do(req, nil)
 	if err != nil {
-		jerr := NewJiraError(resp, err)
-		return resp, jerr
+		return resp, err
 	}
 
 	return resp, nil
@@ -174,17 +168,15 @@ func (s *OrganizationService) GetPropertiesKeys(ctx context.Context, organizatio
 	apiEndPoint := fmt.Sprintf("rest/servicedeskapi/organization/%d/property", organizationID)
 
 	req, err := s.client.NewRequest(ctx, http.MethodGet, apiEndPoint, nil)
-	req.Header.Set("Accept", "application/json")
-
 	if err != nil {
 		return nil, nil, err
 	}
+	req.Header.Set("Accept", "application/json")
 
 	pk := new(PropertyKeys)
 	resp, err := s.client.Do(req, &pk)
 	if err != nil {
-		jerr := NewJiraError(resp, err)
-		return nil, resp, jerr
+		return nil, resp, err
 	}
 
 	return pk, resp, nil
@@ -199,17 +191,15 @@ func (s *OrganizationService) GetProperty(ctx context.Context, organizationID in
 	apiEndPoint := fmt.Sprintf("rest/servicedeskapi/organization/%d/property/%s", organizationID, propertyKey)
 
 	req, err := s.client.NewRequest(ctx, http.MethodGet, apiEndPoint, nil)
-	req.Header.Set("Accept", "application/json")
-
 	if err != nil {
 		return nil, nil, err
 	}
+	req.Header.Set("Accept", "application/json")
 
 	ep := new(EntityProperty)
 	resp, err := s.client.Do(req, &ep)
 	if err != nil {
-		jerr := NewJiraError(resp, err)
-		return nil, resp, jerr
+		return nil, resp, err
 	}
 
 	return ep, resp, nil
@@ -225,16 +215,14 @@ func (s *OrganizationService) SetProperty(ctx context.Context, organizationID in
 	apiEndPoint := fmt.Sprintf("rest/servicedeskapi/organization/%d/property/%s", organizationID, propertyKey)
 
 	req, err := s.client.NewRequest(ctx, http.MethodPut, apiEndPoint, nil)
-	req.Header.Set("Accept", "application/json")
-
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Accept", "application/json")
 
 	resp, err := s.client.Do(req, nil)
 	if err != nil {
-		jerr := NewJiraError(resp, err)
-		return resp, jerr
+		return resp, err
 	}
 
 	return resp, nil
@@ -248,16 +236,14 @@ func (s *OrganizationService) DeleteProperty(ctx context.Context, organizationID
 	apiEndPoint := fmt.Sprintf("rest/servicedeskapi/organization/%d/property/%s", organizationID, propertyKey)
 
 	req, err := s.client.NewRequest(ctx, http.MethodDelete, apiEndPoint, nil)
-	req.Header.Set("Accept", "application/json")
-
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Accept", "application/json")
 
 	resp, err := s.client.Do(req, nil)
 	if err != nil {
-		jerr := NewJiraError(resp, err)
-		return resp, jerr
+		return resp, err
 	}
 
 	return resp, nil
@@ -274,17 +260,15 @@ func (s *OrganizationService) GetUsers(ctx context.Context, organizationID int, 
 	apiEndPoint := fmt.Sprintf("rest/servicedeskapi/organization/%d/user?start=%d&limit=%d", organizationID, start, limit)
 
 	req, err := s.client.NewRequest(ctx, http.MethodGet, apiEndPoint, nil)
-	req.Header.Set("Accept", "application/json")
-
 	if err != nil {
 		return nil, nil, err
 	}
+	req.Header.Set("Accept", "application/json")
 
 	users := new(PagedDTO)
 	resp, err := s.client.Do(req, &users)
 	if err != nil {
-		jerr := NewJiraError(resp, err)
-		return nil, resp, jerr
+		return nil, resp, err
 	}
 
 	return users, resp, nil
@@ -298,15 +282,13 @@ func (s *OrganizationService) AddUsers(ctx context.Context, organizationID int, 
 	apiEndPoint := fmt.Sprintf("rest/servicedeskapi/organization/%d/user", organizationID)
 
 	req, err := s.client.NewRequest(ctx, http.MethodPost, apiEndPoint, users)
-
 	if err != nil {
 		return nil, err
 	}
 
 	resp, err := s.client.Do(req, nil)
 	if err != nil {
-		jerr := NewJiraError(resp, err)
-		return resp, jerr
+		return resp, err
 	}
 
 	return resp, nil
@@ -320,16 +302,14 @@ func (s *OrganizationService) RemoveUsers(ctx context.Context, organizationID in
 	apiEndPoint := fmt.Sprintf("rest/servicedeskapi/organization/%d/user", organizationID)
 
 	req, err := s.client.NewRequest(ctx, http.MethodDelete, apiEndPoint, nil)
-	req.Header.Set("Accept", "application/json")
-
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Accept", "application/json")
 
 	resp, err := s.client.Do(req, nil)
 	if err != nil {
-		jerr := NewJiraError(resp, err)
-		return resp, jerr
+		return resp, err
 	}
 
 	return resp, nil

--- a/cloud/permissionscheme.go
+++ b/cloud/permissionscheme.go
@@ -41,8 +41,7 @@ func (s *PermissionSchemeService) GetList(ctx context.Context) (*PermissionSchem
 	pss := new(PermissionSchemes)
 	resp, err := s.client.Do(req, &pss)
 	if err != nil {
-		jerr := NewJiraError(resp, err)
-		return nil, resp, jerr
+		return nil, resp, err
 	}
 
 	return pss, resp, nil
@@ -61,8 +60,7 @@ func (s *PermissionSchemeService) Get(ctx context.Context, schemeID int) (*Permi
 	ps := new(PermissionScheme)
 	resp, err := s.client.Do(req, ps)
 	if err != nil {
-		jerr := NewJiraError(resp, err)
-		return nil, resp, jerr
+		return nil, resp, err
 	}
 	if ps.Self == "" {
 		return nil, resp, fmt.Errorf("no permissionscheme with ID %d found", schemeID)

--- a/cloud/priority.go
+++ b/cloud/priority.go
@@ -34,7 +34,8 @@ func (s *PriorityService) GetList(ctx context.Context) ([]Priority, *Response, e
 	priorityList := []Priority{}
 	resp, err := s.client.Do(req, &priorityList)
 	if err != nil {
-		return nil, resp, NewJiraError(resp, err)
+		return nil, resp, err
 	}
+
 	return priorityList, resp, nil
 }

--- a/cloud/project.go
+++ b/cloud/project.go
@@ -102,8 +102,7 @@ func (s *ProjectService) GetAll(ctx context.Context, options *GetQueryOptions) (
 	projectList := new(ProjectList)
 	resp, err := s.client.Do(req, projectList)
 	if err != nil {
-		jerr := NewJiraError(resp, err)
-		return nil, resp, jerr
+		return nil, resp, err
 	}
 
 	return projectList, resp, nil
@@ -124,8 +123,7 @@ func (s *ProjectService) Get(ctx context.Context, projectID string) (*Project, *
 	project := new(Project)
 	resp, err := s.client.Do(req, project)
 	if err != nil {
-		jerr := NewJiraError(resp, err)
-		return nil, resp, jerr
+		return nil, resp, err
 	}
 
 	return project, resp, nil
@@ -146,8 +144,7 @@ func (s *ProjectService) GetPermissionScheme(ctx context.Context, projectID stri
 	ps := new(PermissionScheme)
 	resp, err := s.client.Do(req, ps)
 	if err != nil {
-		jerr := NewJiraError(resp, err)
-		return nil, resp, jerr
+		return nil, resp, err
 	}
 
 	return ps, resp, nil

--- a/cloud/request.go
+++ b/cloud/request.go
@@ -85,7 +85,7 @@ func (r *RequestService) Create(ctx context.Context, requester string, participa
 	responseRequest := new(Request)
 	resp, err := r.client.Do(req, responseRequest)
 	if err != nil {
-		return nil, resp, NewJiraError(resp, err)
+		return nil, resp, err
 	}
 
 	return responseRequest, resp, nil
@@ -105,7 +105,7 @@ func (r *RequestService) CreateComment(ctx context.Context, issueIDOrKey string,
 	responseComment := new(RequestComment)
 	resp, err := r.client.Do(req, responseComment)
 	if err != nil {
-		return nil, resp, NewJiraError(resp, err)
+		return nil, resp, err
 	}
 
 	return responseComment, resp, nil

--- a/cloud/resolution.go
+++ b/cloud/resolution.go
@@ -32,7 +32,8 @@ func (s *ResolutionService) GetList(ctx context.Context) ([]Resolution, *Respons
 	resolutionList := []Resolution{}
 	resp, err := s.client.Do(req, &resolutionList)
 	if err != nil {
-		return nil, resp, NewJiraError(resp, err)
+		return nil, resp, err
 	}
+
 	return resolutionList, resp, nil
 }

--- a/cloud/role.go
+++ b/cloud/role.go
@@ -44,12 +44,13 @@ func (s *RoleService) GetList(ctx context.Context) (*[]Role, *Response, error) {
 	if err != nil {
 		return nil, nil, err
 	}
+
 	roles := new([]Role)
 	resp, err := s.client.Do(req, roles)
 	if err != nil {
-		jerr := NewJiraError(resp, err)
-		return nil, resp, jerr
+		return nil, resp, err
 	}
+
 	return roles, resp, err
 }
 
@@ -62,12 +63,13 @@ func (s *RoleService) Get(ctx context.Context, roleID int) (*Role, *Response, er
 	if err != nil {
 		return nil, nil, err
 	}
+	
 	role := new(Role)
 	resp, err := s.client.Do(req, role)
 	if err != nil {
-		jerr := NewJiraError(resp, err)
-		return nil, resp, jerr
+		return nil, resp, err
 	}
+
 	if role.Self == "" {
 		return nil, resp, fmt.Errorf("no role with ID %d found", roleID)
 	}

--- a/cloud/servicedesk.go
+++ b/cloud/servicedesk.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io"
 	"net/http"
 
 	"github.com/google/go-querystring/query"
@@ -29,17 +28,15 @@ func (s *ServiceDeskService) GetOrganizations(ctx context.Context, serviceDeskID
 	}
 
 	req, err := s.client.NewRequest(ctx, http.MethodGet, apiEndPoint, nil)
-	req.Header.Set("Accept", "application/json")
-
 	if err != nil {
 		return nil, nil, err
 	}
+	req.Header.Set("Accept", "application/json")
 
 	orgs := new(PagedDTO)
 	resp, err := s.client.Do(req, &orgs)
 	if err != nil {
-		jerr := NewJiraError(resp, err)
-		return nil, resp, jerr
+		return nil, resp, err
 	}
 
 	return orgs, resp, nil
@@ -60,15 +57,13 @@ func (s *ServiceDeskService) AddOrganization(ctx context.Context, serviceDeskID 
 	}
 
 	req, err := s.client.NewRequest(ctx, http.MethodPost, apiEndPoint, organization)
-
 	if err != nil {
 		return nil, err
 	}
 
 	resp, err := s.client.Do(req, nil)
 	if err != nil {
-		jerr := NewJiraError(resp, err)
-		return resp, jerr
+		return resp, err
 	}
 
 	return resp, nil
@@ -89,15 +84,13 @@ func (s *ServiceDeskService) RemoveOrganization(ctx context.Context, serviceDesk
 	}
 
 	req, err := s.client.NewRequest(ctx, http.MethodDelete, apiEndPoint, organization)
-
 	if err != nil {
 		return nil, err
 	}
 
 	resp, err := s.client.Do(req, nil)
 	if err != nil {
-		jerr := NewJiraError(resp, err)
-		return resp, jerr
+		return resp, err
 	}
 
 	return resp, nil
@@ -121,11 +114,9 @@ func (s *ServiceDeskService) AddCustomers(ctx context.Context, serviceDeskID int
 
 	resp, err := s.client.Do(req, nil)
 	if err != nil {
-		return resp, NewJiraError(resp, err)
+		return resp, err
 	}
-
 	defer resp.Body.Close()
-	_, _ = io.Copy(io.Discard, resp.Body)
 
 	return resp, nil
 }
@@ -148,11 +139,9 @@ func (s *ServiceDeskService) RemoveCustomers(ctx context.Context, serviceDeskID 
 
 	resp, err := s.client.Do(req, nil)
 	if err != nil {
-		return resp, NewJiraError(resp, err)
+		return resp, err
 	}
-
 	defer resp.Body.Close()
-	_, _ = io.Copy(io.Discard, resp.Body)
 
 	return resp, nil
 }
@@ -167,7 +156,7 @@ func (s *ServiceDeskService) ListCustomers(ctx context.Context, serviceDeskID in
 		return nil, nil, err
 	}
 
-	// this is an experiemntal endpoint
+	// this is an experimental endpoint
 	req.Header.Set("X-ExperimentalApi", "opt-in")
 
 	if options != nil {
@@ -180,13 +169,13 @@ func (s *ServiceDeskService) ListCustomers(ctx context.Context, serviceDeskID in
 
 	resp, err := s.client.Do(req, nil)
 	if err != nil {
-		return nil, resp, NewJiraError(resp, err)
+		return nil, resp, err
 	}
 	defer resp.Body.Close()
 
 	customerList := new(CustomerList)
 	if err := json.NewDecoder(resp.Body).Decode(customerList); err != nil {
-		return nil, resp, fmt.Errorf("could not unmarshall the data into struct")
+		return nil, resp, fmt.Errorf("could not unmarshall the data into struct: %w", err)
 	}
 
 	return customerList, resp, nil

--- a/cloud/sprint.go
+++ b/cloud/sprint.go
@@ -34,16 +34,11 @@ func (s *SprintService) MoveIssuesToSprint(ctx context.Context, sprintID int, is
 	payload := IssuesWrapper{Issues: issueIDs}
 
 	req, err := s.client.NewRequest(ctx, http.MethodPost, apiEndpoint, payload)
-
 	if err != nil {
 		return nil, err
 	}
 
-	resp, err := s.client.Do(req, nil)
-	if err != nil {
-		err = NewJiraError(resp, err)
-	}
-	return resp, err
+	return s.client.Do(req, nil)
 }
 
 // GetIssuesForSprint returns all issues in a sprint, for a given sprint Id.
@@ -55,17 +50,12 @@ func (s *SprintService) GetIssuesForSprint(ctx context.Context, sprintID int) ([
 	apiEndpoint := fmt.Sprintf("rest/agile/1.0/sprint/%d/issue", sprintID)
 
 	req, err := s.client.NewRequest(ctx, http.MethodGet, apiEndpoint, nil)
-
 	if err != nil {
 		return nil, nil, err
 	}
 
 	result := new(IssuesInSprintResult)
 	resp, err := s.client.Do(req, result)
-	if err != nil {
-		err = NewJiraError(resp, err)
-	}
-
 	return result.Issues, resp, err
 }
 
@@ -83,7 +73,6 @@ func (s *SprintService) GetIssue(ctx context.Context, issueID string, options *G
 	apiEndpoint := fmt.Sprintf("rest/agile/1.0/issue/%s", issueID)
 
 	req, err := s.client.NewRequest(ctx, http.MethodGet, apiEndpoint, nil)
-
 	if err != nil {
 		return nil, nil, err
 	}
@@ -98,10 +87,8 @@ func (s *SprintService) GetIssue(ctx context.Context, issueID string, options *G
 
 	issue := new(Issue)
 	resp, err := s.client.Do(req, issue)
-
 	if err != nil {
-		jerr := NewJiraError(resp, err)
-		return nil, resp, jerr
+		return nil, resp, err
 	}
 
 	return issue, resp, nil

--- a/cloud/status.go
+++ b/cloud/status.go
@@ -28,7 +28,6 @@ type Status struct {
 func (s *StatusService) GetAllStatuses(ctx context.Context) ([]Status, *Response, error) {
 	apiEndpoint := "rest/api/2/status"
 	req, err := s.client.NewRequest(ctx, http.MethodGet, apiEndpoint, nil)
-
 	if err != nil {
 		return nil, nil, err
 	}
@@ -36,7 +35,7 @@ func (s *StatusService) GetAllStatuses(ctx context.Context) ([]Status, *Response
 	statusList := []Status{}
 	resp, err := s.client.Do(req, &statusList)
 	if err != nil {
-		return nil, resp, NewJiraError(resp, err)
+		return nil, resp, err
 	}
 
 	return statusList, resp, nil

--- a/cloud/statuscategory.go
+++ b/cloud/statuscategory.go
@@ -41,7 +41,8 @@ func (s *StatusCategoryService) GetList(ctx context.Context) ([]StatusCategory, 
 	statusCategoryList := []StatusCategory{}
 	resp, err := s.client.Do(req, &statusCategoryList)
 	if err != nil {
-		return nil, resp, NewJiraError(resp, err)
+		return nil, resp, err
 	}
+
 	return statusCategoryList, resp, nil
 }

--- a/cloud/user.go
+++ b/cloud/user.go
@@ -58,8 +58,9 @@ func (s *UserService) Get(ctx context.Context, accountId string) (*User, *Respon
 	user := new(User)
 	resp, err := s.client.Do(req, user)
 	if err != nil {
-		return nil, resp, NewJiraError(resp, err)
+		return nil, resp, err
 	}
+
 	return user, resp, nil
 }
 
@@ -77,8 +78,9 @@ func (s *UserService) GetByAccountID(ctx context.Context, accountID string) (*Us
 	user := new(User)
 	resp, err := s.client.Do(req, user)
 	if err != nil {
-		return nil, resp, NewJiraError(resp, err)
+		return nil, resp, err
 	}
+
 	return user, resp, nil
 }
 
@@ -101,14 +103,14 @@ func (s *UserService) Create(ctx context.Context, user *User) (*User, *Response,
 	defer resp.Body.Close()
 	data, err := io.ReadAll(resp.Body)
 	if err != nil {
-		e := fmt.Errorf("could not read the returned data")
-		return nil, resp, NewJiraError(resp, e)
+		return nil, resp, fmt.Errorf("could not read the returned data: %w", err)
 	}
+
 	err = json.Unmarshal(data, responseUser)
 	if err != nil {
-		e := fmt.Errorf("could not unmarshall the data into struct")
-		return nil, resp, NewJiraError(resp, e)
+		return nil, resp, fmt.Errorf("could not unmarshall the data into struct: %w", err)
 	}
+
 	return responseUser, resp, nil
 }
 
@@ -126,8 +128,9 @@ func (s *UserService) Delete(ctx context.Context, accountId string) (*Response, 
 
 	resp, err := s.client.Do(req, nil)
 	if err != nil {
-		return resp, NewJiraError(resp, err)
+		return resp, err
 	}
+
 	return resp, nil
 }
 
@@ -144,8 +147,9 @@ func (s *UserService) GetGroups(ctx context.Context, accountId string) (*[]UserG
 	userGroups := new([]UserGroup)
 	resp, err := s.client.Do(req, userGroups)
 	if err != nil {
-		return nil, resp, NewJiraError(resp, err)
+		return nil, resp, err
 	}
+
 	return userGroups, resp, nil
 }
 
@@ -158,11 +162,13 @@ func (s *UserService) GetSelf(ctx context.Context) (*User, *Response, error) {
 	if err != nil {
 		return nil, nil, err
 	}
+
 	var user User
 	resp, err := s.client.Do(req, &user)
 	if err != nil {
-		return nil, resp, NewJiraError(resp, err)
+		return nil, resp, err
 	}
+
 	return &user, resp, nil
 }
 
@@ -251,7 +257,8 @@ func (s *UserService) Find(ctx context.Context, property string, tweaks ...userS
 	users := []User{}
 	resp, err := s.client.Do(req, &users)
 	if err != nil {
-		return nil, resp, NewJiraError(resp, err)
+		return nil, resp, err
 	}
+
 	return users, resp, nil
 }

--- a/cloud/version.go
+++ b/cloud/version.go
@@ -40,8 +40,9 @@ func (s *VersionService) Get(ctx context.Context, versionID int) (*Version, *Res
 	version := new(Version)
 	resp, err := s.client.Do(req, version)
 	if err != nil {
-		return nil, resp, NewJiraError(resp, err)
+		return nil, resp, err
 	}
+
 	return version, resp, nil
 }
 
@@ -64,14 +65,14 @@ func (s *VersionService) Create(ctx context.Context, version *Version) (*Version
 	defer resp.Body.Close()
 	data, err := io.ReadAll(resp.Body)
 	if err != nil {
-		e := fmt.Errorf("could not read the returned data")
-		return nil, resp, NewJiraError(resp, e)
+		return nil, resp, fmt.Errorf("could not read the returned data: %w", err)
 	}
+
 	err = json.Unmarshal(data, responseVersion)
 	if err != nil {
-		e := fmt.Errorf("could not unmarshall the data into struct")
-		return nil, resp, NewJiraError(resp, e)
+		return nil, resp, fmt.Errorf("could not unmarshall the data into struct: %w", err)
 	}
+
 	return responseVersion, resp, nil
 }
 
@@ -85,10 +86,10 @@ func (s *VersionService) Update(ctx context.Context, version *Version) (*Version
 	if err != nil {
 		return nil, nil, err
 	}
+
 	resp, err := s.client.Do(req, nil)
 	if err != nil {
-		jerr := NewJiraError(resp, err)
-		return nil, resp, jerr
+		return nil, resp, err
 	}
 
 	// This is just to follow the rest of the API's convention of returning a version.


### PR DESCRIPTION
#### What type of PR is this?

* cleanup
* feature
* api-change

#### What this PR does / why we need it:

This PR replaces the existing request error handling with a more generic variation which allows it to extract the response body depending on the use case and handle the status code which isn't possible at the moment.

#### Which issue(s) this PR fixes:

Relates to https://github.com/andygrunwald/go-jira/pull/565#issuecomment-1244244545

#### Special notes for your reviewer:

I am not familiar with any kind of error messages, so far i only checked the insight API and there errors messages are not static or being able to parse to static structs.

#### Additional documentation e.g., usage docs, etc.:

The idea was to have use cases like:
```go
issue, _, err := client.Issue.Get(context.Background(), "123", nil)
if err != nil && errors.Is(err, ErrNotFound) {
	// create new issue
} else err != nil {
	return err
}

issue, _, err := client.Issue.Create(context.Background(), &Issue{})
if err != nil && errors.Is(err, ErrValidation) {
	// check error content and proceed as preferred
} else err != nil {
	return err
}
```