### PR TITLE
Make comment Author & UpdateAuthor properties pointers

### DIFF
--- a/cloud/issue.go
+++ b/cloud/issue.go
@@ -474,9 +474,9 @@ type Comment struct {
 	ID           string            `json:"id,omitempty" structs:"id,omitempty"`
 	Self         string            `json:"self,omitempty" structs:"self,omitempty"`
 	Name         string            `json:"name,omitempty" structs:"name,omitempty"`
-	Author       User              `json:"author,omitempty" structs:"author,omitempty"`
+	Author       *User             `json:"author,omitempty" structs:"author,omitempty"`
 	Body         string            `json:"body,omitempty" structs:"body,omitempty"`
-	UpdateAuthor User              `json:"updateAuthor,omitempty" structs:"updateAuthor,omitempty"`
+	UpdateAuthor *User             `json:"updateAuthor,omitempty" structs:"updateAuthor,omitempty"`
 	Updated      string            `json:"updated,omitempty" structs:"updated,omitempty"`
 	Created      string            `json:"created,omitempty" structs:"created,omitempty"`
 	Visibility   CommentVisibility `json:"visibility,omitempty" structs:"visibility,omitempty"`

--- a/onpremise/issue.go
+++ b/onpremise/issue.go
@@ -474,9 +474,9 @@ type Comment struct {
 	ID           string            `json:"id,omitempty" structs:"id,omitempty"`
 	Self         string            `json:"self,omitempty" structs:"self,omitempty"`
 	Name         string            `json:"name,omitempty" structs:"name,omitempty"`
-	Author       User              `json:"author,omitempty" structs:"author,omitempty"`
+	Author       *User             `json:"author,omitempty" structs:"author,omitempty"`
 	Body         string            `json:"body,omitempty" structs:"body,omitempty"`
-	UpdateAuthor User              `json:"updateAuthor,omitempty" structs:"updateAuthor,omitempty"`
+	UpdateAuthor *User             `json:"updateAuthor,omitempty" structs:"updateAuthor,omitempty"`
 	Updated      string            `json:"updated,omitempty" structs:"updated,omitempty"`
 	Created      string            `json:"created,omitempty" structs:"created,omitempty"`
 	Visibility   CommentVisibility `json:"visibility,omitempty" structs:"visibility,omitempty"`


### PR DESCRIPTION
#### What type of PR is this?
* bug

#### What this PR does / why we need it:
Currently requests built using the AddComment() and UpdateComment() functions will fail (HTTP 400) due to a schema mismatch. Because Author and UpdateAuthor properties are not pointers, they get marshalled into the resulting JSON body, rather than being omitted via omitempty.

This change brings the Comment struct type in line with other structs that using pointers for Author and UpdateAuthor properties.

#### Which issue(s) this PR fixes:
https://github.com/andygrunwald/go-jira/issues/604

Fixes #

#### Special notes for your reviewer:

#### Additional documentation e.g., usage docs, etc.:
