### PR TITLE
replace github.com/golang-jwt/jwt/v4 with v5

### DIFF
--- a/cloud/auth_transport_jwt.go
+++ b/cloud/auth_transport_jwt.go
@@ -10,7 +10,7 @@ import (
 	"strings"
 	"time"
 
-	jwt "github.com/golang-jwt/jwt/v4"
+	jwt "github.com/golang-jwt/jwt/v5"
 )
 
 // JWTAuthTransport is an http.RoundTripper that authenticates all requests

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ toolchain go1.23
 
 require (
 	github.com/fatih/structs v1.1.0
-	github.com/golang-jwt/jwt/v4 v4.5.2
+	github.com/golang-jwt/jwt/v5 v5.3.1
 	github.com/google/go-cmp v0.7.0
 	github.com/google/go-querystring v1.2.0
 	github.com/trivago/tgo v1.0.7

--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,7 @@
 github.com/fatih/structs v1.1.0 h1:Q7juDM0QtcnhCpeyLGQKyg4TOIghuNXrkL32pHAUMxo=
 github.com/fatih/structs v1.1.0/go.mod h1:9NiDSp5zOcgEDl+j00MP/WkGVPOlPRLejGD8Ga6PJ7M=
-github.com/golang-jwt/jwt/v4 v4.5.2 h1:YtQM7lnr8iZ+j5q71MGKkNw9Mn7AjHM68uc9g5fXeUI=
-github.com/golang-jwt/jwt/v4 v4.5.2/go.mod h1:m21LjoU+eqJr34lmDMbreY2eSTRJ1cv77w39/MY0Ch0=
+github.com/golang-jwt/jwt/v5 v5.3.1 h1:kYf81DTWFe7t+1VvL7eS+jKFVWaUnK9cB1qbwn63YCY=
+github.com/golang-jwt/jwt/v5 v5.3.1/go.mod h1:fxCRLWMO43lRc8nhHWY6LGqRcf+1gQWArsqaEUEa5bE=
 github.com/google/go-cmp v0.6.0/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
 github.com/google/go-cmp v0.7.0 h1:wk8382ETsv4JYUZwIsn6YpYiWiBsYLSJiTsyBybVuN8=
 github.com/google/go-cmp v0.7.0/go.mod h1:pXiqmnSA92OHEEa9HXL2W4E7lf9JzCmGVUdgjX3N/iU=

--- a/onpremise/auth_transport_jwt.go
+++ b/onpremise/auth_transport_jwt.go
@@ -10,7 +10,7 @@ import (
 	"strings"
 	"time"
 
-	jwt "github.com/golang-jwt/jwt/v4"
+	jwt "github.com/golang-jwt/jwt/v5"
 )
 
 // JWTAuthTransport is an http.RoundTripper that authenticates all requests


### PR DESCRIPTION
#### What type of PR is this?

* cleanup

#### What this PR does / why we need it:

This PR changes the usage of the golang-jwt/jwt/v4 library to the v5 equivalent. 
v5 is largely a drop-in replacement for v4, save for some changes in types, etc, but there were no uses of those types in go-jira.

#### Which issue(s) this PR fixes:


#### Special notes for your reviewer:


#### Additional documentation e.g., usage docs, etc.:
