### PR TITLE
Add FindAssignable method to User

### DIFF
--- a/cloud/user_test.go
+++ b/cloud/user_test.go
@@ -282,3 +282,26 @@ func TestUserService_Find_SuccessParams(t *testing.T) {
 		t.Error("Expected user. User is nil")
 	}
 }
+
+func TestUserService_FindAssignable_Success(t *testing.T) {
+	setup()
+	defer teardown()
+	testMux.HandleFunc("/rest/api/2/user/assignable/search", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, http.MethodGet)
+		testRequestURL(t, r, "/rest/api/2/user/assignable/search?username=fred@example.com&project=DAPHNE&issueKey=DAPHNE-11&maxResults=100&startAt=0")
+
+		fmt.Fprint(w, `[{"self":"http://www.example.com/jira/rest/api/2/user?accountId=000000000000000000000000","key":"fred",
+        "name":"fred","emailAddress":"fred@example.com","avatarUrls":{"48x48":"http://www.example.com/jira/secure/useravatar?size=large&ownerId=fred",
+        "24x24":"http://www.example.com/jira/secure/useravatar?size=small&ownerId=fred","16x16":"http://www.example.com/jira/secure/useravatar?size=xsmall&ownerId=fred",
+        "32x32":"http://www.example.com/jira/secure/useravatar?size=medium&ownerId=fred"},"displayName":"Fred F. User","active":true,"timeZone":"Australia/Sydney","groups":{"size":3,"items":[
+        {"name":"jira-user","self":"http://www.example.com/jira/rest/api/2/group?groupname=jira-user"},{"name":"jira-admin",
+        "self":"http://www.example.com/jira/rest/api/2/group?groupname=jira-admin"},{"name":"important","self":"http://www.example.com/jira/rest/api/2/group?groupname=important"
+        }]},"applicationRoles":{"size":1,"items":[]},"expand":"groups,applicationRoles"}]`)
+	})
+
+	if user, _, err := testClient.User.FindAssignable(context.Background(), WithUsername("fred@example.com"), WithProject("DAPHNE"), WithIssueKey("DAPHNE-11"), WithMaxResults(100), WithStartAt(0)); err != nil {
+		t.Errorf("Error given: %s", err)
+	} else if user == nil {
+		t.Error("Expected user. User is nil")
+	}
+}


### PR DESCRIPTION
Feature: Adding a new method to the User interface

#### What this PR does / why we need it:
Adding support for the find assignable users route https://docs.atlassian.com/software/jira/docs/api/REST/1000.1568.0/#api/2/user-findAssignableUsers

#### Which issue(s) this PR fixes:

No linked issue - can create if that's required.

#### Special notes for your reviewer:

I attempted to follow the pattern from User.Find by using the option funcs. The other option I considered was using the query library that's being used in Issue. 

