### PR TITLE
Add SearchV2JQL to fix deprecation of JQL search and evaluate expression…

### DIFF
--- a/jira.go
+++ b/jira.go
@@ -327,6 +327,10 @@ type Response struct {
 	StartAt    int
 	MaxResults int
 	Total      int
+
+	// *searchResultV2
+	IsLast        bool
+	NextPageToken string
 }
 
 func newResponse(r *http.Response, v interface{}) *Response {
@@ -343,6 +347,9 @@ func (r *Response) populatePageValues(v interface{}) {
 		r.StartAt = value.StartAt
 		r.MaxResults = value.MaxResults
 		r.Total = value.Total
+	case *searchResultV2:
+		r.IsLast = value.IsLast
+		r.NextPageToken = value.NextPageToken
 	case *groupMembersResult:
 		r.StartAt = value.StartAt
 		r.MaxResults = value.MaxResults
@@ -561,8 +568,9 @@ func (t *CookieAuthTransport) transport() http.RoundTripper {
 //
 // Jira docs: https://developer.atlassian.com/cloud/jira/platform/understanding-jwt
 // Examples in other languages:
-//    https://bitbucket.org/atlassian/atlassian-jwt-ruby/src/d44a8e7a4649e4f23edaa784402655fda7c816ea/lib/atlassian/jwt.rb
-//    https://bitbucket.org/atlassian/atlassian-jwt-py/src/master/atlassian_jwt/url_utils.py
+//
+//	https://bitbucket.org/atlassian/atlassian-jwt-ruby/src/d44a8e7a4649e4f23edaa784402655fda7c816ea/lib/atlassian/jwt.rb
+//	https://bitbucket.org/atlassian/atlassian-jwt-py/src/master/atlassian_jwt/url_utils.py
 type JWTAuthTransport struct {
 	Secret []byte
 	Issuer string


### PR DESCRIPTION
… endpoints

#### What type of PR is this?

<!--
Add one of the following kinds:
* bug
* cleanup
* documentation
* feature

Optionally add one or more of the following kinds if applicable:
* api-change
* deprecation
-->

* bug

#### What this PR does / why we need it:
The endpoint GET /rest/api/2|3|latest/search is being deprecated. This is the migration of the endpoint.

See https://developer.atlassian.com/changelog/#CHANGE-2046

#### Which issue(s) this PR fixes:

Fixes #715 

#### Special notes for your reviewer:


#### Additional documentation e.g., usage docs, etc.:
