### PR TITLE
fix issueLinkType

### DIFF
--- a/cloud/issuelinktype.go
+++ b/cloud/issuelinktype.go
@@ -25,12 +25,14 @@ func (s *IssueLinkTypeService) GetList(ctx context.Context) ([]IssueLinkType, *R
 		return nil, nil, err
 	}
 
-	linkTypeList := []IssueLinkType{}
+	linkTypeList := struct {
+		IssueLinkTypes []IssueLinkType `json:"issueLinkTypes"`
+	}{}
 	resp, err := s.client.Do(req, &linkTypeList)
 	if err != nil {
 		return nil, resp, NewJiraError(resp, err)
 	}
-	return linkTypeList, resp, nil
+	return linkTypeList.IssueLinkTypes, resp, nil
 }
 
 // Get gets info of a specific issue link type from Jira.


### PR DESCRIPTION
according to https://developer.atlassian.com/cloud/jira/platform/rest/v2/api-group-issue-link-types/#api-rest-api-2-issuelinktype-get it returns a json object with link types array, not the bare array

#### What type of PR is this?
Bug fix for IssueLinkType

<!--
Add one of the following kinds:
* bug
* cleanup
* documentation
* feature

Optionally add one or more of the following kinds if applicable:
* api-change
* deprecation
-->

#### What this PR does / why we need it:


#### Which issue(s) this PR fixes:

Fixes #

#### Special notes for your reviewer:


#### Additional documentation e.g., usage docs, etc.:
