### PR TITLE
Remove erroneous properties from Issue Comment

### DIFF
--- a/cloud/issue.go
+++ b/cloud/issue.go
@@ -471,15 +471,13 @@ type Comments struct {
 
 // Comment represents a comment by a person to an issue in Jira.
 type Comment struct {
-	ID           string            `json:"id,omitempty" structs:"id,omitempty"`
-	Self         string            `json:"self,omitempty" structs:"self,omitempty"`
-	Name         string            `json:"name,omitempty" structs:"name,omitempty"`
-	Author       User              `json:"author,omitempty" structs:"author,omitempty"`
-	Body         string            `json:"body,omitempty" structs:"body,omitempty"`
-	UpdateAuthor User              `json:"updateAuthor,omitempty" structs:"updateAuthor,omitempty"`
-	Updated      string            `json:"updated,omitempty" structs:"updated,omitempty"`
-	Created      string            `json:"created,omitempty" structs:"created,omitempty"`
-	Visibility   CommentVisibility `json:"visibility,omitempty" structs:"visibility,omitempty"`
+	ID         string            `json:"id,omitempty" structs:"id,omitempty"`
+	Self       string            `json:"self,omitempty" structs:"self,omitempty"`
+	Name       string            `json:"name,omitempty" structs:"name,omitempty"`
+	Body       string            `json:"body,omitempty" structs:"body,omitempty"`
+	Updated    string            `json:"updated,omitempty" structs:"updated,omitempty"`
+	Created    string            `json:"created,omitempty" structs:"created,omitempty"`
+	Visibility CommentVisibility `json:"visibility,omitempty" structs:"visibility,omitempty"`
 
 	// A list of comment properties. Optional on create and update.
 	Properties []EntityProperty `json:"properties,omitempty" structs:"properties,omitempty"`

--- a/onpremise/issue.go
+++ b/onpremise/issue.go
@@ -471,15 +471,13 @@ type Comments struct {
 
 // Comment represents a comment by a person to an issue in Jira.
 type Comment struct {
-	ID           string            `json:"id,omitempty" structs:"id,omitempty"`
-	Self         string            `json:"self,omitempty" structs:"self,omitempty"`
-	Name         string            `json:"name,omitempty" structs:"name,omitempty"`
-	Author       User              `json:"author,omitempty" structs:"author,omitempty"`
-	Body         string            `json:"body,omitempty" structs:"body,omitempty"`
-	UpdateAuthor User              `json:"updateAuthor,omitempty" structs:"updateAuthor,omitempty"`
-	Updated      string            `json:"updated,omitempty" structs:"updated,omitempty"`
-	Created      string            `json:"created,omitempty" structs:"created,omitempty"`
-	Visibility   CommentVisibility `json:"visibility,omitempty" structs:"visibility,omitempty"`
+	ID         string            `json:"id,omitempty" structs:"id,omitempty"`
+	Self       string            `json:"self,omitempty" structs:"self,omitempty"`
+	Name       string            `json:"name,omitempty" structs:"name,omitempty"`
+	Body       string            `json:"body,omitempty" structs:"body,omitempty"`
+	Updated    string            `json:"updated,omitempty" structs:"updated,omitempty"`
+	Created    string            `json:"created,omitempty" structs:"created,omitempty"`
+	Visibility CommentVisibility `json:"visibility,omitempty" structs:"visibility,omitempty"`
 
 	// A list of comment properties. Optional on create and update.
 	Properties []EntityProperty `json:"properties,omitempty" structs:"properties,omitempty"`


### PR DESCRIPTION
#### What type of PR is this?
* bug

#### What this PR does / why we need it:
Currently requests built using the AddComment() and UpdateComment() functions will fail (HTTP 400) due to a schema mismatch. V2 of the Jira REST Api does not accept Author or UpdateAuthor properties.

#### Which issue(s) this PR fixes:
https://github.com/andygrunwald/go-jira/issues/604

Fixes #

#### Special notes for your reviewer:


#### Additional documentation e.g., usage docs, etc.:
https://developer.atlassian.com/cloud/jira/platform/rest/v2/api-group-issue-comments/#api-rest-api-2-issue-issueidorkey-comment-post
https://developer.atlassian.com/cloud/jira/platform/rest/v2/api-group-issue-comments/#api-rest-api-2-issue-issueidorkey-comment-id-put