### PR TITLE
export custom types in user service that are exposed in function signatures

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 
 **v2 of this library is in development.**
 **v2 will contain breaking changes :warning:**
-**The current main branch can contains the development version of v2.**
+**The current main branch contains the development version of v2.**
 
 The goals of v2 are:
 

--- a/cloud/user.go
+++ b/cloud/user.go
@@ -67,14 +67,14 @@ type ApplicationRole struct {
 	// Key `defaultGroupsDetails` missing - https://developer.atlassian.com/cloud/jira/platform/rest/v3/api-group-application-roles/#api-rest-api-3-applicationrole-key-get
 }
 
-type userSearchParam struct {
+type UserSearchParam struct {
 	name  string
 	value string
 }
 
-type userSearch []userSearchParam
+type UserSearch []UserSearchParam
 
-type userSearchF func(userSearch) userSearch
+type UserSearchF func(UserSearch) UserSearch
 
 // Get gets user info from Jira using its Account Id
 //
@@ -210,57 +210,57 @@ func (s *UserService) GetCurrentUser(ctx context.Context) (*User, *Response, err
 }
 
 // WithMaxResults sets the max results to return
-func WithMaxResults(maxResults int) userSearchF {
-	return func(s userSearch) userSearch {
-		s = append(s, userSearchParam{name: "maxResults", value: fmt.Sprintf("%d", maxResults)})
+func WithMaxResults(maxResults int) UserSearchF {
+	return func(s UserSearch) UserSearch {
+		s = append(s, UserSearchParam{name: "maxResults", value: fmt.Sprintf("%d", maxResults)})
 		return s
 	}
 }
 
 // WithStartAt set the start pager
-func WithStartAt(startAt int) userSearchF {
-	return func(s userSearch) userSearch {
-		s = append(s, userSearchParam{name: "startAt", value: fmt.Sprintf("%d", startAt)})
+func WithStartAt(startAt int) UserSearchF {
+	return func(s UserSearch) UserSearch {
+		s = append(s, UserSearchParam{name: "startAt", value: fmt.Sprintf("%d", startAt)})
 		return s
 	}
 }
 
 // WithActive sets the active users lookup
-func WithActive(active bool) userSearchF {
-	return func(s userSearch) userSearch {
-		s = append(s, userSearchParam{name: "includeActive", value: fmt.Sprintf("%t", active)})
+func WithActive(active bool) UserSearchF {
+	return func(s UserSearch) UserSearch {
+		s = append(s, UserSearchParam{name: "includeActive", value: fmt.Sprintf("%t", active)})
 		return s
 	}
 }
 
 // WithInactive sets the inactive users lookup
-func WithInactive(inactive bool) userSearchF {
-	return func(s userSearch) userSearch {
-		s = append(s, userSearchParam{name: "includeInactive", value: fmt.Sprintf("%t", inactive)})
+func WithInactive(inactive bool) UserSearchF {
+	return func(s UserSearch) UserSearch {
+		s = append(s, UserSearchParam{name: "includeInactive", value: fmt.Sprintf("%t", inactive)})
 		return s
 	}
 }
 
 // WithUsername sets the username to search
-func WithUsername(username string) userSearchF {
-	return func(s userSearch) userSearch {
-		s = append(s, userSearchParam{name: "username", value: username})
+func WithUsername(username string) UserSearchF {
+	return func(s UserSearch) UserSearch {
+		s = append(s, UserSearchParam{name: "username", value: username})
 		return s
 	}
 }
 
 // WithAccountId sets the account id to search
-func WithAccountId(accountId string) userSearchF {
-	return func(s userSearch) userSearch {
-		s = append(s, userSearchParam{name: "accountId", value: accountId})
+func WithAccountId(accountId string) UserSearchF {
+	return func(s UserSearch) UserSearch {
+		s = append(s, UserSearchParam{name: "accountId", value: accountId})
 		return s
 	}
 }
 
 // WithProperty sets the property (Property keys are specified by path) to search
-func WithProperty(property string) userSearchF {
-	return func(s userSearch) userSearch {
-		s = append(s, userSearchParam{name: "property", value: property})
+func WithProperty(property string) UserSearchF {
+	return func(s UserSearch) UserSearch {
+		s = append(s, UserSearchParam{name: "property", value: property})
 		return s
 	}
 }
@@ -272,8 +272,8 @@ func WithProperty(property string) userSearchF {
 //
 // TODO Double check this method if this works as expected, is using the latest API and the response is complete
 // This double check effort is done for v2 - Remove this two lines if this is completed.
-func (s *UserService) Find(ctx context.Context, property string, tweaks ...userSearchF) ([]User, *Response, error) {
-	search := []userSearchParam{
+func (s *UserService) Find(ctx context.Context, property string, tweaks ...UserSearchF) ([]User, *Response, error) {
+	search := []UserSearchParam{
 		{
 			name:  "query",
 			value: property,


### PR DESCRIPTION
#### What type of PR is this?
* cleanup

#### What this PR does / why we need it:
This PR takes a few custom, unexported types in `user.go` and exports them. These types are used in multiple function signatures on `UserService`, making it impossible to write a user-defined interface for those functions which `UserService` can implement. Exporting these types will allow `UserService` to properly implement a user-defined interface, which will in turn allow for cleaner testing and mocking.

#### Which issue(s) this PR fixes:

Fixes #179 

#### Special notes for your reviewer:

It would be awesome to get this out in a 1.x release before 2.x to unblock any ongoing testing efforts from users. This shouldn't be a breaking change, as nobody would've been able to use the unexported type prior to this pull request anyway.

#### Additional documentation e.g., usage docs, etc.:
noticed a minor typo in the README while going through and cleaned that up as well