### PR TITLE
Use correct property name in example documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ A more thorough, [runnable example](cloud/examples/basic_auth/main.go) is provid
 func main() {
 	tp := jira.BasicAuthTransport{
 		Username: "<username>",
-		APIToken: "<api-token>",
+		Password: "<api-token>",
 	}
 
 	client, err := jira.NewClient(tp.Client(), "https://my.jira.com")


### PR DESCRIPTION
#### What type of PR is this?

documentation

#### What this PR does / why we need it:

This pull request is to update the basic authentication example in the main README file. The example suggests to use the `APIToken` property, which doesn't exist, so I have updated it to use the correct property, `Password`.

