### PR TITLE
CI: Switch Github action to label PRs with merge conflict

### DIFF
--- a/.github/workflows/label-merge-conflicts.yml
+++ b/.github/workflows/label-merge-conflicts.yml
@@ -1,22 +1,23 @@
 name: Auto-label merge conflicts
 
 on:
-  pull_request:
   workflow_dispatch:
-  schedule:
-    - cron: "*/15 * * * *"
-
-# limit permissions
-permissions:
-  contents: read
-  pull-requests: write
+  # So that PRs touching the same files as the push are updated
+  push:
+  # So that the `dirtyLabel` is removed if conflicts are resolve
+  # We recommend `pull_request_target` so that github secrets are available.
+  # In `pull_request` we wouldn't be able to change labels of fork PRs
+  pull_request_target:
+    types: [synchronize]
 
 jobs:
-  conflicts:
+  main:
     runs-on: ubuntu-latest
-
     steps:
-      - uses: mschilde/auto-label-merge-conflicts@v2.0
+      - name: check if prs are dirty
+        uses: eps1lon/actions-label-merge-conflict@v3
         with:
-          CONFLICT_LABEL_NAME: conflicts
-          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+          dirtyLabel: "conflicts"
+          repoToken: "${{ secrets.GITHUB_TOKEN }}"
+          commentOnDirty: "This pull request has conflicts, please resolve those before we can evaluate the pull request."
+          commentOnClean: "Conflicts have been resolved. A maintainer will review the pull request shortly."


### PR DESCRIPTION
#### What type of PR is this?

* cleanup

#### What this PR does / why we need it:

CI: Switch Github action to label PRs with merge conflict

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

None

#### Additional documentation e.g., usage docs, etc.:

None
