### PR TITLE
fix: update comment fields of struct type to be pointers to fix json …

### DIFF
--- a/cloud/issue.go
+++ b/cloud/issue.go
@@ -472,15 +472,15 @@ type Comments struct {
 
 // Comment represents a comment by a person to an issue in Jira.
 type Comment struct {
-	ID           string            `json:"id,omitempty" structs:"id,omitempty"`
-	Self         string            `json:"self,omitempty" structs:"self,omitempty"`
-	Name         string            `json:"name,omitempty" structs:"name,omitempty"`
-	Author       User              `json:"author,omitempty" structs:"author,omitempty"`
-	Body         string            `json:"body,omitempty" structs:"body,omitempty"`
-	UpdateAuthor User              `json:"updateAuthor,omitempty" structs:"updateAuthor,omitempty"`
-	Updated      string            `json:"updated,omitempty" structs:"updated,omitempty"`
-	Created      string            `json:"created,omitempty" structs:"created,omitempty"`
-	Visibility   CommentVisibility `json:"visibility,omitempty" structs:"visibility,omitempty"`
+	ID           string             `json:"id,omitempty" structs:"id,omitempty"`
+	Self         string             `json:"self,omitempty" structs:"self,omitempty"`
+	Name         string             `json:"name,omitempty" structs:"name,omitempty"`
+	Author       *User              `json:"author,omitempty" structs:"author,omitempty"`
+	Body         string             `json:"body,omitempty" structs:"body,omitempty"`
+	UpdateAuthor *User              `json:"updateAuthor,omitempty" structs:"updateAuthor,omitempty"`
+	Updated      string             `json:"updated,omitempty" structs:"updated,omitempty"`
+	Created      string             `json:"created,omitempty" structs:"created,omitempty"`
+	Visibility   *CommentVisibility `json:"visibility,omitempty" structs:"visibility,omitempty"`
 
 	// A list of comment properties. Optional on create and update.
 	Properties []EntityProperty `json:"properties,omitempty" structs:"properties,omitempty"`

--- a/cloud/issue_test.go
+++ b/cloud/issue_test.go
@@ -191,7 +191,7 @@ func TestIssueService_AddComment(t *testing.T) {
 
 	c := &Comment{
 		Body: "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Pellentesque eget venenatis elit. Duis eu justo eget augue iaculis fermentum. Sed semper quam laoreet nisi egestas at posuere augue semper.",
-		Visibility: CommentVisibility{
+		Visibility: &CommentVisibility{
 			Type:  "role",
 			Value: "Administrators",
 		},
@@ -219,7 +219,7 @@ func TestIssueService_UpdateComment(t *testing.T) {
 	c := &Comment{
 		ID:   "10001",
 		Body: "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Pellentesque eget venenatis elit. Duis eu justo eget augue iaculis fermentum. Sed semper quam laoreet nisi egestas at posuere augue semper.",
-		Visibility: CommentVisibility{
+		Visibility: &CommentVisibility{
 			Type:  "role",
 			Value: "Administrators",
 		},
@@ -316,7 +316,7 @@ func TestIssueService_AddLink(t *testing.T) {
 		},
 		Comment: &Comment{
 			Body: "Linked related issue!",
-			Visibility: CommentVisibility{
+			Visibility: &CommentVisibility{
 				Type:  "group",
 				Value: "jira-software-users",
 			},

--- a/onpremise/issue.go
+++ b/onpremise/issue.go
@@ -471,15 +471,15 @@ type Comments struct {
 
 // Comment represents a comment by a person to an issue in Jira.
 type Comment struct {
-	ID           string            `json:"id,omitempty" structs:"id,omitempty"`
-	Self         string            `json:"self,omitempty" structs:"self,omitempty"`
-	Name         string            `json:"name,omitempty" structs:"name,omitempty"`
-	Author       User              `json:"author,omitempty" structs:"author,omitempty"`
-	Body         string            `json:"body,omitempty" structs:"body,omitempty"`
-	UpdateAuthor User              `json:"updateAuthor,omitempty" structs:"updateAuthor,omitempty"`
-	Updated      string            `json:"updated,omitempty" structs:"updated,omitempty"`
-	Created      string            `json:"created,omitempty" structs:"created,omitempty"`
-	Visibility   CommentVisibility `json:"visibility,omitempty" structs:"visibility,omitempty"`
+	ID           string             `json:"id,omitempty" structs:"id,omitempty"`
+	Self         string             `json:"self,omitempty" structs:"self,omitempty"`
+	Name         string             `json:"name,omitempty" structs:"name,omitempty"`
+	Author       *User              `json:"author,omitempty" structs:"author,omitempty"`
+	Body         string             `json:"body,omitempty" structs:"body,omitempty"`
+	UpdateAuthor *User              `json:"updateAuthor,omitempty" structs:"updateAuthor,omitempty"`
+	Updated      string             `json:"updated,omitempty" structs:"updated,omitempty"`
+	Created      string             `json:"created,omitempty" structs:"created,omitempty"`
+	Visibility   *CommentVisibility `json:"visibility,omitempty" structs:"visibility,omitempty"`
 
 	// A list of comment properties. Optional on create and update.
 	Properties []EntityProperty `json:"properties,omitempty" structs:"properties,omitempty"`

--- a/onpremise/issue_test.go
+++ b/onpremise/issue_test.go
@@ -191,7 +191,7 @@ func TestIssueService_AddComment(t *testing.T) {
 
 	c := &Comment{
 		Body: "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Pellentesque eget venenatis elit. Duis eu justo eget augue iaculis fermentum. Sed semper quam laoreet nisi egestas at posuere augue semper.",
-		Visibility: CommentVisibility{
+		Visibility: &CommentVisibility{
 			Type:  "role",
 			Value: "Administrators",
 		},
@@ -219,7 +219,7 @@ func TestIssueService_UpdateComment(t *testing.T) {
 	c := &Comment{
 		ID:   "10001",
 		Body: "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Pellentesque eget venenatis elit. Duis eu justo eget augue iaculis fermentum. Sed semper quam laoreet nisi egestas at posuere augue semper.",
-		Visibility: CommentVisibility{
+		Visibility: &CommentVisibility{
 			Type:  "role",
 			Value: "Administrators",
 		},
@@ -316,7 +316,7 @@ func TestIssueService_AddLink(t *testing.T) {
 		},
 		Comment: &Comment{
 			Body: "Linked related issue!",
-			Visibility: CommentVisibility{
+			Visibility: &CommentVisibility{
 				Type:  "group",
 				Value: "jira-software-users",
 			},


### PR DESCRIPTION
…marshal for addcomment method on issue service

#### What type of PR is this?

* bug
<!--
Add one of the following kinds:
* bug
* cleanup
* documentation
* feature

Optionally add one or more of the following kinds if applicable:
* api-change
* deprecation
-->

#### What this PR does / why we need it:

We have experienced issues using the AddCommentWithContext method with the following input:

```go
jid := "ABC-123"
c := &jira.Comment{
  Body: "Some comment body",
}

cmntBytes, _ := json.Marshal(c)

cmnt, resp, err := jc.Issue.AddComment(context.Background(), jid, c)
```

I receive
```
Invalid request payload. Refer to the REST API documentation and try again.: request failed. Please analyze the request body for more details. Status code: 400
```

This likely happens because the marshalled output from `json.Marshal` comes up as
```json
{
  "author": {
    "avatarUrls": {},
    "groups": {},
    "applicationRoles": {}
  }
  "body": "Some comment body",
  "updateAuthor": {
    "avatarUrls": {},
    "groups": {},
    "applicationRoles": {}
  },
  "visibility": {}
}
```

#### Which issue(s) this PR fixes:

Fixes #671 

#### Special notes for your reviewer:


#### Additional documentation e.g., usage docs, etc.:
