### PR TITLE
Replaced ReadAll and Unmarshal with NewDecoder

### DIFF
--- a/cloud/authentication.go
+++ b/cloud/authentication.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io"
 	"net/http"
 )
 
@@ -172,16 +171,11 @@ func (s *AuthenticationService) GetCurrentUser(ctx context.Context) (*Session, e
 	if resp.StatusCode != 200 {
 		return nil, fmt.Errorf("getting user info failed with status : %d", resp.StatusCode)
 	}
+
 	ret := new(Session)
-	data, err := io.ReadAll(resp.Body)
+	err = json.NewDecoder(resp.Body).Decode(&ret)
 	if err != nil {
-		return nil, fmt.Errorf("couldn't read body from the response : %s", err)
-	}
-
-	err = json.Unmarshal(data, &ret)
-
-	if err != nil {
-		return nil, fmt.Errorf("could not unmarshall received user info : %s", err)
+		return nil, err
 	}
 
 	return ret, nil

--- a/cloud/authentication.go
+++ b/cloud/authentication.go
@@ -73,16 +73,15 @@ func (s *AuthenticationService) AcquireSessionCookie(ctx context.Context, userna
 
 	session := new(Session)
 	resp, err := s.client.Do(req, session)
-
-	if resp != nil {
-		session.Cookies = resp.Cookies()
-	}
-
 	if err != nil {
-		return false, fmt.Errorf("auth at Jira instance failed (HTTP(S) request). %s", err)
+		return false, fmt.Errorf("auth at Jira instance failed (HTTP(S) request). %w", err)
 	}
+
 	if resp != nil && resp.StatusCode != 200 {
 		return false, fmt.Errorf("auth at Jira instance failed (HTTP(S) request). Status code: %d", resp.StatusCode)
+	}
+	if resp != nil {
+		session.Cookies = resp.Cookies()
 	}
 
 	s.client.session = session
@@ -127,12 +126,12 @@ func (s *AuthenticationService) Logout(ctx context.Context) error {
 	apiEndpoint := "rest/auth/1/session"
 	req, err := s.client.NewRequest(ctx, http.MethodDelete, apiEndpoint, nil)
 	if err != nil {
-		return fmt.Errorf("creating the request to log the user out failed : %s", err)
+		return fmt.Errorf("creating the request to log the user out failed : %w", err)
 	}
 
 	resp, err := s.client.Do(req, nil)
 	if err != nil {
-		return fmt.Errorf("error sending the logout request: %s", err)
+		return fmt.Errorf("error sending the logout request: %w", err)
 	}
 	defer resp.Body.Close()
 	if resp.StatusCode != 204 {
@@ -160,12 +159,12 @@ func (s *AuthenticationService) GetCurrentUser(ctx context.Context) (*Session, e
 	apiEndpoint := "rest/auth/1/session"
 	req, err := s.client.NewRequest(ctx, http.MethodGet, apiEndpoint, nil)
 	if err != nil {
-		return nil, fmt.Errorf("could not create request for getting user info : %s", err)
+		return nil, fmt.Errorf("could not create request for getting user info: %w", err)
 	}
 
 	resp, err := s.client.Do(req, nil)
 	if err != nil {
-		return nil, fmt.Errorf("error sending request to get user info : %s", err)
+		return nil, fmt.Errorf("error sending request to get user info: %w", err)
 	}
 	defer resp.Body.Close()
 	if resp.StatusCode != 200 {

--- a/cloud/issue.go
+++ b/cloud/issue.go
@@ -785,22 +785,20 @@ func (s *IssueService) Create(ctx context.Context, issue *Issue) (*Issue, *Respo
 	if err != nil {
 		return nil, nil, err
 	}
+
 	resp, err := s.client.Do(req, nil)
 	if err != nil {
 		// incase of error return the resp for further inspection
 		return nil, resp, err
 	}
+	defer resp.Body.Close()
 
 	responseIssue := new(Issue)
-	defer resp.Body.Close()
-	data, err := io.ReadAll(resp.Body)
+	err = json.NewDecoder(resp.Body).Decode(&responseIssue)
 	if err != nil {
-		return nil, resp, fmt.Errorf("could not read the returned data")
+		return nil, resp, err
 	}
-	err = json.Unmarshal(data, responseIssue)
-	if err != nil {
-		return nil, resp, fmt.Errorf("could not unmarshall the data into struct")
-	}
+
 	return responseIssue, resp, nil
 }
 

--- a/cloud/issue_test.go
+++ b/cloud/issue_test.go
@@ -945,70 +945,69 @@ func TestIssueService_DoTransitionWithPayload(t *testing.T) {
 
 func TestIssueFields_TestMarshalJSON_PopulateUnknownsSuccess(t *testing.T) {
 	data := `{
-			"customfield_123":"test",
-			"description":"example bug report",
-			"project":{
-				"self":"http://www.example.com/jira/rest/api/2/project/EX",
+		"customfield_123":"test",
+		"description":"example bug report",
+		"project":{
+			"self":"http://www.example.com/jira/rest/api/2/project/EX",
+			"id":"10000",
+			"key":"EX",
+			"name":"Example",
+			"avatarUrls":{
+				"48x48":"http://www.example.com/jira/secure/projectavatar?size=large&pid=10000",
+				"24x24":"http://www.example.com/jira/secure/projectavatar?size=small&pid=10000",
+				"16x16":"http://www.example.com/jira/secure/projectavatar?size=xsmall&pid=10000",
+				"32x32":"http://www.example.com/jira/secure/projectavatar?size=medium&pid=10000"
+			},
+			"projectCategory":{
+				"self":"http://www.example.com/jira/rest/api/2/projectCategory/10000",
 				"id":"10000",
-				"key":"EX",
-				"name":"Example",
-				"avatarUrls":{
-					"48x48":"http://www.example.com/jira/secure/projectavatar?size=large&pid=10000",
-					"24x24":"http://www.example.com/jira/secure/projectavatar?size=small&pid=10000",
-					"16x16":"http://www.example.com/jira/secure/projectavatar?size=xsmall&pid=10000",
-					"32x32":"http://www.example.com/jira/secure/projectavatar?size=medium&pid=10000"
+				"name":"FIRST",
+				"description":"First Project Category"
+			}
+		},
+		"issuelinks":[
+			{
+				"id":"10001",
+				"type":{
+				"id":"10000",
+				"name":"Dependent",
+				"inward":"depends on",
+				"outward":"is depended by"
 				},
-				"projectCategory":{
-					"self":"http://www.example.com/jira/rest/api/2/projectCategory/10000",
-					"id":"10000",
-					"name":"FIRST",
-					"description":"First Project Category"
+				"outwardIssue":{
+				"id":"10004L",
+				"key":"PRJ-2",
+				"self":"http://www.example.com/jira/rest/api/2/issue/PRJ-2",
+				"fields":{
+					"status":{
+						"iconUrl":"http://www.example.com/jira//images/icons/statuses/open.png",
+						"name":"Open"
+					}
+				}
 				}
 			},
-			"issuelinks":[
-				{
-					"id":"10001",
-					"type":{
-					"id":"10000",
-					"name":"Dependent",
-					"inward":"depends on",
-					"outward":"is depended by"
-					},
-					"outwardIssue":{
-					"id":"10004L",
-					"key":"PRJ-2",
-					"self":"http://www.example.com/jira/rest/api/2/issue/PRJ-2",
-					"fields":{
-						"status":{
-							"iconUrl":"http://www.example.com/jira//images/icons/statuses/open.png",
-							"name":"Open"
-						}
-					}
-					}
+			{
+				"id":"10002",
+				"type":{
+				"id":"10000",
+				"name":"Dependent",
+				"inward":"depends on",
+				"outward":"is depended by"
 				},
-				{
-					"id":"10002",
-					"type":{
-					"id":"10000",
-					"name":"Dependent",
-					"inward":"depends on",
-					"outward":"is depended by"
-					},
-					"inwardIssue":{
-					"id":"10004",
-					"key":"PRJ-3",
-					"self":"http://www.example.com/jira/rest/api/2/issue/PRJ-3",
-					"fields":{
-						"status":{
-							"iconUrl":"http://www.example.com/jira//images/icons/statuses/open.png",
-							"name":"Open"
-						}
-					}
+				"inwardIssue":{
+				"id":"10004",
+				"key":"PRJ-3",
+				"self":"http://www.example.com/jira/rest/api/2/issue/PRJ-3",
+				"fields":{
+					"status":{
+						"iconUrl":"http://www.example.com/jira//images/icons/statuses/open.png",
+						"name":"Open"
 					}
 				}
-			]
-
-   }`
+				}
+			}
+		]
+	}`
 
 	i := new(IssueFields)
 	err := json.Unmarshal([]byte(data), i)

--- a/cloud/issuelinktype.go
+++ b/cloud/issuelinktype.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io"
 	"net/http"
 )
 
@@ -63,19 +62,14 @@ func (s *IssueLinkTypeService) Create(ctx context.Context, linkType *IssueLinkTy
 	if err != nil {
 		return nil, resp, err
 	}
+	defer resp.Body.Close()
 
 	responseLinkType := new(IssueLinkType)
-	defer resp.Body.Close()
-	data, err := io.ReadAll(resp.Body)
+	err = json.NewDecoder(resp.Body).Decode(&responseLinkType)
 	if err != nil {
-		e := fmt.Errorf("could not read the returned data")
-		return nil, resp, NewJiraError(resp, e)
+		return nil, resp, err
 	}
-	err = json.Unmarshal(data, responseLinkType)
-	if err != nil {
-		e := fmt.Errorf("could no unmarshal the data into struct")
-		return nil, resp, NewJiraError(resp, e)
-	}
+
 	return linkType, resp, nil
 }
 

--- a/cloud/user.go
+++ b/cloud/user.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io"
 	"net/http"
 )
 
@@ -96,19 +95,14 @@ func (s *UserService) Create(ctx context.Context, user *User) (*User, *Response,
 	if err != nil {
 		return nil, resp, err
 	}
+	defer resp.Body.Close()
 
 	responseUser := new(User)
-	defer resp.Body.Close()
-	data, err := io.ReadAll(resp.Body)
+	err = json.NewDecoder(resp.Body).Decode(&responseUser)
 	if err != nil {
-		e := fmt.Errorf("could not read the returned data")
-		return nil, resp, NewJiraError(resp, e)
+		return nil, resp, err
 	}
-	err = json.Unmarshal(data, responseUser)
-	if err != nil {
-		e := fmt.Errorf("could not unmarshall the data into struct")
-		return nil, resp, NewJiraError(resp, e)
-	}
+
 	return responseUser, resp, nil
 }
 

--- a/cloud/version.go
+++ b/cloud/version.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io"
 	"net/http"
 )
 
@@ -59,19 +58,14 @@ func (s *VersionService) Create(ctx context.Context, version *Version) (*Version
 	if err != nil {
 		return nil, resp, err
 	}
+	defer resp.Body.Close()
 
 	responseVersion := new(Version)
-	defer resp.Body.Close()
-	data, err := io.ReadAll(resp.Body)
+	err = json.NewDecoder(resp.Body).Decode(&responseVersion)
 	if err != nil {
-		e := fmt.Errorf("could not read the returned data")
-		return nil, resp, NewJiraError(resp, e)
+		return nil, resp, err
 	}
-	err = json.Unmarshal(data, responseVersion)
-	if err != nil {
-		e := fmt.Errorf("could not unmarshall the data into struct")
-		return nil, resp, NewJiraError(resp, e)
-	}
+
 	return responseVersion, resp, nil
 }
 

--- a/onpremise/authentication.go
+++ b/onpremise/authentication.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io"
 	"net/http"
 )
 
@@ -172,16 +171,11 @@ func (s *AuthenticationService) GetCurrentUser(ctx context.Context) (*Session, e
 	if resp.StatusCode != 200 {
 		return nil, fmt.Errorf("getting user info failed with status : %d", resp.StatusCode)
 	}
+
 	ret := new(Session)
-	data, err := io.ReadAll(resp.Body)
+	err = json.NewDecoder(resp.Body).Decode(&ret)
 	if err != nil {
-		return nil, fmt.Errorf("couldn't read body from the response : %s", err)
-	}
-
-	err = json.Unmarshal(data, &ret)
-
-	if err != nil {
-		return nil, fmt.Errorf("could not unmarshall received user info : %s", err)
+		return nil, err
 	}
 
 	return ret, nil

--- a/onpremise/issue.go
+++ b/onpremise/issue.go
@@ -785,22 +785,20 @@ func (s *IssueService) Create(ctx context.Context, issue *Issue) (*Issue, *Respo
 	if err != nil {
 		return nil, nil, err
 	}
+
 	resp, err := s.client.Do(req, nil)
 	if err != nil {
 		// incase of error return the resp for further inspection
 		return nil, resp, err
 	}
+	defer resp.Body.Close()
 
 	responseIssue := new(Issue)
-	defer resp.Body.Close()
-	data, err := io.ReadAll(resp.Body)
+	err = json.NewDecoder(resp.Body).Decode(&responseIssue)
 	if err != nil {
-		return nil, resp, fmt.Errorf("could not read the returned data")
+		return nil, resp, err
 	}
-	err = json.Unmarshal(data, responseIssue)
-	if err != nil {
-		return nil, resp, fmt.Errorf("could not unmarshall the data into struct")
-	}
+
 	return responseIssue, resp, nil
 }
 

--- a/onpremise/issuelinktype.go
+++ b/onpremise/issuelinktype.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io"
 	"net/http"
 )
 
@@ -63,19 +62,14 @@ func (s *IssueLinkTypeService) Create(ctx context.Context, linkType *IssueLinkTy
 	if err != nil {
 		return nil, resp, err
 	}
+	defer resp.Body.Close()
 
 	responseLinkType := new(IssueLinkType)
-	defer resp.Body.Close()
-	data, err := io.ReadAll(resp.Body)
+	err = json.NewDecoder(resp.Body).Decode(&responseLinkType)
 	if err != nil {
-		e := fmt.Errorf("could not read the returned data")
-		return nil, resp, NewJiraError(resp, e)
+		return nil, resp, err
 	}
-	err = json.Unmarshal(data, responseLinkType)
-	if err != nil {
-		e := fmt.Errorf("could no unmarshal the data into struct")
-		return nil, resp, NewJiraError(resp, e)
-	}
+
 	return linkType, resp, nil
 }
 

--- a/onpremise/user.go
+++ b/onpremise/user.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io"
 	"net/http"
 )
 
@@ -96,19 +95,14 @@ func (s *UserService) Create(ctx context.Context, user *User) (*User, *Response,
 	if err != nil {
 		return nil, resp, err
 	}
+	defer resp.Body.Close()
 
 	responseUser := new(User)
-	defer resp.Body.Close()
-	data, err := io.ReadAll(resp.Body)
+	err = json.NewDecoder(resp.Body).Decode(&responseUser)
 	if err != nil {
-		e := fmt.Errorf("could not read the returned data")
-		return nil, resp, NewJiraError(resp, e)
+		return nil, resp, err
 	}
-	err = json.Unmarshal(data, responseUser)
-	if err != nil {
-		e := fmt.Errorf("could not unmarshall the data into struct")
-		return nil, resp, NewJiraError(resp, e)
-	}
+
 	return responseUser, resp, nil
 }
 

--- a/onpremise/version.go
+++ b/onpremise/version.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io"
 	"net/http"
 )
 
@@ -59,19 +58,14 @@ func (s *VersionService) Create(ctx context.Context, version *Version) (*Version
 	if err != nil {
 		return nil, resp, err
 	}
+	defer resp.Body.Close()
 
 	responseVersion := new(Version)
-	defer resp.Body.Close()
-	data, err := io.ReadAll(resp.Body)
+	err = json.NewDecoder(resp.Body).Decode(&responseVersion)
 	if err != nil {
-		e := fmt.Errorf("could not read the returned data")
-		return nil, resp, NewJiraError(resp, e)
+		return nil, resp, err
 	}
-	err = json.Unmarshal(data, responseVersion)
-	if err != nil {
-		e := fmt.Errorf("could not unmarshall the data into struct")
-		return nil, resp, NewJiraError(resp, e)
-	}
+
 	return responseVersion, resp, nil
 }
 


### PR DESCRIPTION
#### What type of PR is this?

* cleanup

#### What this PR does / why we need it:

Replaced all `io.ReadAll` & `json.Unmarshal` with `json.NewDecoder(...).Decode(...)`.
In some cases the original error was not returned, which is now the case.

#### Which issue(s) this PR fixes:



#### Special notes for your reviewer:


#### Additional documentation e.g., usage docs, etc.:

Was found while changing code in #570