### PR TITLE
feature: add UpdateIssueWithOptions …

### DIFF
--- a/cloud/issue_test.go
+++ b/cloud/issue_test.go
@@ -178,6 +178,30 @@ func TestIssueService_UpdateIssue(t *testing.T) {
 
 }
 
+func TestIssueService_UpdateIssueWithOptions(t *testing.T) {
+	setup()
+	defer teardown()
+	testMux.HandleFunc("/rest/api/2/issue/PROJ-9001", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, http.MethodPut)
+		testRequestURL(t, r, "/rest/api/2/issue/PROJ-9001")
+		testRequestParams(t, r, map[string]string{"notifyUsers": "true"})
+
+		w.WriteHeader(http.StatusNoContent)
+	})
+	jID := "PROJ-9001"
+	i := make(map[string]interface{})
+	fields := make(map[string]interface{})
+	i["fields"] = fields
+	resp, err := testClient.Issue.client.Issue.UpdateIssueWithOptions(context.Background(), jID, i, &UpdateQueryOptions{NotifyUsers: false})
+	if resp == nil {
+		t.Error("Expected resp. resp is nil")
+	}
+	if err != nil {
+		t.Errorf("Error given: %s", err)
+	}
+
+}
+
 func TestIssueService_AddComment(t *testing.T) {
 	setup()
 	defer teardown()

--- a/cloud/jira_test.go
+++ b/cloud/jira_test.go
@@ -73,6 +73,19 @@ func testRequestParams(t *testing.T, r *http.Request, want map[string]string) {
 
 }
 
+func Test_addOptions(t *testing.T) {
+	v, err := addOptions("rest/api/2/issue/123", &UpdateQueryOptions{NotifyUsers: false})
+	if err != nil {
+		t.Errorf("Expected no error. Got: %+v", err)
+	}
+
+	expectedOutput := "rest/api/2/issue/123?notifyUsers=false"
+	if v != expectedOutput {
+		t.Errorf("Expected: %+v, got: %+v", expectedOutput, v)
+	}
+
+}
+
 func TestNewClient_WrongUrl(t *testing.T) {
 	c, err := NewClient("://issues.apache.org/jira/", nil)
 

--- a/onpremise/issue.go
+++ b/onpremise/issue.go
@@ -31,7 +31,7 @@ type IssueService service
 
 // UpdateQueryOptions specifies the optional parameters to the Edit issue
 type UpdateQueryOptions struct {
-	NotifyUsers            bool `url:"notifyUsers,omitempty"`
+	NotifyUsers            bool `url:"notifyUsers"` // can't be omitted as this means it's omitted when false which isn't desired as this defaults to true
 	OverrideScreenSecurity bool `url:"overrideScreenSecurity,omitempty"`
 	OverrideEditableFlag   bool `url:"overrideEditableFlag,omitempty"`
 }
@@ -839,7 +839,7 @@ func (s *IssueService) Create(ctx context.Context, issue *Issue) (*Issue, *Respo
 // This double check effort is done for v2 - Remove this two lines if this is completed.
 func (s *IssueService) Update(ctx context.Context, issue *Issue, opts *UpdateQueryOptions) (*Issue, *Response, error) {
 	apiEndpoint := fmt.Sprintf("rest/api/2/issue/%v", issue.Key)
-	url, err := addOptions(apiEndpoint, opts)
+	url, err := addOptions(apiEndpoint, *opts)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/onpremise/issue_test.go
+++ b/onpremise/issue_test.go
@@ -155,6 +155,60 @@ func TestIssueService_Update(t *testing.T) {
 	}
 }
 
+func TestIssueService_Update_with_false_opts(t *testing.T) {
+	setup()
+	defer teardown()
+	testMux.HandleFunc("/rest/api/2/issue/PROJ-9001", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, http.MethodPut)
+		testRequestURL(t, r, "/rest/api/2/issue/PROJ-9001")
+		testRequestParams(t, r, map[string]string{"notifyUsers": "false"})
+
+		w.WriteHeader(http.StatusNoContent)
+	})
+
+	i := &Issue{
+		Key: "PROJ-9001",
+		Fields: &IssueFields{
+			Description: "example bug report",
+		},
+	}
+	issue, _, err := testClient.Issue.Update(context.Background(), i, &UpdateQueryOptions{NotifyUsers: false})
+	if issue == nil {
+		t.Error("Expected issue. Issue is nil")
+	}
+	if err != nil {
+		t.Errorf("Error given: %s", err)
+	}
+
+}
+
+func TestIssueService_Update_with_multiple_opts(t *testing.T) {
+	setup()
+	defer teardown()
+	testMux.HandleFunc("/rest/api/2/issue/PROJ-9001", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, http.MethodPut)
+		testRequestURL(t, r, "/rest/api/2/issue/PROJ-9001")
+		testRequestParams(t, r, map[string]string{"notifyUsers": "false", "overrideScreenSecurity": "true"})
+
+		w.WriteHeader(http.StatusNoContent)
+	})
+
+	i := &Issue{
+		Key: "PROJ-9001",
+		Fields: &IssueFields{
+			Description: "example bug report",
+		},
+	}
+	issue, _, err := testClient.Issue.Update(context.Background(), i, &UpdateQueryOptions{NotifyUsers: false, OverrideScreenSecurity: true})
+	if issue == nil {
+		t.Error("Expected issue. Issue is nil")
+	}
+	if err != nil {
+		t.Errorf("Error given: %s", err)
+	}
+
+}
+
 func TestIssueService_UpdateIssue(t *testing.T) {
 	setup()
 	defer teardown()


### PR DESCRIPTION
and add testing for addOptions to make clear what it does

#### What type of PR is this?

* feature


#### What this PR does / why we need it:
* Added an equivalent to func (*IssueService) UpdateWithOptions for just issue patches
* added some testing coverages to addOptions to help show how it works and 
* Fixes a bug where "NotifyUsers: false" would not get sent to the server due to ommit empty, and empty for booleans are false. This may be present in other fields but just focussed on fixing my own issue

#### Which issue(s) this PR fixes:



#### Special notes for your reviewer:


#### Additional documentation e.g., usage docs, etc.:
